### PR TITLE
feat: add democracy methods to txwrapper-substrate

### DIFF
--- a/packages/txwrapper-substrate/src/methods/democracy/index.ts
+++ b/packages/txwrapper-substrate/src/methods/democracy/index.ts
@@ -1,0 +1,1 @@
+export * from './vote';

--- a/packages/txwrapper-substrate/src/methods/democracy/types.ts
+++ b/packages/txwrapper-substrate/src/methods/democracy/types.ts
@@ -1,0 +1,39 @@
+import { AllConvictions } from '@polkadot/types/interfaces/democracy/definitions';
+import { ArrayElementType } from '@polkadot/types/types';
+
+/**
+ * A vote in a referendum
+ */
+type Vote = {
+    /*
+     * Whether the vote is to enact the proposal (true) or keep the status quo (false).
+     */
+    aye: boolean;
+    /*
+     * A value denoting the strength of conviction of a vote. Can be "None", "Locked1x",
+     * "Locked2x", "Locked3x", "Locked4x", or "Locked5x".
+     */
+    conviction: ArrayElementType<typeof AllConvictions>;
+};
+
+/**
+ * A vote in a referendum. Can be one of:
+ * - Standard: A standard vote, one-way (approve or reject) with a given amount
+ * of conviction.
+ * - Split: A split vote with balances given for both ways, and with no
+ * conviction, useful for parachains when voting.
+ */
+
+export type AccountVote =
+    | {
+        Standard: {
+            balance: number;
+            vote: Vote;
+        };
+    }
+    | {
+        Split: {
+            aye: number;
+            nay: number;
+        };
+    };

--- a/packages/txwrapper-substrate/src/methods/democracy/types.ts
+++ b/packages/txwrapper-substrate/src/methods/democracy/types.ts
@@ -5,15 +5,15 @@ import { ArrayElementType } from '@polkadot/types/types';
  * A vote in a referendum
  */
 type Vote = {
-    /*
-     * Whether the vote is to enact the proposal (true) or keep the status quo (false).
-     */
-    aye: boolean;
-    /*
-     * A value denoting the strength of conviction of a vote. Can be "None", "Locked1x",
-     * "Locked2x", "Locked3x", "Locked4x", or "Locked5x".
-     */
-    conviction: ArrayElementType<typeof AllConvictions>;
+	/*
+	 * Whether the vote is to enact the proposal (true) or keep the status quo (false).
+	 */
+	aye: boolean;
+	/*
+	 * A value denoting the strength of conviction of a vote. Can be "None", "Locked1x",
+	 * "Locked2x", "Locked3x", "Locked4x", or "Locked5x".
+	 */
+	conviction: ArrayElementType<typeof AllConvictions>;
 };
 
 /**
@@ -25,15 +25,15 @@ type Vote = {
  */
 
 export type AccountVote =
-    | {
-        Standard: {
-            balance: number;
-            vote: Vote;
-        };
-    }
-    | {
-        Split: {
-            aye: number;
-            nay: number;
-        };
-    };
+	| {
+			Standard: {
+				balance: number;
+				vote: Vote;
+			};
+	  }
+	| {
+			Split: {
+				aye: number;
+				nay: number;
+			};
+	  };

--- a/packages/txwrapper-substrate/src/methods/democracy/types.ts
+++ b/packages/txwrapper-substrate/src/methods/democracy/types.ts
@@ -21,7 +21,10 @@ type Vote = {
  * - Standard: A standard vote, one-way (approve or reject) with a given amount
  * of conviction.
  * - Split: A split vote with balances given for both ways, and with no
- * conviction, useful for parachains when voting.
+ * conviction. This is useful for parachains, which vote on behalf of their 
+participants and are free to choose their own way of splitting up the total
+balance. The stake behind a parachain can e.g. be split e.g. 2/3 aye and
+1/3 nay.
  */
 
 export type AccountVote =

--- a/packages/txwrapper-substrate/src/methods/democracy/vote.spec.ts
+++ b/packages/txwrapper-substrate/src/methods/democracy/vote.spec.ts
@@ -1,0 +1,22 @@
+import {
+    POLKADOT_25_TEST_OPTIONS,
+    TEST_BASE_TX_INFO,
+    itHasCorrectBaseTxInfo,
+} from '@substrate/txwrapper-core';
+import { TEST_METHOD_ARGS } from '../../test-helpers'
+import { vote } from './vote';
+
+describe('democracy::vote', () => {
+    it('should work', () => {
+        const unsigned = vote(
+            TEST_METHOD_ARGS.democracy.vote,
+            TEST_BASE_TX_INFO,
+            POLKADOT_25_TEST_OPTIONS
+        );
+
+        itHasCorrectBaseTxInfo(unsigned);
+        expect(unsigned.method).toBe(
+            '0x0a02000081d2040000000000000000000000000000'
+        );
+    });
+});

--- a/packages/txwrapper-substrate/src/methods/democracy/vote.spec.ts
+++ b/packages/txwrapper-substrate/src/methods/democracy/vote.spec.ts
@@ -1,22 +1,23 @@
 import {
-    POLKADOT_25_TEST_OPTIONS,
-    TEST_BASE_TX_INFO,
-    itHasCorrectBaseTxInfo,
+	itHasCorrectBaseTxInfo,
+	POLKADOT_25_TEST_OPTIONS,
+	TEST_BASE_TX_INFO,
 } from '@substrate/txwrapper-core';
-import { TEST_METHOD_ARGS } from '../../test-helpers'
+
+import { TEST_METHOD_ARGS } from '../../test-helpers';
 import { vote } from './vote';
 
 describe('democracy::vote', () => {
-    it('should work', () => {
-        const unsigned = vote(
-            TEST_METHOD_ARGS.democracy.vote,
-            TEST_BASE_TX_INFO,
-            POLKADOT_25_TEST_OPTIONS
-        );
+	it('should work', () => {
+		const unsigned = vote(
+			TEST_METHOD_ARGS.democracy.vote,
+			TEST_BASE_TX_INFO,
+			POLKADOT_25_TEST_OPTIONS
+		);
 
-        itHasCorrectBaseTxInfo(unsigned);
-        expect(unsigned.method).toBe(
-            '0x0a02000081d2040000000000000000000000000000'
-        );
-    });
+		itHasCorrectBaseTxInfo(unsigned);
+		expect(unsigned.method).toBe(
+			'0x0a02000081d2040000000000000000000000000000'
+		);
+	});
 });

--- a/packages/txwrapper-substrate/src/methods/democracy/vote.ts
+++ b/packages/txwrapper-substrate/src/methods/democracy/vote.ts
@@ -1,21 +1,22 @@
 import {
-    Args,
-    BaseTxInfo,
-    defineMethod,
-    OptionsWithMeta,
-    UnsignedTransaction,
+	Args,
+	BaseTxInfo,
+	defineMethod,
+	OptionsWithMeta,
+	UnsignedTransaction,
 } from '@substrate/txwrapper-core';
+
 import { AccountVote } from './types';
 
 export interface DemocracyVoteArgs extends Args {
-    /*
-     * Referendum index.
-     */
-    refIndex: number;
-    /**
-     * Vote.
-     */
-    vote: AccountVote;
+	/*
+	 * Referendum index.
+	 */
+	refIndex: number;
+	/**
+	 * Vote.
+	 */
+	vote: AccountVote;
 }
 
 /**
@@ -26,19 +27,19 @@ export interface DemocracyVoteArgs extends Args {
  * @param options - Registry and metadata used for constructing the method.
  */
 export function vote(
-    args: DemocracyVoteArgs,
-    info: BaseTxInfo,
-    options: OptionsWithMeta
+	args: DemocracyVoteArgs,
+	info: BaseTxInfo,
+	options: OptionsWithMeta
 ): UnsignedTransaction {
-    return defineMethod(
-        {
-            method: {
-                args,
-                name: 'vote',
-                pallet: 'democracy',
-            },
-            ...info,
-        },
-        options
-    );
+	return defineMethod(
+		{
+			method: {
+				args,
+				name: 'vote',
+				pallet: 'democracy',
+			},
+			...info,
+		},
+		options
+	);
 }

--- a/packages/txwrapper-substrate/src/methods/democracy/vote.ts
+++ b/packages/txwrapper-substrate/src/methods/democracy/vote.ts
@@ -1,0 +1,44 @@
+import {
+    Args,
+    BaseTxInfo,
+    defineMethod,
+    OptionsWithMeta,
+    UnsignedTransaction,
+} from '@substrate/txwrapper-core';
+import { AccountVote } from './types';
+
+export interface DemocracyVoteArgs extends Args {
+    /*
+     * Referendum index.
+     */
+    refIndex: number;
+    /**
+     * Vote.
+     */
+    vote: AccountVote;
+}
+
+/**
+ * Vote in a referendum.
+ *
+ * @param args - Arguments specific to this method.
+ * @param info - Information required to construct the transaction.
+ * @param options - Registry and metadata used for constructing the method.
+ */
+export function vote(
+    args: DemocracyVoteArgs,
+    info: BaseTxInfo,
+    options: OptionsWithMeta
+): UnsignedTransaction {
+    return defineMethod(
+        {
+            method: {
+                args,
+                name: 'vote',
+                pallet: 'democracy',
+            },
+            ...info,
+        },
+        options
+    );
+}

--- a/packages/txwrapper-substrate/src/methods/index.ts
+++ b/packages/txwrapper-substrate/src/methods/index.ts
@@ -1,5 +1,6 @@
 // Name exports to create namespaces that map to pallets
 export * as balances from './balances';
+export * as democracy from './democracy';
 export * as proxy from './proxy';
 export * as staking from './staking';
 export * as utility from './utility';

--- a/packages/txwrapper-substrate/src/test-helpers/TEST_METHOD_ARGS.ts
+++ b/packages/txwrapper-substrate/src/test-helpers/TEST_METHOD_ARGS.ts
@@ -73,4 +73,15 @@ export const TEST_METHOD_ARGS = {
 		},
 		withdrawUnbonded: { numSlashingSpans: 11 },
 	},
+	democracy: {
+		vote: {
+			refIndex: 0,
+			vote: {
+				Standard: {
+					balance: 1234,
+					vote: { aye: true, conviction: 'Locked1x' },
+				},
+			},
+		},
+	},
 };


### PR DESCRIPTION
## Info 

Migrate over the un-deprecated democracy methods from txwrapper to txwrapper-core/txwrapper-substrate.

## Changelog

`./packages/txwrapper-substrate/src/test-helpers/TEST_METHOD_ARGS.ts`

Add the democracy key for testing. 

`./packages/txwrapper-substrate/src/methods/democracy`

Add `vote` method and its tests, as well as corresponding types. 