### PR TITLE
feat: add vesting methods to txwrapper-substrate

### DIFF
--- a/packages/txwrapper-substrate/src/methods/index.ts
+++ b/packages/txwrapper-substrate/src/methods/index.ts
@@ -3,3 +3,4 @@ export * as balances from './balances';
 export * as proxy from './proxy';
 export * as staking from './staking';
 export * as utility from './utility';
+export * as vesting from './vesting';

--- a/packages/txwrapper-substrate/src/methods/vesting/index.ts
+++ b/packages/txwrapper-substrate/src/methods/vesting/index.ts
@@ -1,0 +1,2 @@
+export * from './vest';
+export * from './vestOther';

--- a/packages/txwrapper-substrate/src/methods/vesting/vest.spec.ts
+++ b/packages/txwrapper-substrate/src/methods/vesting/vest.spec.ts
@@ -1,21 +1,21 @@
 import {
-    POLKADOT_25_TEST_OPTIONS,
-    TEST_BASE_TX_INFO,
-    itHasCorrectBaseTxInfo,
+	itHasCorrectBaseTxInfo,
+	POLKADOT_25_TEST_OPTIONS,
+	TEST_BASE_TX_INFO,
 } from '@substrate/txwrapper-core';
 
 import { TEST_METHOD_ARGS } from '../../test-helpers';
 import { vest } from './vest';
 
 describe('vesting::vest', () => {
-    it('should work', () => {
-        const unsigned = vest(
-            TEST_METHOD_ARGS.vesting.vest,
-            TEST_BASE_TX_INFO,
-            POLKADOT_25_TEST_OPTIONS
-        );
+	it('should work', () => {
+		const unsigned = vest(
+			TEST_METHOD_ARGS.vesting.vest,
+			TEST_BASE_TX_INFO,
+			POLKADOT_25_TEST_OPTIONS
+		);
 
-        itHasCorrectBaseTxInfo(unsigned);
-        expect(unsigned.method).toBe('0x1a00');
-    });
+		itHasCorrectBaseTxInfo(unsigned);
+		expect(unsigned.method).toBe('0x1b00');
+	});
 });

--- a/packages/txwrapper-substrate/src/methods/vesting/vest.spec.ts
+++ b/packages/txwrapper-substrate/src/methods/vesting/vest.spec.ts
@@ -1,0 +1,21 @@
+import {
+    POLKADOT_25_TEST_OPTIONS,
+    TEST_BASE_TX_INFO,
+    itHasCorrectBaseTxInfo,
+} from '@substrate/txwrapper-core';
+
+import { TEST_METHOD_ARGS } from '../../test-helpers';
+import { vest } from './vest';
+
+describe('vesting::vest', () => {
+    it('should work', () => {
+        const unsigned = vest(
+            TEST_METHOD_ARGS.vesting.vest,
+            TEST_BASE_TX_INFO,
+            POLKADOT_25_TEST_OPTIONS
+        );
+
+        itHasCorrectBaseTxInfo(unsigned);
+        expect(unsigned.method).toBe('0x1a00');
+    });
+});

--- a/packages/txwrapper-substrate/src/methods/vesting/vest.ts
+++ b/packages/txwrapper-substrate/src/methods/vesting/vest.ts
@@ -1,0 +1,31 @@
+import {
+    BaseTxInfo,
+    defineMethod,
+    OptionsWithMeta,
+    UnsignedTransaction,
+} from '@substrate/txwrapper-core';
+
+/**
+ * Unlock any vested funds of the sender account.
+ *
+ * @param args - Arguments specific to this method.
+ * @param info - Information required to construct the transaction.
+ * @param options - Registry and metadata used for constructing the method.
+ */
+export function vest(
+    args: {},
+    info: BaseTxInfo,
+    options: OptionsWithMeta
+): UnsignedTransaction {
+    return defineMethod(
+        {
+            method: {
+                args,
+                name: 'vest',
+                pallet: 'vesting',
+            },
+            ...info,
+        },
+        options
+    );
+}

--- a/packages/txwrapper-substrate/src/methods/vesting/vest.ts
+++ b/packages/txwrapper-substrate/src/methods/vesting/vest.ts
@@ -1,8 +1,8 @@
 import {
-    BaseTxInfo,
-    defineMethod,
-    OptionsWithMeta,
-    UnsignedTransaction,
+	BaseTxInfo,
+	defineMethod,
+	OptionsWithMeta,
+	UnsignedTransaction,
 } from '@substrate/txwrapper-core';
 
 /**
@@ -13,19 +13,19 @@ import {
  * @param options - Registry and metadata used for constructing the method.
  */
 export function vest(
-    args: {},
-    info: BaseTxInfo,
-    options: OptionsWithMeta
+	args: {},
+	info: BaseTxInfo,
+	options: OptionsWithMeta
 ): UnsignedTransaction {
-    return defineMethod(
-        {
-            method: {
-                args,
-                name: 'vest',
-                pallet: 'vesting',
-            },
-            ...info,
-        },
-        options
-    );
+	return defineMethod(
+		{
+			method: {
+				args,
+				name: 'vest',
+				pallet: 'vesting',
+			},
+			...info,
+		},
+		options
+	);
 }

--- a/packages/txwrapper-substrate/src/methods/vesting/vestOther.spec.ts
+++ b/packages/txwrapper-substrate/src/methods/vesting/vestOther.spec.ts
@@ -1,23 +1,23 @@
 import {
-    POLKADOT_25_TEST_OPTIONS,
-    TEST_BASE_TX_INFO,
-    itHasCorrectBaseTxInfo,
+	itHasCorrectBaseTxInfo,
+	POLKADOT_25_TEST_OPTIONS,
+	TEST_BASE_TX_INFO,
 } from '@substrate/txwrapper-core';
 
-import { TEST_METHOD_ARGS} from '../../test-helpers'
+import { TEST_METHOD_ARGS } from '../../test-helpers';
 import { vestOther } from './vestOther';
 
 describe('vesting::vestOther', () => {
-    it('should work', () => {
-        const unsigned = vestOther(
-            TEST_METHOD_ARGS.vesting.vestOther,
-            TEST_BASE_TX_INFO,
-            POLKADOT_25_TEST_OPTIONS
-        );
+	it('should work', () => {
+		const unsigned = vestOther(
+			TEST_METHOD_ARGS.vesting.vestOther,
+			TEST_BASE_TX_INFO,
+			POLKADOT_25_TEST_OPTIONS
+		);
 
-        itHasCorrectBaseTxInfo(unsigned);
-        expect(unsigned.method).toBe(
-            '0x1a0190b5ab205c6974c9ea841be688864633dc9ca8a357843eeacf2314649965fe22'
-        );
-    });
+		itHasCorrectBaseTxInfo(unsigned);
+		expect(unsigned.method).toBe(
+			'0x1b0190b5ab205c6974c9ea841be688864633dc9ca8a357843eeacf2314649965fe22'
+		);
+	});
 });

--- a/packages/txwrapper-substrate/src/methods/vesting/vestOther.spec.ts
+++ b/packages/txwrapper-substrate/src/methods/vesting/vestOther.spec.ts
@@ -1,0 +1,23 @@
+import {
+    POLKADOT_25_TEST_OPTIONS,
+    TEST_BASE_TX_INFO,
+    itHasCorrectBaseTxInfo,
+} from '@substrate/txwrapper-core';
+
+import { TEST_METHOD_ARGS} from '../../test-helpers'
+import { vestOther } from './vestOther';
+
+describe('vesting::vestOther', () => {
+    it('should work', () => {
+        const unsigned = vestOther(
+            TEST_METHOD_ARGS.vesting.vestOther,
+            TEST_BASE_TX_INFO,
+            POLKADOT_25_TEST_OPTIONS
+        );
+
+        itHasCorrectBaseTxInfo(unsigned);
+        expect(unsigned.method).toBe(
+            '0x1a0190b5ab205c6974c9ea841be688864633dc9ca8a357843eeacf2314649965fe22'
+        );
+    });
+});

--- a/packages/txwrapper-substrate/src/methods/vesting/vestOther.ts
+++ b/packages/txwrapper-substrate/src/methods/vesting/vestOther.ts
@@ -1,0 +1,40 @@
+import {
+    Args,
+    BaseTxInfo,
+    defineMethod,
+    OptionsWithMeta,
+    UnsignedTransaction,
+} from '@substrate/txwrapper-core';
+
+export interface VestingVestOtherArgs extends Args {
+    /**
+     * The account whose vested funds should be unlocked. Must have funds still
+     * locked under this module.
+     */
+    target: string;
+}
+
+/**
+ * Unlock any vested funds of a `target` account.
+ *
+ * @param args - Arguments specific to this method.
+ * @param info - Information required to construct the transaction.
+ * @param options - Registry and metadata used for constructing the method.
+ */
+export function vestOther(
+    args: VestingVestOtherArgs,
+    info: BaseTxInfo,
+    options: OptionsWithMeta
+): UnsignedTransaction {
+    return defineMethod(
+        {
+            method: {
+                args,
+                name: 'vestOther',
+                pallet: 'vesting',
+            },
+            ...info,
+        },
+        options
+    );
+}

--- a/packages/txwrapper-substrate/src/methods/vesting/vestOther.ts
+++ b/packages/txwrapper-substrate/src/methods/vesting/vestOther.ts
@@ -1,17 +1,17 @@
 import {
-    Args,
-    BaseTxInfo,
-    defineMethod,
-    OptionsWithMeta,
-    UnsignedTransaction,
+	Args,
+	BaseTxInfo,
+	defineMethod,
+	OptionsWithMeta,
+	UnsignedTransaction,
 } from '@substrate/txwrapper-core';
 
 export interface VestingVestOtherArgs extends Args {
-    /**
-     * The account whose vested funds should be unlocked. Must have funds still
-     * locked under this module.
-     */
-    target: string;
+	/**
+	 * The account whose vested funds should be unlocked. Must have funds still
+	 * locked under this module.
+	 */
+	target: string;
 }
 
 /**
@@ -22,19 +22,19 @@ export interface VestingVestOtherArgs extends Args {
  * @param options - Registry and metadata used for constructing the method.
  */
 export function vestOther(
-    args: VestingVestOtherArgs,
-    info: BaseTxInfo,
-    options: OptionsWithMeta
+	args: VestingVestOtherArgs,
+	info: BaseTxInfo,
+	options: OptionsWithMeta
 ): UnsignedTransaction {
-    return defineMethod(
-        {
-            method: {
-                args,
-                name: 'vestOther',
-                pallet: 'vesting',
-            },
-            ...info,
-        },
-        options
-    );
+	return defineMethod(
+		{
+			method: {
+				args,
+				name: 'vestOther',
+				pallet: 'vesting',
+			},
+			...info,
+		},
+		options
+	);
 }

--- a/packages/txwrapper-substrate/src/test-helpers/TEST_METHOD_ARGS.ts
+++ b/packages/txwrapper-substrate/src/test-helpers/TEST_METHOD_ARGS.ts
@@ -73,4 +73,10 @@ export const TEST_METHOD_ARGS = {
 		},
 		withdrawUnbonded: { numSlashingSpans: 11 },
 	},
+	vesting: {
+		vest: {},
+		vestOther: {
+			target: 'Fr4NzY1udSFFLzb2R3qxVQkwz9cZraWkyfH4h3mVVk7BK7P', // seed "//Charlie"
+		},
+	},
 };


### PR DESCRIPTION
## Info
Migrate over the vesting methods (excluding deprecated ones) from txwrapper to txwrapper-core/txwrapper-substrate.

## Changelog
`./packages/txwrapper-substrate/src/test-helpers/TEST_METHOD_ARGS.ts`

Add the vesting key for testing.

`./packages/txwrapper-substrate/src/methods/vesting`

Add  `vest` and `vestOther` along with their tests. 