### PR TITLE
build(deploy): Improve deploy script

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,9 +88,3 @@ yarn run deploy
 ```
 
 *The publisher will need publishing permissions to the @substrate npm org.
-
-Update dependencies:
-
-```bash
-yarn run upgrade
-```

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "packages/*"
   ],
   "scripts": {
-    "deploy": "yarn run build && lerna publish --conventional-commits --create-release github",
+    "deploy": "yarn run build && lerna version --conventional-commits --create-release github && lerna publish",
     "build": "lerna run build",
     "lint": "tsc --noEmit && eslint . --ext ts",
     "test": "jest",


### PR DESCRIPTION
The publish script did not generate change logs as expected. So instead of relying on `lerna publish` to call `lerna version`, this calls `lerna version` upfront prior to publishing.