### PR TITLE
feat(substrate): Add pallet method `utility.batchAll` + example

### DIFF
--- a/packages/txwrapper-core/src/core/construct/createSigningPayload.ts
+++ b/packages/txwrapper-core/src/core/construct/createSigningPayload.ts
@@ -34,7 +34,7 @@ import { Options, UnsignedTransaction } from '../../types';
  *  });
  *
  * // With the `ExtrinsicPayload` class, construct the actual payload to sign.
- * // N.B. signing payloads bigger than 256 bits get hashed with blake2_256
+ * // N.B. signing payloads > 256 bytes get hashed with blake2_256
  * // ref: https://substrate.dev/rustdocs/v3.0.0/src/sp_runtime/generic/unchecked_extrinsic.rs.html#201-209
  * extrinsicPayloadU8a = extrinsicPayload.toU8a({ method: true })
  * const actualPayload = extrinsicPayloadU8a.length > 256

--- a/packages/txwrapper-core/src/core/construct/createSigningPayload.ts
+++ b/packages/txwrapper-core/src/core/construct/createSigningPayload.ts
@@ -34,8 +34,16 @@ import { Options, UnsignedTransaction } from '../../types';
  *  });
  *
  * // With the `ExtrinsicPayload` class, construct the actual payload to sign.
- * const actualPayload = extrinsicPayload.toU8a({ method: true });
+ * // N.B. signing payloads bigger than 256 bits get hashed with blake2_256
+ * // ref: https://substrate.dev/rustdocs/v3.0.0/src/sp_runtime/generic/unchecked_extrinsic.rs.html#201-209
+ * extrinsicPayloadU8a = extrinsicPayload.toU8a({ method: true })
+ * const actualPayload = extrinsicPayloadU8a.length > 256
+ *   ? registry.hash(extrinsicPayloadU8a)
+ *   : extrinsicPayloadU8a;
+ *
  * // You can now sign `actualPayload` with you private key.
+ * // Note: you can can use `u8ToHex` from @polkadot/util to convert `actualPayload`
+ * // to a hex string.
  *
  * // Alternatively, call the `.sign()` method directly on the
  * `ExtrinsicPayload` class.

--- a/packages/txwrapper-examples/package.json
+++ b/packages/txwrapper-examples/package.json
@@ -15,6 +15,7 @@
   "scripts": {
     "build": "tsc -p tsconfig.build.json",
     "polkadot": "node lib/polkadot",
+    "polkadotBatchAll": "node lib/polkadotBatchAll",
     "mandala": "node lib/mandala"
   },
   "dependencies": {

--- a/packages/txwrapper-examples/src/polkadotBatchAll.ts
+++ b/packages/txwrapper-examples/src/polkadotBatchAll.ts
@@ -113,8 +113,6 @@ async function main(): Promise<void> {
 
 	// Create an array of `balances.transferKeepAlive().method`s. We just need the
 	// `method` from the `UnsignedTransaction` that txwrapper methods returns.
-	// The `calls` argument for `batchAll` in this case is of type
-	// `Array<UnsignedTransaction.method>`
 	const txMethods = transferArgs.map((args) => {
 		const txInfo = methods.balances.transferKeepAlive(
 			args,
@@ -134,7 +132,9 @@ async function main(): Promise<void> {
 		return txInfo.method;
 	});
 
-	// Create a `utility.batchAll` unsigned tx
+	// Create a `utility.batchAll` unsigned tx. Based on the above code the
+	// `calls` argument for `batchAll` (`txMethods`)  is of type
+	// `Array<UnsignedTransaction.method>`
 	const unsigned = methods.utility.batchAll(
 		{
 			calls: txMethods,

--- a/packages/txwrapper-examples/src/polkadotBatchAll.ts
+++ b/packages/txwrapper-examples/src/polkadotBatchAll.ts
@@ -53,32 +53,105 @@ async function main(): Promise<void> {
 		metadataRpc,
 	});
 
-	// Now we can create our `balances.transferKeepAlive` unsigned tx. The following
-	// function takes the above data as arguments, so can be performed offline
-	// if desired.
-	const unsigned = methods.balances.transferKeepAlive(
+	// Metadata and type defintion registry used to create the calls
+	const optionsWithMeta = {
+		registry: registry,
+		metadataRpc: metadataRpc,
+	};
+
+	// Arguments for 12 balances transferKeepAlive
+	const transferArgs = [
 		{
-			value: '90071992547409910',
-			dest: '14E5nqKAp3oAJcmzgZhUD2RcptBeUBScxKHgJKU4HPNcKVf3', // Bob
+			dest: '5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty',
+			value: '1000000000',
 		},
 		{
-			address: deriveAddress(alice.publicKey, PolkadotSS58Format.polkadot),
-			blockHash,
-			blockNumber: registry
-				.createType('BlockNumber', block.header.number)
-				.toNumber(),
-			eraPeriod: 64,
+			dest: '5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty',
+			value: '2000000000',
+		},
+		{
+			dest: '5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty',
+			value: '3000000000',
+		},
+		{
+			dest: '5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty',
+			value: '4000000000',
+		},
+		{
+			dest: '5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty',
+			value: '5000000000',
+		},
+		{
+			dest: '5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty',
+			value: '6000000000',
+		},
+		{
+			dest: '5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty',
+			value: '7000000000',
+		},
+		{
+			dest: '5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty',
+			value: '8000000000',
+		},
+		{
+			dest: '5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty',
+			value: '9000000000',
+		},
+		{
+			dest: '5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty',
+			value: '10000000000',
+		},
+		{
+			dest: '5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty',
+			value: '11000000000',
+		},
+		{
+			dest: '5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty',
+			value: '12000000000',
+		},
+	];
+
+	// Create an array of `balances.transferKeepAlive().method`s. We just need the
+	// `method` from the `UnsignedTransaction` that txwrapper methods returns.
+	// The `calls` argument for `batchAll` in this case is of type
+	// `Array<UnsignedTransaction.method>`
+	const txMethods = transferArgs.map((args) => {
+		const txInfo = methods.balances.transferKeepAlive(
+			args,
+			{
+				address: alice.address,
+				blockHash: blockHash,
+				blockNumber: block.header.number,
+				genesisHash,
+				metadataRpc,
+				nonce: 0,
+				specVersion: specVersion,
+				transactionVersion,
+			},
+			optionsWithMeta
+		);
+
+		return txInfo.method;
+	});
+
+	// Create a `utility.batchAll` unsigned tx
+	const unsigned = methods.utility.batchAll(
+		{
+			calls: txMethods,
+		},
+		{
+			address: alice.address,
+			blockHash: blockHash,
+			blockNumber: block.header.number,
 			genesisHash,
 			metadataRpc,
-			nonce: 0, // Assuming this is Alice's first tx on the chain
-			specVersion,
+			nonce: 0,
+			specVersion: specVersion,
 			tip: 0,
+			eraPeriod: 64,
 			transactionVersion,
 		},
-		{
-			metadataRpc,
-			registry,
-		}
+		optionsWithMeta
 	);
 
 	// Decode an unsigned transaction.
@@ -87,9 +160,9 @@ async function main(): Promise<void> {
 		registry,
 	});
 	console.log(
-		`\nDecoded Transaction\n  To: ${
-			(decodedUnsigned.method.args.dest as { id: string })?.id
-		}\n` + `  Amount: ${decodedUnsigned.method.args.value}`
+		`\nDecoded Transaction\n  calls: ${JSON.stringify(
+			decodedUnsigned.method.args.calls
+		)}\n`
 	);
 
 	// Construct the signing payload from an unsigned transaction.
@@ -102,9 +175,9 @@ async function main(): Promise<void> {
 		registry,
 	});
 	console.log(
-		`\nDecoded Transaction\n  To: ${
-			(payloadInfo.method.args.dest as { id: string })?.id
-		}\n` + `  Amount: ${payloadInfo.method.args.value}`
+		`\nDecoded Transaction\n  calls: ${JSON.stringify(
+			payloadInfo.method.args.calls
+		)}\n`
 	);
 
 	// Sign a payload. This operation should be performed on an offline device.
@@ -137,9 +210,9 @@ async function main(): Promise<void> {
 		registry,
 	});
 	console.log(
-		`\nDecoded Transaction\n  To: ${
-			(txInfo.method.args.dest as { id: string })?.id
-		}\n` + `  Amount: ${txInfo.method.args.value}\n`
+		`\nDecoded Transaction\n  calls: ${JSON.stringify(
+			txInfo.method.args.calls
+		)}\n`
 	);
 }
 

--- a/packages/txwrapper-substrate/src/methods/utility/batchAll.spec.ts
+++ b/packages/txwrapper-substrate/src/methods/utility/batchAll.spec.ts
@@ -1,0 +1,33 @@
+import {
+	itHasCorrectBaseTxInfo,
+	POLKADOT_25_TEST_OPTIONS,
+	TEST_BASE_TX_INFO,
+} from '@substrate/txwrapper-core';
+
+import { TEST_METHOD_ARGS } from '../../test-helpers';
+import { transferKeepAlive } from '../balances/transferKeepAlive';
+import { batchAll } from './batchAll';
+
+describe('utility::batchAll', () => {
+	it('should work', () => {
+		const unsignedBalancesTransferKeepAlive = transferKeepAlive(
+			TEST_METHOD_ARGS.balances.transferKeepAlive,
+			TEST_BASE_TX_INFO,
+			POLKADOT_25_TEST_OPTIONS
+		);
+
+		const unsignedBatchAll = batchAll(
+			{
+				calls: [unsignedBalancesTransferKeepAlive.method],
+			},
+			TEST_BASE_TX_INFO,
+			POLKADOT_25_TEST_OPTIONS
+		);
+
+		itHasCorrectBaseTxInfo(unsignedBatchAll);
+
+		expect(unsignedBatchAll.method).toBe(
+			'0x010204060396074594cccf1cd185fa8a72ceaeefd86648f8d45514f3ce33c31bdd07e4655d30'
+		);
+	});
+});

--- a/packages/txwrapper-substrate/src/methods/utility/batchAll.ts
+++ b/packages/txwrapper-substrate/src/methods/utility/batchAll.ts
@@ -1,0 +1,40 @@
+import {
+	BaseTxInfo,
+	defineMethod,
+	OptionsWithMeta,
+	UnsignedTransaction,
+} from '@substrate/txwrapper-core';
+
+import { UtilityBatch } from './batch';
+
+/**
+ * Send a batch of dispatch calls and atomically execute them.
+ * The whole transaction will rollback and fail if any of the calls failed.
+ *
+ * May be called from any origin.
+ *
+ *
+ * If origin is root then call are dispatch without checking origin filter.
+ * (This includes bypassing `frame_system::Config::BaseCallFilter`).
+ *
+ * @param args
+ * @param info
+ * @param options
+ */
+export function batchAll(
+	args: UtilityBatch,
+	info: BaseTxInfo,
+	options: OptionsWithMeta
+): UnsignedTransaction {
+	return defineMethod(
+		{
+			method: {
+				args,
+				name: 'batchAll',
+				pallet: 'utility',
+			},
+			...info,
+		},
+		options
+	);
+}

--- a/packages/txwrapper-substrate/src/methods/utility/batchAll.ts
+++ b/packages/txwrapper-substrate/src/methods/utility/batchAll.ts
@@ -13,8 +13,7 @@ import { UtilityBatch } from './batch';
  *
  * May be called from any origin.
  *
- *
- * If origin is root then call are dispatch without checking origin filter.
+ * If origin is root then calls are dispatch without checking origin filter.
  * (This includes bypassing `frame_system::Config::BaseCallFilter`).
  *
  * @param args

--- a/packages/txwrapper-substrate/src/methods/utility/index.ts
+++ b/packages/txwrapper-substrate/src/methods/utility/index.ts
@@ -1,2 +1,3 @@
 export * from './asDerivative';
 export * from './batch';
+export * from './batchAll';


### PR DESCRIPTION
## Overview

Adds the pallet method `utility.batchAll` to the txwrapper-substrate package. Additionally it adds an example for how to use the new method in txwrapper-examples; there has been questions in the past about how to create a batch with other txwrapper calls.

## Other changes

- Update incorrect docs in `createSigningPayload` that did not account for how to signining payloads over 256 bits need to be hashed. (I consider this a bug because people base there signing code off these docs.) 
relates to: https://github.com/paritytech/txwrapper/pull/410
- Change the `transfer` example to use `transferKeepAlive` to reflect best practices for reducing replay attacks.

## Future work

- It may make sense to make a PR to polkadot-js's `ExtrinsicPayload` to add a `.toEncodedSigningPayload` that produces an encoded u8a/hex string ready to be signed by any valid crypto code
