### PR TITLE
fix(types): Bump deps to get latest types

### DIFF
--- a/packages/txwrapper-acala/package.json
+++ b/packages/txwrapper-acala/package.json
@@ -18,7 +18,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "@acala-network/type-definitions": "0.7.2-4",
+    "@acala-network/type-definitions": "0.7.2-5",
     "@substrate/txwrapper-core": "^0.4.1",
     "@substrate/txwrapper-orml": "^0.4.1"
   }

--- a/packages/txwrapper-core/package.json
+++ b/packages/txwrapper-core/package.json
@@ -21,7 +21,7 @@
     "build": "rimraf lib/ && tsc -p tsconfig.build.json"
   },
   "dependencies": {
-    "@polkadot/api": "4.3.1",
+    "@polkadot/api": "4.4.1",
     "memoizee": "0.4.15"
   },
   "devDependencies": {

--- a/packages/txwrapper-examples/package.json
+++ b/packages/txwrapper-examples/package.json
@@ -19,7 +19,7 @@
     "mandala": "node lib/mandala"
   },
   "dependencies": {
-    "@polkadot/api": "4.3.1",
+    "@polkadot/api": "4.4.1",
     "@substrate/txwrapper-polkadot": "^0.4.1",
     "txwrapper-acala": "^0.4.1"
   }

--- a/packages/txwrapper-orml/package.json
+++ b/packages/txwrapper-orml/package.json
@@ -24,6 +24,6 @@
     "@substrate/txwrapper-core": "^0.4.1"
   },
   "devDependencies": {
-    "@acala-network/type-definitions": "0.7.2-4"
+    "@acala-network/type-definitions": "0.7.2-5"
   }
 }

--- a/packages/txwrapper-registry/package.json
+++ b/packages/txwrapper-registry/package.json
@@ -21,7 +21,7 @@
     "build": "rimraf lib/ && tsc -p tsconfig.build.json"
   },
   "dependencies": {
-    "@polkadot/apps-config": "0.86.2",
+    "@polkadot/apps-config": "0.86.3-40",
     "@polkadot/networks": "6.0.5",
     "@substrate/txwrapper-core": "^0.4.1"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,7 +2,14 @@
 # yarn lockfile v1
 
 
-"@acala-network/type-definitions@0.7.2-4", "@acala-network/type-definitions@^0.7.2-4":
+"@acala-network/type-definitions@0.7.2-5":
+  version "0.7.2-5"
+  resolved "https://registry.yarnpkg.com/@acala-network/type-definitions/-/type-definitions-0.7.2-5.tgz#66eca66269d0ba5b4997fbf5c97c043ed0148d64"
+  integrity sha512-I5/eV+3PlNAvb8d8Jlyam/gcK6UlkOFNJQOyp3YsVU/h9Gywbu0X3X2y8PFfeWqhTQBtb/DCqD80jpMobSKXCQ==
+  dependencies:
+    "@open-web3/orml-type-definitions" "^0.9.1"
+
+"@acala-network/type-definitions@^0.7.2-4":
   version "0.7.2-4"
   resolved "https://registry.yarnpkg.com/@acala-network/type-definitions/-/type-definitions-0.7.2-4.tgz#df550fd4f092488b358ad9195a6bae59322809e9"
   integrity sha512-e9nOMDc+RU1pDei0tVG4WQl84e+2BP9hoVrNdQHf6K/aRKpWhkRyAtpvTqVhZli3Zy2n83cT3XybK3SG3dtKuA==
@@ -1444,43 +1451,43 @@
   resolved "https://registry.yarnpkg.com/@open-web3/orml-type-definitions/-/orml-type-definitions-0.9.1.tgz#6c0572ec8a879f23a4f45df29abff8af328d1c83"
   integrity sha512-nC/csEqQsHtYQBUSOy+P5UOuH8oV71+LxUAwYbiiK1iDYF2L/xv6xFrGE+tnabs3eAkeF9zbin0aWq6beVQebg==
 
-"@polkadot/api-derive@4.3.1":
-  version "4.3.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/api-derive/-/api-derive-4.3.1.tgz#ad7045b5bd9feedd91e51eb24ca13c8bf1cac2d6"
-  integrity sha512-KHV66rr3cn2g0Ls33oSPGKglyC8IxfJEyKj6rI5ahj8aYol5oFnICCsKOn4gHO87nufJ+vDSNhtAeKSFBjRUhA==
+"@polkadot/api-derive@4.4.1":
+  version "4.4.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/api-derive/-/api-derive-4.4.1.tgz#2e3a26b59573a04c18e05b85e0b8a951a7f970b0"
+  integrity sha512-N+U4S2zT4W9UNaJpOlEn8kvUnchiqvfYXnD1CXhxbn8yLo3jMW/WNJ8KksxxW2jg3RGW24slYVARvYFHBrlFYQ==
   dependencies:
     "@babel/runtime" "^7.13.10"
-    "@polkadot/api" "4.3.1"
-    "@polkadot/rpc-core" "4.3.1"
-    "@polkadot/types" "4.3.1"
+    "@polkadot/api" "4.4.1"
+    "@polkadot/rpc-core" "4.4.1"
+    "@polkadot/types" "4.4.1"
     "@polkadot/util" "^6.0.5"
     "@polkadot/util-crypto" "^6.0.5"
     "@polkadot/x-rxjs" "^6.0.5"
     bn.js "^4.11.9"
 
-"@polkadot/api@4.3.1":
-  version "4.3.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/api/-/api-4.3.1.tgz#65aa6f1541101fcbc237e952ba3e63f1258f9135"
-  integrity sha512-n7HrVqHd8uRG2bDs/kfGxRmDfYFWFBOVa7LsmiUHJYBSbEzqdaS0lHusiGQhfzx8frjieZDGNz1idYIKRts07g==
+"@polkadot/api@4.4.1":
+  version "4.4.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/api/-/api-4.4.1.tgz#7f5e9bdafce53e34505875183c9cbcdd966a6e8b"
+  integrity sha512-r/zpFYVebp6TYE5SjEH9eYNFQEq4IzNYM6rM65d0nPCbXFVmpzY5hsqPUhiRL6+drdhEO47pgxAow+60Pdx1fg==
   dependencies:
     "@babel/runtime" "^7.13.10"
-    "@polkadot/api-derive" "4.3.1"
+    "@polkadot/api-derive" "4.4.1"
     "@polkadot/keyring" "^6.0.5"
-    "@polkadot/metadata" "4.3.1"
-    "@polkadot/rpc-core" "4.3.1"
-    "@polkadot/rpc-provider" "4.3.1"
-    "@polkadot/types" "4.3.1"
-    "@polkadot/types-known" "4.3.1"
+    "@polkadot/metadata" "4.4.1"
+    "@polkadot/rpc-core" "4.4.1"
+    "@polkadot/rpc-provider" "4.4.1"
+    "@polkadot/types" "4.4.1"
+    "@polkadot/types-known" "4.4.1"
     "@polkadot/util" "^6.0.5"
     "@polkadot/util-crypto" "^6.0.5"
     "@polkadot/x-rxjs" "^6.0.5"
     bn.js "^4.11.9"
     eventemitter3 "^4.0.7"
 
-"@polkadot/apps-config@0.86.2":
-  version "0.86.2"
-  resolved "https://registry.yarnpkg.com/@polkadot/apps-config/-/apps-config-0.86.2.tgz#643f9b4c9e16003a4f73c488d12f3d2478d9219f"
-  integrity sha512-1UnFuPNE1Mak6IG6CL+QybaN1Hvh+bUiPQpQXxCPgGMOWpqHBkMSi3Ladw4Trt33zuRByyN+GouH5LhprPTSaQ==
+"@polkadot/apps-config@0.86.3-40":
+  version "0.86.3-40"
+  resolved "https://registry.yarnpkg.com/@polkadot/apps-config/-/apps-config-0.86.3-40.tgz#f1436802c4f424b39b2026208e058bccc3b97800"
+  integrity sha512-z4JNsJt5vJmXQi49qo7rKpbLnQ4nHCywfBFL/0P6lExA06gx2/TUI1FBBOSQTTgICmsG7cSQtBFMCWGzYIjNKg==
   dependencies:
     "@acala-network/type-definitions" "^0.7.2-4"
     "@babel/runtime" "^7.13.10"
@@ -1494,6 +1501,7 @@
     "@snowfork/snowbridge-types" "^0.2.3"
     "@sora-substrate/type-definitions" "^0.6.11"
     "@subsocial/types" "^0.4.35-beta.2"
+    "@zeitgeistpm/type-defs" "^0.1.35"
     moonbeam-types-bundle "1.1.12"
 
 "@polkadot/keyring@^6.0.5":
@@ -1529,6 +1537,18 @@
     "@polkadot/util-crypto" "^6.0.5"
     bn.js "^4.11.9"
 
+"@polkadot/metadata@4.4.1":
+  version "4.4.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/metadata/-/metadata-4.4.1.tgz#aeecee93f0c63183dddd4a4f4f987cd3ebacf085"
+  integrity sha512-rkOaB90BkYvWLc1gKfY4/hGtXriWi/8LmopDV241on9ED5q8gvD5gX8gamrHeK7p0IDvUELkP35/0zyKpK2ihw==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@polkadot/types" "4.4.1"
+    "@polkadot/types-known" "4.4.1"
+    "@polkadot/util" "^6.0.5"
+    "@polkadot/util-crypto" "^6.0.5"
+    bn.js "^4.11.9"
+
 "@polkadot/networks@6.0.5", "@polkadot/networks@^6.0.5":
   version "6.0.5"
   resolved "https://registry.yarnpkg.com/@polkadot/networks/-/networks-6.0.5.tgz#36271138eb2b1b7d79462fa89544d1b90fa77010"
@@ -1536,25 +1556,25 @@
   dependencies:
     "@babel/runtime" "^7.13.9"
 
-"@polkadot/rpc-core@4.3.1":
-  version "4.3.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/rpc-core/-/rpc-core-4.3.1.tgz#6b81e2468536e5aac9b0bad7710bda4e027492c3"
-  integrity sha512-vUPwQW6mvKIxdffVELyVivfGFzQIN4U+RPU8PlFrF1Fmnhb3RBSDDXvCFeVMSbsLpVNZCG9ISD8NQfm3uL9Tlw==
+"@polkadot/rpc-core@4.4.1":
+  version "4.4.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/rpc-core/-/rpc-core-4.4.1.tgz#bf010efa0bafb4b353db10067b945457ba3852eb"
+  integrity sha512-tDN6qt0LYbslHVS4iTlssNaqv5Zepe9do0Edew6oa7b4wAr5zmXbsyhlVQFgaPvi/whNjpcyRF2ZYxhGbEkd6Q==
   dependencies:
     "@babel/runtime" "^7.13.10"
-    "@polkadot/metadata" "4.3.1"
-    "@polkadot/rpc-provider" "4.3.1"
-    "@polkadot/types" "4.3.1"
+    "@polkadot/metadata" "4.4.1"
+    "@polkadot/rpc-provider" "4.4.1"
+    "@polkadot/types" "4.4.1"
     "@polkadot/util" "^6.0.5"
     "@polkadot/x-rxjs" "^6.0.5"
 
-"@polkadot/rpc-provider@4.3.1":
-  version "4.3.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/rpc-provider/-/rpc-provider-4.3.1.tgz#bd4bfc784b2ad2ca0b038eb8d1602a20dbda7c62"
-  integrity sha512-xVf7oJunaw6IEBg0l+ys4l5E7UuyYZLNALIdz7IZ2ErlO5r90662rBtIVv1BG7HgQ07eK4CpUq702XIVaoXebQ==
+"@polkadot/rpc-provider@4.4.1":
+  version "4.4.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/rpc-provider/-/rpc-provider-4.4.1.tgz#c60e27253dc0be7c6361ae63e10ac77795588e74"
+  integrity sha512-6v4iAkFzbeCLaCBvsTVTSyCy+Fp7AzMKySpdB4g/+MG8dupqts5f2BDmlnMFHBlNBDantVpJoMTvfvLfLxJz7g==
   dependencies:
     "@babel/runtime" "^7.13.10"
-    "@polkadot/types" "4.3.1"
+    "@polkadot/types" "4.4.1"
     "@polkadot/util" "^6.0.5"
     "@polkadot/util-crypto" "^6.0.5"
     "@polkadot/x-fetch" "^6.0.5"
@@ -1585,6 +1605,17 @@
     "@polkadot/util" "^6.0.5"
     bn.js "^4.11.9"
 
+"@polkadot/types-known@4.4.1":
+  version "4.4.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/types-known/-/types-known-4.4.1.tgz#dfd7e9bb8cafd50fb1438270f0310fbdf78c978d"
+  integrity sha512-JPRqRnwxTweDZMWVg+vjFLK2xB3dsJsBUcUGoL96KH8klywk5m07JueRYdNuWhnZ77OloSo+0FvLWC83oBhBfg==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@polkadot/networks" "^6.0.5"
+    "@polkadot/types" "4.4.1"
+    "@polkadot/util" "^6.0.5"
+    bn.js "^4.11.9"
+
 "@polkadot/types@4.0.4-5":
   version "4.0.4-5"
   resolved "https://registry.yarnpkg.com/@polkadot/types/-/types-4.0.4-5.tgz#f157a3d32b84ac7d7c1356bc5a55d4c31c10cfd5"
@@ -1605,6 +1636,19 @@
   dependencies:
     "@babel/runtime" "^7.13.10"
     "@polkadot/metadata" "4.3.1"
+    "@polkadot/util" "^6.0.5"
+    "@polkadot/util-crypto" "^6.0.5"
+    "@polkadot/x-rxjs" "^6.0.5"
+    "@types/bn.js" "^4.11.6"
+    bn.js "^4.11.9"
+
+"@polkadot/types@4.4.1":
+  version "4.4.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/types/-/types-4.4.1.tgz#85bdbdd965e33e2832bf77e7ffc5741e513938f7"
+  integrity sha512-sP0yqAKmv4WcFYX3fGdZ2xFaLAo1dcTY9gSL4twnG1TYBh1FT9fTux1d0d46VSPM6/+fbTV/HSIBa6wSETRHUQ==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@polkadot/metadata" "4.4.1"
     "@polkadot/util" "^6.0.5"
     "@polkadot/util-crypto" "^6.0.5"
     "@polkadot/x-rxjs" "^6.0.5"
@@ -2051,6 +2095,11 @@
   dependencies:
     "@typescript-eslint/types" "4.20.0"
     eslint-visitor-keys "^2.0.0"
+
+"@zeitgeistpm/type-defs@^0.1.35":
+  version "0.1.35"
+  resolved "https://registry.yarnpkg.com/@zeitgeistpm/type-defs/-/type-defs-0.1.35.tgz#ebbac5bc2c72792d05c939d62f84265d3088176e"
+  integrity sha512-fgsTuVy/5LE8+Q4Vi5aBiWJa9E3IuoJ10etcOUUSnE5/3fHlpoLorukZX9pQguVXFhagvCKALsKEoRMTSHkkbg==
 
 JSONStream@^1.0.4:
   version "1.3.5"


### PR DESCRIPTION
@polkadot/api
  * @substrate/txwrapper-core: 4.3.1 → 4.4.1
  * @substrate/txwrapper-examples: 4.3.1 → 4.4.1

@acala-network/type-definitions
  * @substrate/txwrapper-orml: 0.7.2-4 → 0.7.2-5
  * txwrapper-acala: 0.7.2-4 → 0.7.2-5

@polkadot/apps-config
  * @substrate/txwrapper-registry: 0.86.2 → 0.86.3-40

@polkadot/networks
  * @substrate/txwrapper-registry: 6.0.5