### PR TITLE
fix: workspace script sharing

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,9 @@
   "scripts": {
     "deploy": "yarn run build && lerna version --conventional-commits --create-release github && lerna publish from-package",
     "build": "lerna run build",
+    "build:workspace": "cd $INIT_CWD && rimraf lib/ && substrate-exec-tsc -p tsconfig.build.json",
+    "build:example": "cd $INIT_CWD && substrate-exec-tsc -p tsconfig.build.json",
+    "build:template": "cd $INIT_CWD && substrate-exec-tsc -p tsconfig.json",
     "lint": "substrate-dev-run-lint",
     "test": "substrate-exec-jest",
     "docs": "typedoc"

--- a/package.json
+++ b/package.json
@@ -11,8 +11,6 @@
     "deploy": "yarn run build && lerna version --conventional-commits --create-release github && lerna publish from-package",
     "build": "lerna run build",
     "build:workspace": "cd $INIT_CWD && rimraf lib/ && substrate-exec-tsc -p tsconfig.build.json",
-    "build:example": "cd $INIT_CWD && substrate-exec-tsc -p tsconfig.build.json",
-    "build:template": "cd $INIT_CWD && substrate-exec-tsc -p tsconfig.json",
     "lint": "substrate-dev-run-lint",
     "test": "substrate-exec-jest",
     "docs": "typedoc"

--- a/packages/txwrapper-acala/package.json
+++ b/packages/txwrapper-acala/package.json
@@ -14,7 +14,7 @@
     "node": ">=14"
   },
   "scripts": {
-    "build": "rimraf lib/ && substrate-exec-tsc -p tsconfig.build.json",
+    "build": "yarn build:workspace",
     "test": "jest"
   },
   "dependencies": {

--- a/packages/txwrapper-core/package.json
+++ b/packages/txwrapper-core/package.json
@@ -18,7 +18,7 @@
     "node": ">=14"
   },
   "scripts": {
-    "build": "rimraf lib/ && substrate-exec-tsc -p tsconfig.build.json"
+    "build": "yarn build:workspace"
   },
   "dependencies": {
     "@polkadot/api": "4.7.2",

--- a/packages/txwrapper-examples/package.json
+++ b/packages/txwrapper-examples/package.json
@@ -13,7 +13,7 @@
     "node": ">=14"
   },
   "scripts": {
-    "build": "yarn build:example",
+    "build": "yarn build:workspace",
     "polkadot": "node lib/polkadot",
     "polkadotBatchAll": "node lib/polkadotBatchAll",
     "mandala": "node lib/mandala"

--- a/packages/txwrapper-examples/package.json
+++ b/packages/txwrapper-examples/package.json
@@ -13,7 +13,7 @@
     "node": ">=14"
   },
   "scripts": {
-    "build": "substrate-exec-tsc -p tsconfig.build.json",
+    "build": "yarn build:example",
     "polkadot": "node lib/polkadot",
     "polkadotBatchAll": "node lib/polkadotBatchAll",
     "mandala": "node lib/mandala"

--- a/packages/txwrapper-orml/package.json
+++ b/packages/txwrapper-orml/package.json
@@ -18,7 +18,7 @@
   "bugs": "https://github.com/paritytech/txwrapper-core/issues",
   "homepage": "https://github.com/paritytech/txwrapper-core/tree/master/packages/txwrapper-orml#readme",
   "scripts": {
-    "build": "rimraf lib/ && substrate-exec-tsc -p tsconfig.build.json"
+    "build": "yarn build:workspace"
   },
   "dependencies": {
     "@substrate/txwrapper-core": "^0.5.1"

--- a/packages/txwrapper-polkadot/package.json
+++ b/packages/txwrapper-polkadot/package.json
@@ -18,7 +18,7 @@
     "node": ">=14"
   },
   "scripts": {
-    "build": "rimraf lib/ && substrate-exec-tsc -p tsconfig.build.json"
+    "build": "yarn build:workspace"
   },
   "dependencies": {
     "@substrate/txwrapper-core": "^0.5.1",

--- a/packages/txwrapper-registry/package.json
+++ b/packages/txwrapper-registry/package.json
@@ -18,7 +18,7 @@
     "node": ">=14"
   },
   "scripts": {
-    "build": "rimraf lib/ && substrate-exec-tsc -p tsconfig.build.json"
+    "build": "yarn build:workspace"
   },
   "dependencies": {
     "@polkadot/apps-config": "0.89.1",

--- a/packages/txwrapper-substrate/package.json
+++ b/packages/txwrapper-substrate/package.json
@@ -18,7 +18,7 @@
     "node": ">=14"
   },
   "scripts": {
-    "build": "rimraf lib/ && substrate-exec-tsc -p tsconfig.build.json"
+    "build": "yarn build:workspace"
   },
   "dependencies": {
     "@substrate/txwrapper-core": "^0.5.1"

--- a/packages/txwrapper-template/package.json
+++ b/packages/txwrapper-template/package.json
@@ -16,7 +16,7 @@
     "node": ">=14"
   },
   "scripts": {
-    "build": "substrate-exec-tsc -p tsconfig.json"
+    "build": "yarn build:template"
   },
   "dependencies": {
     "@substrate/txwrapper-core": "^0.5.1",

--- a/packages/txwrapper-template/package.json
+++ b/packages/txwrapper-template/package.json
@@ -16,7 +16,7 @@
     "node": ">=14"
   },
   "scripts": {
-    "build": "yarn build:template"
+    "build": "tsc"
   },
   "dependencies": {
     "@substrate/txwrapper-core": "^0.5.1",


### PR DESCRIPTION
This PR aims to handle a behavior that yarn 2.x introduces. Being in a workspace we now need to share scripts accessing `bin` commands from `@substrate/dev`. This is only useful if you are developing in a single package and want to run the build locally. 

For example, if we call `yarn build` from the root directory it has access to the `bin` commands, and will then be accessible to the script calls in each packages `package.json`.  If we were to `cd` into one of the packages they no longer have access, therefore we need to share scripts from the root directory. That can be achieved by adding a colon `:` in the root package.json directory followed by a  `cd $INIT_CWD &&` in the scripts itself.

For example: `"build:workspace": "cd $INIT_CWD && rimraf lib/ && substrate-exec-tsc -p tsconfig.build.json"`

You then would just call it as `yarn build:workspace` in the packages scripts. 