### PR TITLE
fix: update polkadot-js deps; update `decorateConstants` usage

### DIFF
--- a/packages/txwrapper-core/package.json
+++ b/packages/txwrapper-core/package.json
@@ -21,7 +21,7 @@
     "build": "yarn build:workspace"
   },
   "dependencies": {
-    "@polkadot/api": "4.7.2",
+    "@polkadot/api": "4.8.1",
     "memoizee": "0.4.15"
   },
   "devDependencies": {

--- a/packages/txwrapper-core/src/core/metadata/createDecorated.ts
+++ b/packages/txwrapper-core/src/core/metadata/createDecorated.ts
@@ -34,8 +34,6 @@ export function createDecoratedConstants(
 	registry: TypeRegistry,
 	metadataRpc: string
 ): Constants {
-	return decorateConstants(
-		registry,
-		createMetadata(registry, metadataRpc).asLatest
-	);
+	const metadata = createMetadata(registry, metadataRpc);
+	return decorateConstants(registry, metadata.asLatest, metadata.version);
 }

--- a/packages/txwrapper-examples/package.json
+++ b/packages/txwrapper-examples/package.json
@@ -19,7 +19,7 @@
     "mandala": "node lib/mandala"
   },
   "dependencies": {
-    "@polkadot/api": "4.7.2",
+    "@polkadot/api": "4.8.1",
     "@substrate/txwrapper-polkadot": "^0.5.1",
     "txwrapper-acala": "^0.5.1"
   }

--- a/packages/txwrapper-registry/package.json
+++ b/packages/txwrapper-registry/package.json
@@ -21,8 +21,8 @@
     "build": "yarn build:workspace"
   },
   "dependencies": {
-    "@polkadot/apps-config": "0.89.1",
-    "@polkadot/networks": "6.2.1",
+    "@polkadot/apps-config": "0.90.1",
+    "@polkadot/networks": "6.3.1",
     "@substrate/txwrapper-core": "^0.5.1"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -405,6 +405,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/runtime@npm:^7.14.0":
+  version: 7.14.0
+  resolution: "@babel/runtime@npm:7.14.0"
+  dependencies:
+    regenerator-runtime: ^0.13.4
+  checksum: ab6653f2f8ecdaebf36674894cef458a9d4f881dc007fdcd50a8261f5c6d9731e03fda2c17e32ecf0e6c779d69eb6cf49d68a48c780aaf07d5b572e8b7ef0508
+  languageName: node
+  linkType: hard
+
 "@babel/template@npm:^7.12.13, @babel/template@npm:^7.3.3":
   version: 7.12.13
   resolution: "@babel/template@npm:7.12.13"
@@ -481,24 +490,24 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@darwinia/types-known@npm:^1.1.0-alpha.9":
-  version: 1.1.0-alpha.9
-  resolution: "@darwinia/types-known@npm:1.1.0-alpha.9"
+"@darwinia/types-known@npm:^1.1.0-alpha.11":
+  version: 1.1.0-alpha.11
+  resolution: "@darwinia/types-known@npm:1.1.0-alpha.11"
   dependencies:
     "@babel/runtime": ^7.9.6
     "@polkadot/types": 4.0.4-5
     "@polkadot/util": 6.0.5
     bn.js: ^5.1.2
-  checksum: 3e35205b377278466a18ec8ffc09090437f6526c420b801e9aa0e36f226131d05498c797002a5f414d0440ca91c46372cee453d30e595d6a38dd4a0f34ba7374
+  checksum: b11c20453703ee56b7bb722bbf0298e7c57a544e22865c69957b05c42e149336d2290a7dc9daf908484045cc506f52a870f97d42178a4dce5c622e030310a4e6
   languageName: node
   linkType: hard
 
-"@darwinia/types@npm:^1.1.0-alpha.9":
-  version: 1.1.0-alpha.9
-  resolution: "@darwinia/types@npm:1.1.0-alpha.9"
+"@darwinia/types@npm:^1.1.0-alpha.11":
+  version: 1.1.0-alpha.11
+  resolution: "@darwinia/types@npm:1.1.0-alpha.11"
   dependencies:
-    "@darwinia/types-known": ^1.1.0-alpha.9
-  checksum: 9eecfa7aa01294f143452fd2a6b8ec7aa4caec87b528b339331156994f4cd16997623e945d08cdb9c322f174912581ae81ee01e12abe9ea2d2d3608ee6914503
+    "@darwinia/types-known": ^1.1.0-alpha.11
+  checksum: 54015bed406c650751a3827328eb681f2bdcfc8fc9466a68470efd2aabc4b9874fec76ca1f1f0460275fc47a30bcafbc388139c263a7ace6c28f7f33d4f3f208
   languageName: node
   linkType: hard
 
@@ -509,10 +518,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@equilab/definitions@npm:1.0.3":
-  version: 1.0.3
-  resolution: "@equilab/definitions@npm:1.0.3"
-  checksum: a569faeacf4499b456e383840b7d7e1be81e8fdf40d7f436fc6456057eaafe91ce7ff6812e46a53f09ae3d26e519216cee580a1c079047a7abb337a05b17edc1
+"@equilab/definitions@npm:1.0.4":
+  version: 1.0.4
+  resolution: "@equilab/definitions@npm:1.0.4"
+  checksum: 15b0234c78d41ec682035be3178648428fce594335041c04efb374734f10ece5031b3da19c1fdfb6cee8923d1465d1e33edf1e009b93fa47528c84d39181e5ad
   languageName: node
   linkType: hard
 
@@ -1820,64 +1829,64 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@polkadot/api-derive@npm:4.7.2":
-  version: 4.7.2
-  resolution: "@polkadot/api-derive@npm:4.7.2"
+"@polkadot/api-derive@npm:4.8.1":
+  version: 4.8.1
+  resolution: "@polkadot/api-derive@npm:4.8.1"
   dependencies:
-    "@babel/runtime": ^7.13.17
-    "@polkadot/api": 4.7.2
-    "@polkadot/rpc-core": 4.7.2
-    "@polkadot/types": 4.7.2
+    "@babel/runtime": ^7.14.0
+    "@polkadot/api": 4.8.1
+    "@polkadot/rpc-core": 4.8.1
+    "@polkadot/types": 4.8.1
     "@polkadot/util": ^6.3.1
     "@polkadot/util-crypto": ^6.3.1
     "@polkadot/x-rxjs": ^6.3.1
     bn.js: ^4.11.9
-  checksum: 1361fb058c48cd1e4b1adbfb1225e77844a52c3b0a5e84932ec0828b8dfef571e5ab2ddeae8cd9698f05b02ec43e143bb10618714b585ea9812ebdbac0e2e970
+  checksum: 479188a0a16bdafa5fd50d581022f43629359c7cf5f8fdeec27868dc7bcd2e35103b773ff068c980c18653dfe0f60fe9907577ca0a324ca6e343fc9f1b2df628
   languageName: node
   linkType: hard
 
-"@polkadot/api@npm:4.7.2":
-  version: 4.7.2
-  resolution: "@polkadot/api@npm:4.7.2"
+"@polkadot/api@npm:4.8.1":
+  version: 4.8.1
+  resolution: "@polkadot/api@npm:4.8.1"
   dependencies:
-    "@babel/runtime": ^7.13.17
-    "@polkadot/api-derive": 4.7.2
+    "@babel/runtime": ^7.14.0
+    "@polkadot/api-derive": 4.8.1
     "@polkadot/keyring": ^6.3.1
-    "@polkadot/metadata": 4.7.2
-    "@polkadot/rpc-core": 4.7.2
-    "@polkadot/rpc-provider": 4.7.2
-    "@polkadot/types": 4.7.2
-    "@polkadot/types-known": 4.7.2
+    "@polkadot/metadata": 4.8.1
+    "@polkadot/rpc-core": 4.8.1
+    "@polkadot/rpc-provider": 4.8.1
+    "@polkadot/types": 4.8.1
+    "@polkadot/types-known": 4.8.1
     "@polkadot/util": ^6.3.1
     "@polkadot/util-crypto": ^6.3.1
     "@polkadot/x-rxjs": ^6.3.1
     bn.js: ^4.11.9
     eventemitter3: ^4.0.7
-  checksum: ab987ece65a9f0752d9c8b2d7da282714b0f862b8dee154d3c71ac932c2e38f069d7808a07e12e91b927723b4b0abd5994e39b59bf9de83863e81c663652009b
+  checksum: 01dc838e76bc69d38aa13b192595e8095af405f7e4106cace0ad1cdbb77d76569571177b682b0240cb6480f2f8e02c6503d28b2da61bb2e3346a53f951ba25c2
   languageName: node
   linkType: hard
 
-"@polkadot/apps-config@npm:0.89.1":
-  version: 0.89.1
-  resolution: "@polkadot/apps-config@npm:0.89.1"
+"@polkadot/apps-config@npm:0.90.1":
+  version: 0.90.1
+  resolution: "@polkadot/apps-config@npm:0.90.1"
   dependencies:
     "@acala-network/type-definitions": ^0.7.3
-    "@babel/runtime": ^7.13.17
+    "@babel/runtime": ^7.14.0
     "@crustio/type-definitions": 0.0.6
-    "@darwinia/types": ^1.1.0-alpha.9
+    "@darwinia/types": ^1.1.0-alpha.11
     "@edgeware/node-types": ^3.3.4
-    "@equilab/definitions": 1.0.3
+    "@equilab/definitions": 1.0.4
     "@interlay/polkabtc-types": ^0.6.2
     "@kiltprotocol/type-definitions": ^0.1.3
     "@laminar/type-definitions": ^0.3.1
     "@phala/typedefs": 0.1.0
     "@polkadot/networks": ^6.3.1
     "@snowfork/snowbridge-types": ^0.2.3
-    "@sora-substrate/type-definitions": ^0.8.9
+    "@sora-substrate/type-definitions": ^0.8.14
     "@subsocial/types": ^0.5.0-substrate2.0
-    "@zeitgeistpm/type-defs": ^0.1.36
+    "@zeitgeistpm/type-defs": ^0.1.47
     moonbeam-types-bundle: 1.1.12
-  checksum: 38cf8c07019c8859404c45e629083abb9c0464060c3e98317b3cfa0c9657022b7d91c568a3e5a47a252024f13c32ba9568a0ab127b10042ae84b7376c33b0623
+  checksum: 3872eb1bac66c9352a8deee1fab538cfe8285241fcaa3ed5bcb383fb69f892bbdff38400d78f7c51ed77258739214639f37a34b63c840c2e4f129fe418f92cfb
   languageName: node
   linkType: hard
 
@@ -1923,17 +1932,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@polkadot/metadata@npm:4.7.2":
-  version: 4.7.2
-  resolution: "@polkadot/metadata@npm:4.7.2"
+"@polkadot/metadata@npm:4.8.1":
+  version: 4.8.1
+  resolution: "@polkadot/metadata@npm:4.8.1"
   dependencies:
-    "@babel/runtime": ^7.13.17
-    "@polkadot/types": 4.7.2
-    "@polkadot/types-known": 4.7.2
+    "@babel/runtime": ^7.14.0
+    "@polkadot/types": 4.8.1
+    "@polkadot/types-known": 4.8.1
     "@polkadot/util": ^6.3.1
     "@polkadot/util-crypto": ^6.3.1
     bn.js: ^4.11.9
-  checksum: c2d02775bec8333b8f5dc01bab9b04c90256e41f8df24e3d79f0b063f08abe5965b0d398aad53dc53596b6b45717f0d391f7307ccf95d8d252a68c5b245afa2a
+  checksum: 9516361b7a27872ed936cf19560165903823b7efb81accb46a114202583fec66458d87e2e4fcc5ce4e0db9c389575ff10aa821009c3f500eb6ff0a978b164722
   languageName: node
   linkType: hard
 
@@ -1955,26 +1964,26 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@polkadot/rpc-core@npm:4.7.2":
-  version: 4.7.2
-  resolution: "@polkadot/rpc-core@npm:4.7.2"
+"@polkadot/rpc-core@npm:4.8.1":
+  version: 4.8.1
+  resolution: "@polkadot/rpc-core@npm:4.8.1"
   dependencies:
-    "@babel/runtime": ^7.13.17
-    "@polkadot/metadata": 4.7.2
-    "@polkadot/rpc-provider": 4.7.2
-    "@polkadot/types": 4.7.2
+    "@babel/runtime": ^7.14.0
+    "@polkadot/metadata": 4.8.1
+    "@polkadot/rpc-provider": 4.8.1
+    "@polkadot/types": 4.8.1
     "@polkadot/util": ^6.3.1
     "@polkadot/x-rxjs": ^6.3.1
-  checksum: a0ef24baf35d5170258edaab80a2fe59925ee4fd49d6a47ca73b4e3056d0f042061188f5d12fddf44c28f848c941116f3cf5d05f96b3d52f75ac3bd1fa02f62e
+  checksum: 9298e1c81323680c1a384465a1ac204d2f5e3718a4a43e175244aba363cc3df006f2be8d469e96469a2386c45099c50a3b0238cc6e7a998432137de423c20cf9
   languageName: node
   linkType: hard
 
-"@polkadot/rpc-provider@npm:4.7.2":
-  version: 4.7.2
-  resolution: "@polkadot/rpc-provider@npm:4.7.2"
+"@polkadot/rpc-provider@npm:4.8.1":
+  version: 4.8.1
+  resolution: "@polkadot/rpc-provider@npm:4.8.1"
   dependencies:
-    "@babel/runtime": ^7.13.17
-    "@polkadot/types": 4.7.2
+    "@babel/runtime": ^7.14.0
+    "@polkadot/types": 4.8.1
     "@polkadot/util": ^6.3.1
     "@polkadot/util-crypto": ^6.3.1
     "@polkadot/x-fetch": ^6.3.1
@@ -1982,7 +1991,7 @@ __metadata:
     "@polkadot/x-ws": ^6.3.1
     bn.js: ^4.11.9
     eventemitter3: ^4.0.7
-  checksum: a878d12caf90a12dbe6c517e1147f63a8defab37139bbce745030cee4d8c91448ffd8d5020d201ace842c35ee6b26af0ed40e01a4ac4b0236fc2edb4d5e118f9
+  checksum: 65ec370e246ca26b72c9b88b7bbf66824bb467e63394e73e881b38216d7300ad3c81a6b939bf8323f86cafceb2b2fe2ebd8fa37ae915a0b51fab000651f7dedf
   languageName: node
   linkType: hard
 
@@ -2012,16 +2021,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@polkadot/types-known@npm:4.7.2":
-  version: 4.7.2
-  resolution: "@polkadot/types-known@npm:4.7.2"
+"@polkadot/types-known@npm:4.8.1":
+  version: 4.8.1
+  resolution: "@polkadot/types-known@npm:4.8.1"
   dependencies:
-    "@babel/runtime": ^7.13.17
+    "@babel/runtime": ^7.14.0
     "@polkadot/networks": ^6.3.1
-    "@polkadot/types": 4.7.2
+    "@polkadot/types": 4.8.1
     "@polkadot/util": ^6.3.1
     bn.js: ^4.11.9
-  checksum: 6895892af57d0cbbd556d2a70d50065709be91f7de9bcce9ec1b485e31f8f6ff4d8423e41395b370b404de4bb4273ffd804c1e0673b6f21d8635e3c2ec6f01ee
+  checksum: 4c775b473370c8a0368c7098f75e1c87bd024287290bac332c4b97f5c2cf13eb7d62b07c7f90136c4468ae20141d0884ab3084191ddc81b66f330b259b798628
   languageName: node
   linkType: hard
 
@@ -2055,18 +2064,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@polkadot/types@npm:4.7.2":
-  version: 4.7.2
-  resolution: "@polkadot/types@npm:4.7.2"
+"@polkadot/types@npm:4.8.1":
+  version: 4.8.1
+  resolution: "@polkadot/types@npm:4.8.1"
   dependencies:
-    "@babel/runtime": ^7.13.17
-    "@polkadot/metadata": 4.7.2
+    "@babel/runtime": ^7.14.0
+    "@polkadot/metadata": 4.8.1
     "@polkadot/util": ^6.3.1
     "@polkadot/util-crypto": ^6.3.1
     "@polkadot/x-rxjs": ^6.3.1
     "@types/bn.js": ^4.11.6
     bn.js: ^4.11.9
-  checksum: ac815b666b61942b2dd04d0fc3ac9d35be28db2ecf792ec12f30a80bffff85110556564853a8a64fb3de9263dc089ac22ec022c87471d3004fabb863f3a87cd9
+  checksum: 0215f6915053fb666de3f214c3bc8db561c346d8fa458348f1d0b93344053d6d4da7df05687de6f3ed0ce9e01a242b993c178933f1f52695b71b9603367c4b79
   languageName: node
   linkType: hard
 
@@ -2401,12 +2410,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@sora-substrate/type-definitions@npm:^0.8.9":
-  version: 0.8.12
-  resolution: "@sora-substrate/type-definitions@npm:0.8.12"
+"@sora-substrate/type-definitions@npm:^0.8.14":
+  version: 0.8.17
+  resolution: "@sora-substrate/type-definitions@npm:0.8.17"
   dependencies:
     "@open-web3/orml-type-definitions": ^0.8.2-9
-  checksum: 877ca5c7af7240fda54e2a0ff48bf8c5fe6ee4bda177886da07ad971898165c1a6d9c91a2a3a7a06e7099df48f2e81fb15b1c845cb5106e825369b6621a9136a
+  checksum: 61f54d27760b79f06088747ebd856351eb02bb370bd18e9fd2f08c3603006d306a5cb31716227d69bdfd982b1c1d9c8cf553f4818accf97a4484d2c41d9b41f8
   languageName: node
   linkType: hard
 
@@ -2468,7 +2477,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@substrate/txwrapper-core@workspace:packages/txwrapper-core"
   dependencies:
-    "@polkadot/api": 4.7.2
+    "@polkadot/api": 4.8.1
     "@types/memoizee": ^0.4.3
     memoizee: 0.4.15
   languageName: unknown
@@ -2478,7 +2487,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@substrate/txwrapper-examples@workspace:packages/txwrapper-examples"
   dependencies:
-    "@polkadot/api": 4.7.2
+    "@polkadot/api": 4.8.1
     "@substrate/txwrapper-polkadot": ^0.5.1
     txwrapper-acala: ^0.5.1
   languageName: unknown
@@ -2506,8 +2515,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@substrate/txwrapper-registry@workspace:packages/txwrapper-registry"
   dependencies:
-    "@polkadot/apps-config": 0.89.1
-    "@polkadot/networks": 6.2.1
+    "@polkadot/apps-config": 0.90.1
+    "@polkadot/networks": 6.3.1
     "@substrate/txwrapper-core": ^0.5.1
   languageName: unknown
   linkType: soft
@@ -2854,10 +2863,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@zeitgeistpm/type-defs@npm:^0.1.36":
-  version: 0.1.36
-  resolution: "@zeitgeistpm/type-defs@npm:0.1.36"
-  checksum: 03bb70408727c55cbb0a6d033ddecb6cd30ce01a9640dffcd177c75de080889f21d33922621939d44a1a7f0bb302cbaab7b6e3068f95d261e519b0ddce767a75
+"@zeitgeistpm/type-defs@npm:^0.1.47":
+  version: 0.1.47
+  resolution: "@zeitgeistpm/type-defs@npm:0.1.47"
+  checksum: ed99384c6cab22f20de2c8d421d06d6ab462e85c6f177096e293869bce45d12dbfca69e6393efe88e9606fd50bfbdb7d5fb8d725d566dce10f8dc40d3be24b1e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
- Bump polkadot-js scoped deps
- update `decorateConstants` usage to account for new version parameter

sister PR to https://github.com/paritytech/txwrapper/pull/433