### PR TITLE
fix: Bump polkadot-js/api; Remove deprecated createType log option

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,12 @@ yarn run lint --fix
 
 ### Maintain
 
+Bump `polkadot-js` scoped deps
+
+```bash
+yarn up "@polkadot/*"
+```
+
 Publish with lerna by running:*
 
 ```bash

--- a/packages/txwrapper-core/package.json
+++ b/packages/txwrapper-core/package.json
@@ -21,7 +21,7 @@
     "build": "yarn build:workspace"
   },
   "dependencies": {
-    "@polkadot/api": "4.8.1",
+    "@polkadot/api": "^4.9.2",
     "memoizee": "0.4.15"
   },
   "devDependencies": {

--- a/packages/txwrapper-core/src/core/decode/decodeSigningPayload.ts
+++ b/packages/txwrapper-core/src/core/decode/decodeSigningPayload.ts
@@ -37,15 +37,9 @@ export function decodeSigningPayload(
 			{
 				version: EXTRINSIC_VERSION,
 			},
-		],
-		{ withoutLog: true }
+		]
 	);
-	const methodCall: Call = createTypeUnsafe(
-		registry,
-		'Call',
-		[payload.method],
-		{ withoutLog: true }
-	);
+	const methodCall: Call = createTypeUnsafe(registry, 'Call', [payload.method]);
 	const method = toTxMethod(registry, methodCall);
 
 	return {

--- a/packages/txwrapper-examples/package.json
+++ b/packages/txwrapper-examples/package.json
@@ -19,7 +19,7 @@
     "mandala": "node lib/mandala"
   },
   "dependencies": {
-    "@polkadot/api": "4.8.1",
+    "@polkadot/api": "^4.9.2",
     "@substrate/txwrapper-polkadot": "^1.0.0",
     "txwrapper-acala": "^1.0.0"
   }

--- a/packages/txwrapper-registry/package.json
+++ b/packages/txwrapper-registry/package.json
@@ -21,8 +21,8 @@
     "build": "yarn build:workspace"
   },
   "dependencies": {
-    "@polkadot/apps-config": "0.90.1",
-    "@polkadot/networks": "6.3.1",
+    "@polkadot/apps-config": "^0.90.1",
+    "@polkadot/networks": "^6.3.1",
     "@substrate/txwrapper-core": "^1.0.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1829,44 +1829,44 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@polkadot/api-derive@npm:4.8.1":
-  version: 4.8.1
-  resolution: "@polkadot/api-derive@npm:4.8.1"
+"@polkadot/api-derive@npm:4.9.2":
+  version: 4.9.2
+  resolution: "@polkadot/api-derive@npm:4.9.2"
   dependencies:
     "@babel/runtime": ^7.14.0
-    "@polkadot/api": 4.8.1
-    "@polkadot/rpc-core": 4.8.1
-    "@polkadot/types": 4.8.1
+    "@polkadot/api": 4.9.2
+    "@polkadot/rpc-core": 4.9.2
+    "@polkadot/types": 4.9.2
     "@polkadot/util": ^6.3.1
     "@polkadot/util-crypto": ^6.3.1
     "@polkadot/x-rxjs": ^6.3.1
     bn.js: ^4.11.9
-  checksum: 479188a0a16bdafa5fd50d581022f43629359c7cf5f8fdeec27868dc7bcd2e35103b773ff068c980c18653dfe0f60fe9907577ca0a324ca6e343fc9f1b2df628
+  checksum: b8c1b4f66348535b5d88ae239602ee04eee401855a628c3202bfa07b70d9c71742bf7724c76d88fbc51c9c380fd521e8a96366bcd44c752355a5841f0fc263a8
   languageName: node
   linkType: hard
 
-"@polkadot/api@npm:4.8.1":
-  version: 4.8.1
-  resolution: "@polkadot/api@npm:4.8.1"
+"@polkadot/api@npm:4.9.2, @polkadot/api@npm:^4.9.2":
+  version: 4.9.2
+  resolution: "@polkadot/api@npm:4.9.2"
   dependencies:
     "@babel/runtime": ^7.14.0
-    "@polkadot/api-derive": 4.8.1
+    "@polkadot/api-derive": 4.9.2
     "@polkadot/keyring": ^6.3.1
-    "@polkadot/metadata": 4.8.1
-    "@polkadot/rpc-core": 4.8.1
-    "@polkadot/rpc-provider": 4.8.1
-    "@polkadot/types": 4.8.1
-    "@polkadot/types-known": 4.8.1
+    "@polkadot/metadata": 4.9.2
+    "@polkadot/rpc-core": 4.9.2
+    "@polkadot/rpc-provider": 4.9.2
+    "@polkadot/types": 4.9.2
+    "@polkadot/types-known": 4.9.2
     "@polkadot/util": ^6.3.1
     "@polkadot/util-crypto": ^6.3.1
     "@polkadot/x-rxjs": ^6.3.1
     bn.js: ^4.11.9
     eventemitter3: ^4.0.7
-  checksum: 01dc838e76bc69d38aa13b192595e8095af405f7e4106cace0ad1cdbb77d76569571177b682b0240cb6480f2f8e02c6503d28b2da61bb2e3346a53f951ba25c2
+  checksum: a95686fe008dcf9f5de69ab433b585fb7ece40fd64bae56555873da829704ee0f24bc96d81b7c653402dbf4dbad772f82db4498ca772e1b80ee765ae8c5307dd
   languageName: node
   linkType: hard
 
-"@polkadot/apps-config@npm:0.90.1":
+"@polkadot/apps-config@npm:^0.90.1":
   version: 0.90.1
   resolution: "@polkadot/apps-config@npm:0.90.1"
   dependencies:
@@ -1932,17 +1932,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@polkadot/metadata@npm:4.8.1":
-  version: 4.8.1
-  resolution: "@polkadot/metadata@npm:4.8.1"
+"@polkadot/metadata@npm:4.9.2":
+  version: 4.9.2
+  resolution: "@polkadot/metadata@npm:4.9.2"
   dependencies:
     "@babel/runtime": ^7.14.0
-    "@polkadot/types": 4.8.1
-    "@polkadot/types-known": 4.8.1
+    "@polkadot/types": 4.9.2
+    "@polkadot/types-known": 4.9.2
     "@polkadot/util": ^6.3.1
     "@polkadot/util-crypto": ^6.3.1
     bn.js: ^4.11.9
-  checksum: 9516361b7a27872ed936cf19560165903823b7efb81accb46a114202583fec66458d87e2e4fcc5ce4e0db9c389575ff10aa821009c3f500eb6ff0a978b164722
+  checksum: efb59a743a536ea5f14e37da6024aab6617016b0521e43ab9c570728d06ad6f33fa13780740715750e401cad389ca55ed378ec6a1c37102b4ee7128284180088
   languageName: node
   linkType: hard
 
@@ -1964,26 +1964,26 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@polkadot/rpc-core@npm:4.8.1":
-  version: 4.8.1
-  resolution: "@polkadot/rpc-core@npm:4.8.1"
+"@polkadot/rpc-core@npm:4.9.2":
+  version: 4.9.2
+  resolution: "@polkadot/rpc-core@npm:4.9.2"
   dependencies:
     "@babel/runtime": ^7.14.0
-    "@polkadot/metadata": 4.8.1
-    "@polkadot/rpc-provider": 4.8.1
-    "@polkadot/types": 4.8.1
+    "@polkadot/metadata": 4.9.2
+    "@polkadot/rpc-provider": 4.9.2
+    "@polkadot/types": 4.9.2
     "@polkadot/util": ^6.3.1
     "@polkadot/x-rxjs": ^6.3.1
-  checksum: 9298e1c81323680c1a384465a1ac204d2f5e3718a4a43e175244aba363cc3df006f2be8d469e96469a2386c45099c50a3b0238cc6e7a998432137de423c20cf9
+  checksum: e2246bd701fc86d2df29aafc7051a404b33fda4732da697789e727ebaf97859605707b23770430fce84b639a4c8716772b7618f00c935067d268f2aa5d4db7fb
   languageName: node
   linkType: hard
 
-"@polkadot/rpc-provider@npm:4.8.1":
-  version: 4.8.1
-  resolution: "@polkadot/rpc-provider@npm:4.8.1"
+"@polkadot/rpc-provider@npm:4.9.2":
+  version: 4.9.2
+  resolution: "@polkadot/rpc-provider@npm:4.9.2"
   dependencies:
     "@babel/runtime": ^7.14.0
-    "@polkadot/types": 4.8.1
+    "@polkadot/types": 4.9.2
     "@polkadot/util": ^6.3.1
     "@polkadot/util-crypto": ^6.3.1
     "@polkadot/x-fetch": ^6.3.1
@@ -1991,7 +1991,7 @@ __metadata:
     "@polkadot/x-ws": ^6.3.1
     bn.js: ^4.11.9
     eventemitter3: ^4.0.7
-  checksum: 65ec370e246ca26b72c9b88b7bbf66824bb467e63394e73e881b38216d7300ad3c81a6b939bf8323f86cafceb2b2fe2ebd8fa37ae915a0b51fab000651f7dedf
+  checksum: d2b96ffe6361f69848d76e16a603b8551110dbb71dfe7e8233cad1386d34b5d25434cd9075b4fe9834de662b7d9ebc2f5b543c7438d179392fef523b899961c4
   languageName: node
   linkType: hard
 
@@ -2021,16 +2021,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@polkadot/types-known@npm:4.8.1":
-  version: 4.8.1
-  resolution: "@polkadot/types-known@npm:4.8.1"
+"@polkadot/types-known@npm:4.9.2":
+  version: 4.9.2
+  resolution: "@polkadot/types-known@npm:4.9.2"
   dependencies:
     "@babel/runtime": ^7.14.0
     "@polkadot/networks": ^6.3.1
-    "@polkadot/types": 4.8.1
+    "@polkadot/types": 4.9.2
     "@polkadot/util": ^6.3.1
     bn.js: ^4.11.9
-  checksum: 4c775b473370c8a0368c7098f75e1c87bd024287290bac332c4b97f5c2cf13eb7d62b07c7f90136c4468ae20141d0884ab3084191ddc81b66f330b259b798628
+  checksum: 50e88d5f5c994c3bee45f72186cf4a037310da3d7b3e87a2d0694bfe64c298a8fc247f235ffb4fbe242bda51286eaa3ac0f0aff4c4c17be0fc1fc1f900eac8cf
   languageName: node
   linkType: hard
 
@@ -2064,18 +2064,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@polkadot/types@npm:4.8.1":
-  version: 4.8.1
-  resolution: "@polkadot/types@npm:4.8.1"
+"@polkadot/types@npm:4.9.2":
+  version: 4.9.2
+  resolution: "@polkadot/types@npm:4.9.2"
   dependencies:
     "@babel/runtime": ^7.14.0
-    "@polkadot/metadata": 4.8.1
+    "@polkadot/metadata": 4.9.2
     "@polkadot/util": ^6.3.1
     "@polkadot/util-crypto": ^6.3.1
     "@polkadot/x-rxjs": ^6.3.1
     "@types/bn.js": ^4.11.6
     bn.js: ^4.11.9
-  checksum: 0215f6915053fb666de3f214c3bc8db561c346d8fa458348f1d0b93344053d6d4da7df05687de6f3ed0ce9e01a242b993c178933f1f52695b71b9603367c4b79
+  checksum: c37ce7b2343e3db7846a0d3e88b87bd4306a780e9bf2ae82e8a399fa21624acd6697a129ae8e02284a428fade8592951c6f90bdf26ff338e79a69e46dde72770
   languageName: node
   linkType: hard
 
@@ -2473,11 +2473,11 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@substrate/txwrapper-core@^0.5.1, @substrate/txwrapper-core@workspace:packages/txwrapper-core":
+"@substrate/txwrapper-core@^1.0.0, @substrate/txwrapper-core@workspace:packages/txwrapper-core":
   version: 0.0.0-use.local
   resolution: "@substrate/txwrapper-core@workspace:packages/txwrapper-core"
   dependencies:
-    "@polkadot/api": 4.8.1
+    "@polkadot/api": ^4.9.2
     "@types/memoizee": ^0.4.3
     memoizee: 0.4.15
   languageName: unknown
@@ -2487,45 +2487,45 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@substrate/txwrapper-examples@workspace:packages/txwrapper-examples"
   dependencies:
-    "@polkadot/api": 4.8.1
-    "@substrate/txwrapper-polkadot": ^0.5.1
-    txwrapper-acala: ^0.5.1
+    "@polkadot/api": ^4.9.2
+    "@substrate/txwrapper-polkadot": ^1.0.0
+    txwrapper-acala: ^1.0.0
   languageName: unknown
   linkType: soft
 
-"@substrate/txwrapper-orml@^0.5.1, @substrate/txwrapper-orml@workspace:packages/txwrapper-orml":
+"@substrate/txwrapper-orml@^1.0.0, @substrate/txwrapper-orml@workspace:packages/txwrapper-orml":
   version: 0.0.0-use.local
   resolution: "@substrate/txwrapper-orml@workspace:packages/txwrapper-orml"
   dependencies:
     "@acala-network/type-definitions": 0.7.4-1
-    "@substrate/txwrapper-core": ^0.5.1
+    "@substrate/txwrapper-core": ^1.0.0
   languageName: unknown
   linkType: soft
 
-"@substrate/txwrapper-polkadot@^0.5.1, @substrate/txwrapper-polkadot@workspace:packages/txwrapper-polkadot":
+"@substrate/txwrapper-polkadot@^1.0.0, @substrate/txwrapper-polkadot@workspace:packages/txwrapper-polkadot":
   version: 0.0.0-use.local
   resolution: "@substrate/txwrapper-polkadot@workspace:packages/txwrapper-polkadot"
   dependencies:
-    "@substrate/txwrapper-core": ^0.5.1
-    "@substrate/txwrapper-substrate": ^0.5.1
+    "@substrate/txwrapper-core": ^1.0.0
+    "@substrate/txwrapper-substrate": ^1.0.0
   languageName: unknown
   linkType: soft
 
-"@substrate/txwrapper-registry@^0.5.1, @substrate/txwrapper-registry@workspace:packages/txwrapper-registry":
+"@substrate/txwrapper-registry@^1.0.0, @substrate/txwrapper-registry@workspace:packages/txwrapper-registry":
   version: 0.0.0-use.local
   resolution: "@substrate/txwrapper-registry@workspace:packages/txwrapper-registry"
   dependencies:
-    "@polkadot/apps-config": 0.90.1
-    "@polkadot/networks": 6.3.1
-    "@substrate/txwrapper-core": ^0.5.1
+    "@polkadot/apps-config": ^0.90.1
+    "@polkadot/networks": ^6.3.1
+    "@substrate/txwrapper-core": ^1.0.0
   languageName: unknown
   linkType: soft
 
-"@substrate/txwrapper-substrate@^0.5.1, @substrate/txwrapper-substrate@workspace:packages/txwrapper-substrate":
+"@substrate/txwrapper-substrate@^1.0.0, @substrate/txwrapper-substrate@workspace:packages/txwrapper-substrate":
   version: 0.0.0-use.local
   resolution: "@substrate/txwrapper-substrate@workspace:packages/txwrapper-substrate"
   dependencies:
-    "@substrate/txwrapper-core": ^0.5.1
+    "@substrate/txwrapper-core": ^1.0.0
   languageName: unknown
   linkType: soft
 
@@ -2533,9 +2533,9 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@substrate/txwrapper-template@workspace:packages/txwrapper-template"
   dependencies:
-    "@substrate/txwrapper-core": ^0.5.1
-    "@substrate/txwrapper-registry": ^0.5.1
-    "@substrate/txwrapper-substrate": ^0.5.1
+    "@substrate/txwrapper-core": ^1.0.0
+    "@substrate/txwrapper-registry": ^1.0.0
+    "@substrate/txwrapper-substrate": ^1.0.0
     ts-node: 9.1.1
     typescript: 4.1.5
   languageName: unknown
@@ -10864,13 +10864,13 @@ fsevents@^2.1.2:
   languageName: node
   linkType: hard
 
-"txwrapper-acala@^0.5.1, txwrapper-acala@workspace:packages/txwrapper-acala":
+"txwrapper-acala@^1.0.0, txwrapper-acala@workspace:packages/txwrapper-acala":
   version: 0.0.0-use.local
   resolution: "txwrapper-acala@workspace:packages/txwrapper-acala"
   dependencies:
     "@acala-network/type-definitions": 0.7.4-1
-    "@substrate/txwrapper-core": ^0.5.1
-    "@substrate/txwrapper-orml": ^0.5.1
+    "@substrate/txwrapper-core": ^1.0.0
+    "@substrate/txwrapper-orml": ^1.0.0
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
changes:

- Update polkadot-js/api
- Remove the error log message suppression in decodeSigningPayloads createTypeUnsafe because it is no longer option (and it no longer logs the error).

rel: polkadot-js/api#3480, paritytech/txwrapper/pull/438