### PR TITLE
fix: add lifecycle script to fix CI error on release

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   ],
   "scripts": {
     "deploy": "yarn run build && lerna version --conventional-commits --create-release github && lerna publish from-package",
+    "version": "yarn install && git stage yarn.lock",
     "build": "lerna run build",
     "build:workspace": "cd $INIT_CWD && rimraf lib/ && substrate-exec-tsc -p tsconfig.build.json",
     "lint": "substrate-dev-run-lint",


### PR DESCRIPTION
This adds a lerna lifecycle script that will fix our failing CI tests for releases. 

TL:DR -  The lerna workflow we currently have is updating the versioning for all the packages but not updating the `yarn.lock`. This script fixes that. 

closes: [#125](https://github.com/paritytech/txwrapper-core/issues/125)