### PR TITLE
fix(types): bump polkadot-js deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,14 +17,14 @@
     "docs": "typedoc"
   },
   "resolutions": {
-    "@polkadot/api": "6.12.1",
-    "@polkadot/keyring": "8.1.2",
-    "@polkadot/networks": "8.1.2",
-    "@polkadot/types": "6.12.1",
-    "@polkadot/types-known": "6.12.1",
-    "@polkadot/util": "8.1.2",
-    "@polkadot/util-crypto": "8.1.2",
-    "@polkadot/wasm-crypto": "4.4.1"
+    "@polkadot/api": "7.0.2",
+    "@polkadot/keyring": "8.2.2",
+    "@polkadot/networks": "8.2.2",
+    "@polkadot/types": "7.0.2",
+    "@polkadot/types-known": "7.0.2",
+    "@polkadot/util": "8.2.2",
+    "@polkadot/util-crypto": "8.2.2",
+    "@polkadot/wasm-crypto": "4.5.1"
   },
   "devDependencies": {
     "@babel/plugin-transform-modules-commonjs": "^7.15.4",

--- a/packages/txwrapper-core/package.json
+++ b/packages/txwrapper-core/package.json
@@ -21,7 +21,7 @@
     "build": "yarn build:workspace"
   },
   "dependencies": {
-    "@polkadot/api": "^6.12.1",
+    "@polkadot/api": "^7.0.2",
     "memoizee": "0.4.15"
   },
   "devDependencies": {

--- a/packages/txwrapper-core/src/core/decode/decodeSignedTx.ts
+++ b/packages/txwrapper-core/src/core/decode/decodeSignedTx.ts
@@ -29,7 +29,7 @@ export function decodeSignedTx(
 
 	return {
 		address: tx.signer.toString(),
-		eraPeriod: tx.era.asMortalEra.period.toNumber(),
+		eraPeriod: parseInt(tx.era.asMortalEra.period.toString()),
 		metadataRpc,
 		method,
 		nonce: tx.nonce.toNumber(),

--- a/packages/txwrapper-core/src/core/decode/decodeSignedTx.ts
+++ b/packages/txwrapper-core/src/core/decode/decodeSignedTx.ts
@@ -29,7 +29,7 @@ export function decodeSignedTx(
 
 	return {
 		address: tx.signer.toString(),
-		eraPeriod: parseInt(tx.era.asMortalEra.period.toString()),
+		eraPeriod: tx.era.asMortalEra.period.toNumber(),
 		metadataRpc,
 		method,
 		nonce: tx.nonce.toNumber(),

--- a/packages/txwrapper-core/src/core/method/toTxMethod.ts
+++ b/packages/txwrapper-core/src/core/method/toTxMethod.ts
@@ -4,9 +4,9 @@
  */ /** */
 import { createTypeUnsafe, TypeRegistry } from '@polkadot/types';
 import { Compact } from '@polkadot/types';
-import { AbstractInt } from '@polkadot/types/codec/AbstractInt';
 import { Call } from '@polkadot/types/interfaces';
 import { Codec } from '@polkadot/types/types';
+import { AbstractInt } from '@polkadot/types-codec/abstract/AbstractInt';
 import { BN, stringCamelCase } from '@polkadot/util';
 
 import { Args, TxMethod } from '../../types/method';

--- a/packages/txwrapper-core/src/index.ts
+++ b/packages/txwrapper-core/src/index.ts
@@ -1,3 +1,5 @@
+import '@polkadot/api-augment';
+
 export * from './core';
 export * from './test-helpers';
 export * from './types';

--- a/packages/txwrapper-examples/package.json
+++ b/packages/txwrapper-examples/package.json
@@ -19,7 +19,7 @@
     "mandala": "node lib/mandala"
   },
   "dependencies": {
-    "@polkadot/api": "^6.12.1",
+    "@polkadot/api": "^7.0.2",
     "@substrate/txwrapper-polkadot": "^1.3.2",
     "@substrate/txwrapper-registry": "^1.3.2"
   }

--- a/packages/txwrapper-registry/package.json
+++ b/packages/txwrapper-registry/package.json
@@ -21,8 +21,8 @@
     "build": "yarn build:workspace"
   },
   "dependencies": {
-    "@polkadot/apps-config": "beta",
-    "@polkadot/networks": "^8.1.2",
+    "@polkadot/apps-config": "0.99.1",
+    "@polkadot/networks": "^8.2.2",
     "@substrate/txwrapper-core": "^1.3.2"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -407,7 +407,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/runtime@npm:^7.15.4, @babel/runtime@npm:^7.16.3, @babel/runtime@npm:^7.9.6":
+"@babel/runtime@npm:^7.12.0, @babel/runtime@npm:^7.16.5":
+  version: 7.16.5
+  resolution: "@babel/runtime@npm:7.16.5"
+  dependencies:
+    regenerator-runtime: ^0.13.4
+  checksum: b96e67280efe581c6147b4fe984dfe08a8fbea048934a092f3cbf4dcf61725f6b221cb0c879b6e6e98671f83a104c9e8cfbd24c683e5ebcc886a731aa8984ad0
+  languageName: node
+  linkType: hard
+
+"@babel/runtime@npm:^7.16.3, @babel/runtime@npm:^7.9.6":
   version: 7.16.3
   resolution: "@babel/runtime@npm:7.16.3"
   dependencies:
@@ -461,12 +470,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@bifrost-finance/type-definitions@npm:1.3.12":
-  version: 1.3.12
-  resolution: "@bifrost-finance/type-definitions@npm:1.3.12"
+"@bifrost-finance/type-definitions@npm:1.3.15":
+  version: 1.3.15
+  resolution: "@bifrost-finance/type-definitions@npm:1.3.15"
   dependencies:
     "@open-web3/orml-type-definitions": ^0.9.4-7
-  checksum: b2566bac328000150dcfb134b823f26c7aa7cfd2659509fdd3d8e1e707866402d2138a512e2cdf3b6aa8f8c9db232d4df198a61b5ca0aaef2f40cfd58c18bd5c
+  checksum: 51e00ed329032bd5f5db4209476542518d492b7b6fc05f4cb63bf29ea55d9fb4a246b71ba62f0142de7b450df115df2b590be34a137b11331ae77f14c1d22b36
   languageName: node
   linkType: hard
 
@@ -479,24 +488,24 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@darwinia/types-known@npm:^2.6.100-1":
-  version: 2.6.100
-  resolution: "@darwinia/types-known@npm:2.6.100"
+"@darwinia/types-known@npm:^2.6.100-2":
+  version: 2.7.2
+  resolution: "@darwinia/types-known@npm:2.7.2"
   dependencies:
     "@babel/runtime": ^7.9.6
     "@polkadot/types": 4.0.4-5
     "@polkadot/util": 6.0.5
     bn.js: ^5.1.2
-  checksum: 83b593827ca60ae82f1965f59cad0e00f296ada2723768073c0c4d630b4c9619e88e7591cee522d879157e02c973979d8773bc758f233e96784e76a0d3052278
+  checksum: a88c4c20836fa1b405dcc5bb8adef77fd936cd4aa5d418337382fbb0d8652cb9671d646ce00926044b9418dadd64f5e72931156c83e4c0a5ff0ece18390ea8e7
   languageName: node
   linkType: hard
 
-"@darwinia/types@npm:2.6.100-1":
-  version: 2.6.100-1
-  resolution: "@darwinia/types@npm:2.6.100-1"
+"@darwinia/types@npm:2.6.100-2":
+  version: 2.6.100-2
+  resolution: "@darwinia/types@npm:2.6.100-2"
   dependencies:
-    "@darwinia/types-known": ^2.6.100-1
-  checksum: cba49fe5974ddf8143bf173c4f62b9aa0af90656aed9d3a647203cdc272146763304a8c93e980cf5d24028a4f80fb474164d25fb043cbbbffe33681dfc88d291
+    "@darwinia/types-known": ^2.6.100-2
+  checksum: acc4b75711600ba6320afa72b2229195989173b51c7243bdc6eaa3e8e648edbab3deeb859287ec69139ee96369472342f56b733ebae3901d1e4706a21a9efce8
   languageName: node
   linkType: hard
 
@@ -524,10 +533,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@equilab/definitions@npm:1.4.4":
-  version: 1.4.4
-  resolution: "@equilab/definitions@npm:1.4.4"
-  checksum: 54c37eb96a3d8aab931b835ddb5087c85ae3313e78e4b85039a658a13c4a7841ac65212a442a43cdcde4cd1221e3132800c2e540ed3194bdecc95d280f1c4dda
+"@equilab/definitions@npm:1.4.6":
+  version: 1.4.6
+  resolution: "@equilab/definitions@npm:1.4.6"
+  checksum: 58428932d57f7049925c053d9baf0f14d58d7fc3cf80aafb8829fc8a1848ae63268608525bc46ee1945c7a8b894db33c6ffabb86aec6949e8e4bd9e20738e5c5
   languageName: node
   linkType: hard
 
@@ -566,10 +575,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@interlay/interbtc-types@npm:1.1.1":
-  version: 1.1.1
-  resolution: "@interlay/interbtc-types@npm:1.1.1"
-  checksum: 48a25655be96c4371ed1227bc9462b10d28e525a6b54b6b22a24c6b60b0c63592a0eed19d0ebe50d9818850e8bf967f0646da1c765b1966458965e8abae3d78b
+"@interlay/interbtc-types@npm:1.3.0":
+  version: 1.3.0
+  resolution: "@interlay/interbtc-types@npm:1.3.0"
+  checksum: 824bf57853c13102d7dd1fbd23b35419f5de360cd3698a792661dd85c0061fb82023eb00923b908d68c8a5e75235129b2f0d08c4cfe6c5d49729e6e60dec8b3d
   languageName: node
   linkType: hard
 
@@ -1608,17 +1617,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@noble/hashes@npm:0.4.1":
-  version: 0.4.1
-  resolution: "@noble/hashes@npm:0.4.1"
-  checksum: 3c706beec3bcd9e43f2b88c0791f022b645b5c0a9dd76889dfc189e51da2f0c692ef846b5889e074338353e335269c14f4c0ea34329b4d7dd45ae82c482b4605
+"@noble/hashes@npm:^0.4.5":
+  version: 0.4.5
+  resolution: "@noble/hashes@npm:0.4.5"
+  checksum: 0de28bda5517989d4893db2f1913ca052d22f549a530965599b36f946753bef1d552d60a4be831723a0d81f9bcca3a5f7c9a1d30d4308d11657f9879ad288d03
   languageName: node
   linkType: hard
 
-"@noble/secp256k1@npm:^1.3.0":
-  version: 1.3.0
-  resolution: "@noble/secp256k1@npm:1.3.0"
-  checksum: 4bf5e2a905e0dacbf3b557da74e4073d208b8407f4e1fc95e244c17c6af686fd1870668d231b9f2e774091d72be79baf1c0e50f5ddc9db6fb82b206e23b9b335
+"@noble/secp256k1@npm:^1.3.4":
+  version: 1.3.4
+  resolution: "@noble/secp256k1@npm:1.3.4"
+  checksum: af1f1e76387f1a081315550a938b6cee58ea9d844472eadde0a3cb42ad317bd5d824748e7ff96bcf23e45a346bd5a2aed536b450c635f664f3a1dce674ce7648
   languageName: node
   linkType: hard
 
@@ -1904,321 +1913,409 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@polkadot/api-derive@npm:6.12.1":
-  version: 6.12.1
-  resolution: "@polkadot/api-derive@npm:6.12.1"
+"@polkadot/api-augment@npm:7.0.2":
+  version: 7.0.2
+  resolution: "@polkadot/api-augment@npm:7.0.2"
   dependencies:
-    "@babel/runtime": ^7.16.3
-    "@polkadot/api": 6.12.1
-    "@polkadot/rpc-core": 6.12.1
-    "@polkadot/types": 6.12.1
-    "@polkadot/util": ^8.1.2
-    "@polkadot/util-crypto": ^8.1.2
-    rxjs: ^7.4.0
-  checksum: 95499263c6f16a7bde2b75123ef78d75e194dcf7aa16b6366bf9048cb4b6ff2194a0c6ab337a8de82067dac58f6884f0f772d4d30a8465a2dad116ea59c19fd7
+    "@babel/runtime": ^7.16.5
+    "@polkadot/api-base": 7.0.2
+    "@polkadot/rpc-augment": 7.0.2
+    "@polkadot/types": 7.0.2
+    "@polkadot/types-augment": 7.0.2
+    "@polkadot/types-codec": 7.0.2
+    "@polkadot/util": ^8.2.2
+  checksum: 7c9c6c8e50c5552e01a358ad11552c81d851d8843771e6b0f192c87608b94c4f4a81b2d54a4aa0d9781cd8d767ef3ffb0c2a76db831752a39c1729170f06ba51
   languageName: node
   linkType: hard
 
-"@polkadot/api@npm:6.12.1":
-  version: 6.12.1
-  resolution: "@polkadot/api@npm:6.12.1"
+"@polkadot/api-base@npm:7.0.2":
+  version: 7.0.2
+  resolution: "@polkadot/api-base@npm:7.0.2"
   dependencies:
-    "@babel/runtime": ^7.16.3
-    "@polkadot/api-derive": 6.12.1
-    "@polkadot/keyring": ^8.1.2
-    "@polkadot/rpc-core": 6.12.1
-    "@polkadot/rpc-provider": 6.12.1
-    "@polkadot/types": 6.12.1
-    "@polkadot/types-known": 6.12.1
-    "@polkadot/util": ^8.1.2
-    "@polkadot/util-crypto": ^8.1.2
+    "@babel/runtime": ^7.16.5
+    "@polkadot/rpc-core": 7.0.2
+    "@polkadot/types": 7.0.2
+    "@polkadot/util": ^8.2.2
+    rxjs: ^7.4.0
+  checksum: 3dc46aff948728ec5e044433581bcc500a3b32be9e30abeb1c77f0828c4b854e2c0d10d1e0a71b5ffc03f817173d3b61cf45dd5d810b3a0c9d9b01b12080927e
+  languageName: node
+  linkType: hard
+
+"@polkadot/api-derive@npm:7.0.2, @polkadot/api-derive@npm:^7.0.2":
+  version: 7.0.2
+  resolution: "@polkadot/api-derive@npm:7.0.2"
+  dependencies:
+    "@babel/runtime": ^7.16.5
+    "@polkadot/api": 7.0.2
+    "@polkadot/api-base": 7.0.2
+    "@polkadot/rpc-core": 7.0.2
+    "@polkadot/types": 7.0.2
+    "@polkadot/types-codec": 7.0.2
+    "@polkadot/util": ^8.2.2
+    "@polkadot/util-crypto": ^8.2.2
+    rxjs: ^7.4.0
+  checksum: 27abb056f839f7cf49f6e410a77a53b184213952174ccbe788166eac11400aef40d762e8e3f20df9deb9606d56336bb5083b29465048e3e0e74c7f9c67a192b9
+  languageName: node
+  linkType: hard
+
+"@polkadot/api@npm:7.0.2":
+  version: 7.0.2
+  resolution: "@polkadot/api@npm:7.0.2"
+  dependencies:
+    "@babel/runtime": ^7.16.5
+    "@polkadot/api-augment": 7.0.2
+    "@polkadot/api-base": 7.0.2
+    "@polkadot/api-derive": 7.0.2
+    "@polkadot/keyring": ^8.2.2
+    "@polkadot/rpc-augment": 7.0.2
+    "@polkadot/rpc-core": 7.0.2
+    "@polkadot/rpc-provider": 7.0.2
+    "@polkadot/types": 7.0.2
+    "@polkadot/types-augment": 7.0.2
+    "@polkadot/types-codec": 7.0.2
+    "@polkadot/types-create": 7.0.2
+    "@polkadot/types-known": 7.0.2
+    "@polkadot/util": ^8.2.2
+    "@polkadot/util-crypto": ^8.2.2
     eventemitter3: ^4.0.7
     rxjs: ^7.4.0
-  checksum: de64607d58338e113e567e38fef9ac684ba1e31c66503928999d067e6aae6531ba7e898f166d245fbc57fb9da27d51090353aa13cb91b7ed0b4864f58d33484f
+  checksum: 9b1b700d9c002acc8c94a6551fe6d9b827fb6e46b137f1a22c9c5114ed6e942b21efcdba5a58a497ebc1d97e0ec3928aade53e7382371f1556a5b722c0493dd8
   languageName: node
   linkType: hard
 
-"@polkadot/apps-config@npm:beta":
-  version: 0.98.2-116
-  resolution: "@polkadot/apps-config@npm:0.98.2-116"
+"@polkadot/apps-config@npm:0.99.1":
+  version: 0.99.1
+  resolution: "@polkadot/apps-config@npm:0.99.1"
   dependencies:
     "@acala-network/type-definitions": ^3.0.2-4
-    "@babel/runtime": ^7.16.3
-    "@bifrost-finance/type-definitions": 1.3.12
+    "@babel/runtime": ^7.16.5
+    "@bifrost-finance/type-definitions": 1.3.15
     "@crustio/type-definitions": 1.2.0
-    "@darwinia/types": 2.6.100-1
+    "@darwinia/types": 2.6.100-2
     "@digitalnative/type-definitions": 1.1.26
     "@docknetwork/node-types": 0.6.0
     "@edgeware/node-types": 3.6.2-wako
-    "@equilab/definitions": 1.4.4
-    "@interlay/interbtc-types": 1.1.1
+    "@equilab/definitions": 1.4.6
+    "@interlay/interbtc-types": 1.3.0
     "@kiltprotocol/type-definitions": 0.1.23
     "@laminar/type-definitions": 0.3.1
     "@metaverse-network-sdk/type-definitions": ^0.0.1-6
     "@parallel-finance/type-definitions": 1.4.4
     "@phala/typedefs": 0.2.29
-    "@polkadot/networks": ^8.0.4
+    "@polkadot/api": ^7.0.2
+    "@polkadot/api-derive": ^7.0.2
+    "@polkadot/networks": ^8.2.2
+    "@polkadot/types": ^7.0.2
+    "@polkadot/util": ^8.2.2
+    "@polkadot/x-fetch": ^8.2.2
     "@polymathnetwork/polymesh-types": 0.0.2
     "@snowfork/snowbridge-types": 0.2.6
-    "@sora-substrate/type-definitions": 1.6.22
-    "@subsocial/types": 0.6.5-dev.6
+    "@sora-substrate/type-definitions": 1.6.30
+    "@subsocial/types": 0.6.5
     "@unique-nft/types": 0.2.0
-    "@zeitgeistpm/type-defs": 0.3.5
-    "@zeroio/type-definitions": 0.0.13
+    "@zeitgeistpm/type-defs": 0.3.7
+    "@zeroio/type-definitions": 0.0.14
+    i18next: ^21.6.0
     lodash: ^4.17.21
-    moonbeam-types-bundle: 2.0.1
+    moonbeam-types-bundle: 2.0.2
     pontem-types-bundle: 1.0.15
     rxjs: ^7.4.0
-  checksum: fc98eecda8719b3dbf2884493e3b5543cfe26665ca07defc7c9021ad2ec47ddd95df6348129a355ed80c2f58ff7ce9f962e44b1caf2a16047f3ba1b2f4204c9a
+  checksum: 48f3b02be59d8674633f0b55e856ca40f322398c85b7cfff9b75b092a4af4755938399c37a0957fc4771d6f5922b9169070ff8de5c2c93f9e8fb260559789cf3
   languageName: node
   linkType: hard
 
-"@polkadot/keyring@npm:8.1.2":
-  version: 8.1.2
-  resolution: "@polkadot/keyring@npm:8.1.2"
+"@polkadot/keyring@npm:8.2.2":
+  version: 8.2.2
+  resolution: "@polkadot/keyring@npm:8.2.2"
   dependencies:
-    "@babel/runtime": ^7.16.3
-    "@polkadot/util": 8.1.2
-    "@polkadot/util-crypto": 8.1.2
+    "@babel/runtime": ^7.16.5
+    "@polkadot/util": 8.2.2
+    "@polkadot/util-crypto": 8.2.2
   peerDependencies:
-    "@polkadot/util": 8.1.2
-    "@polkadot/util-crypto": 8.1.2
-  checksum: 72a2f53190b00f4483f32da97ce678b8f334d0f43022237d360b1f6a934ec647ef664cca8185b14d078b490852fd7e9e7cb90f60598ebbf6937b07e8e4d4ec9e
+    "@polkadot/util": 8.2.2
+    "@polkadot/util-crypto": 8.2.2
+  checksum: 9ed75d2dbe69adac418c3f4f26932eea381c3a90ff7b55b42a0b73ad2525ae628f5673eb95cbf784aeafcbdbd10c650ee301740391a4cb63b8d5616a479489c8
   languageName: node
   linkType: hard
 
-"@polkadot/networks@npm:8.1.2":
-  version: 8.1.2
-  resolution: "@polkadot/networks@npm:8.1.2"
+"@polkadot/networks@npm:8.2.2":
+  version: 8.2.2
+  resolution: "@polkadot/networks@npm:8.2.2"
   dependencies:
-    "@babel/runtime": ^7.16.3
-  checksum: 3b6b4ab7fb3117d51d032200b41bacb8123c1b4a7d1b76e998ad69200bbb9f429cf18f261b761007be709ace348af790614043c7a18715f97ab3bd0434203795
+    "@babel/runtime": ^7.16.5
+  checksum: 0aa898b80d5effa4099bea93ae5de5ed9abbe87f38b1d0d36a6c55470ea3bd0e84c1941a51fd2960f8063aa3e03ef242d26576eeaa5ab8368d9f9f912bb41dd1
   languageName: node
   linkType: hard
 
-"@polkadot/rpc-core@npm:6.12.1":
-  version: 6.12.1
-  resolution: "@polkadot/rpc-core@npm:6.12.1"
+"@polkadot/rpc-augment@npm:7.0.2":
+  version: 7.0.2
+  resolution: "@polkadot/rpc-augment@npm:7.0.2"
   dependencies:
-    "@babel/runtime": ^7.16.3
-    "@polkadot/rpc-provider": 6.12.1
-    "@polkadot/types": 6.12.1
-    "@polkadot/util": ^8.1.2
+    "@babel/runtime": ^7.16.5
+    "@polkadot/rpc-core": 7.0.2
+    "@polkadot/types": 7.0.2
+    "@polkadot/types-codec": 7.0.2
+    "@polkadot/util": ^8.2.2
+  checksum: 929870cc206beba88758712c9137a26dd662a1d90e42cd585285a31f2f870fe464eec2fa2cb3dd7691d75a75ec94b21bf3cd076735367ee6d71cb0cebe6c9e2f
+  languageName: node
+  linkType: hard
+
+"@polkadot/rpc-core@npm:7.0.2":
+  version: 7.0.2
+  resolution: "@polkadot/rpc-core@npm:7.0.2"
+  dependencies:
+    "@babel/runtime": ^7.16.5
+    "@polkadot/rpc-augment": 7.0.2
+    "@polkadot/rpc-provider": 7.0.2
+    "@polkadot/types": 7.0.2
+    "@polkadot/util": ^8.2.2
     rxjs: ^7.4.0
-  checksum: b994c705de098905b5bfd9648feac6bb7dda05f7d4211d40cd958ac5288e0a2f59a5b96fc67fa1dee33c975045decba224a0f0a91fad8fa1ce7b22b011fae9d7
+  checksum: 19991baa286a09c7774fc9dbb758d008dc5371b31a48c94b53478d033cd5353c57e5ddb5a17954470d8e59977030686b8c8489d2c34852717ecea63a8128192f
   languageName: node
   linkType: hard
 
-"@polkadot/rpc-provider@npm:6.12.1":
-  version: 6.12.1
-  resolution: "@polkadot/rpc-provider@npm:6.12.1"
+"@polkadot/rpc-provider@npm:7.0.2":
+  version: 7.0.2
+  resolution: "@polkadot/rpc-provider@npm:7.0.2"
   dependencies:
-    "@babel/runtime": ^7.16.3
-    "@polkadot/types": 6.12.1
-    "@polkadot/util": ^8.1.2
-    "@polkadot/util-crypto": ^8.1.2
-    "@polkadot/x-fetch": ^8.1.2
-    "@polkadot/x-global": ^8.1.2
-    "@polkadot/x-ws": ^8.1.2
+    "@babel/runtime": ^7.16.5
+    "@polkadot/keyring": ^8.2.2
+    "@polkadot/types": 7.0.2
+    "@polkadot/types-support": 7.0.2
+    "@polkadot/util": ^8.2.2
+    "@polkadot/util-crypto": ^8.2.2
+    "@polkadot/x-fetch": ^8.2.2
+    "@polkadot/x-global": ^8.2.2
+    "@polkadot/x-ws": ^8.2.2
     eventemitter3: ^4.0.7
-  checksum: 30648f646c541506d328281122ac29b18ffabeea97682ba762d2db159f198b218fa007f963c84e910de6d67a7ca24851b4eec6327feee597fa1137aebcdf62e1
+    mock-socket: ^9.0.8
+    nock: ^13.2.1
+  checksum: e5e5a2a89be80937beb4dfd9c5fa328335c406b2153f0e3f7f010b8e432012c515ebb18d1b1b1dd43fcbab81cc0533590cb587e46a33d6b789294eaf322432c7
   languageName: node
   linkType: hard
 
-"@polkadot/types-known@npm:6.12.1":
-  version: 6.12.1
-  resolution: "@polkadot/types-known@npm:6.12.1"
+"@polkadot/types-augment@npm:7.0.2":
+  version: 7.0.2
+  resolution: "@polkadot/types-augment@npm:7.0.2"
+  dependencies:
+    "@babel/runtime": ^7.16.5
+    "@polkadot/types": 7.0.2
+    "@polkadot/types-codec": 7.0.2
+    "@polkadot/util": ^8.2.2
+  checksum: 6b92804c5247cf6186ba9a956b4871d6cc8f50030ac0ffe7ab5195f70c8e12c4f43d855c43fb1d309e511eef5c6968240092d9044991771af6a49423d3108668
+  languageName: node
+  linkType: hard
+
+"@polkadot/types-codec@npm:7.0.2":
+  version: 7.0.2
+  resolution: "@polkadot/types-codec@npm:7.0.2"
+  dependencies:
+    "@babel/runtime": ^7.16.5
+    "@polkadot/util": ^8.2.2
+  checksum: eb6da6ef190c4c3e938b9718b592029649ef1fa408251aa10198d3a33d72d67a7f4315624fbad3deef22da7daf0748e50fabb0ffcfda0f7ec52caf85fb293d7e
+  languageName: node
+  linkType: hard
+
+"@polkadot/types-create@npm:7.0.2":
+  version: 7.0.2
+  resolution: "@polkadot/types-create@npm:7.0.2"
+  dependencies:
+    "@babel/runtime": ^7.16.5
+    "@polkadot/types-codec": 7.0.2
+    "@polkadot/util": ^8.2.2
+  checksum: a9b35a1303f0720ab1f3c3c6f64cad357c4430e2c1f4583cceaffbab57b5090417703cd3a5d4381ef36d495efdba20953f64a16b77db377f7be75fd36b91f9a4
+  languageName: node
+  linkType: hard
+
+"@polkadot/types-known@npm:7.0.2":
+  version: 7.0.2
+  resolution: "@polkadot/types-known@npm:7.0.2"
+  dependencies:
+    "@babel/runtime": ^7.16.5
+    "@polkadot/networks": ^8.2.2
+    "@polkadot/types": 7.0.2
+    "@polkadot/types-codec": 7.0.2
+    "@polkadot/types-create": 7.0.2
+    "@polkadot/util": ^8.2.2
+  checksum: 1e028a19fb7e9a0593fa21cf863385f8d46e5d9dfe42d7fa06d34031d8589efeff65943259cdf3b6af5d4725b7997180ad3f39491ecbc8e34afb133c297c39e1
+  languageName: node
+  linkType: hard
+
+"@polkadot/types-support@npm:6.9.2":
+  version: 6.9.2
+  resolution: "@polkadot/types-support@npm:6.9.2"
   dependencies:
     "@babel/runtime": ^7.16.3
-    "@polkadot/networks": ^8.1.2
-    "@polkadot/types": 6.12.1
-    "@polkadot/util": ^8.1.2
-  checksum: a15ad68e9c19fefc70d74e216b5fa3c53410ef69494bf514a8128853354f1dd87bdf338fef303f1474adacff044eef24fb59f2a78f59b85134a7139d4f089eb2
+    "@polkadot/util": ^7.9.2
+  checksum: 379819a3a9e40c22b30ecb95c9e39742696ad1e1e2e68cfa5a456d81e76066520f187d0a8fba02a805217121405504af75286284004befcaf6b5447d50eb77cc
   languageName: node
   linkType: hard
 
-"@polkadot/types-support@npm:6.6.1":
-  version: 6.6.1
-  resolution: "@polkadot/types-support@npm:6.6.1"
+"@polkadot/types-support@npm:7.0.2":
+  version: 7.0.2
+  resolution: "@polkadot/types-support@npm:7.0.2"
   dependencies:
-    "@babel/runtime": ^7.15.4
-    "@polkadot/util": ^7.7.1
-  checksum: 3d4d316430a5407c3b0caaf016903b066cc5dd1d6ef93da8a9763ff73033a8be443e5248a48e1d0242b6067ee8bc61d93352f1f38469a87ad92743400cf8a3c6
+    "@babel/runtime": ^7.16.5
+    "@polkadot/util": ^8.2.2
+  checksum: 47c22271a74c1d0c6054ef33e527f0b114ead8b04007b049ff8e56847e6a658d2998ce0636945f338dd2fafa2b760e2f56ea21e5eaeac1d324dc90757a4114ef
   languageName: node
   linkType: hard
 
-"@polkadot/types@npm:6.12.1":
-  version: 6.12.1
-  resolution: "@polkadot/types@npm:6.12.1"
+"@polkadot/types@npm:7.0.2":
+  version: 7.0.2
+  resolution: "@polkadot/types@npm:7.0.2"
   dependencies:
-    "@babel/runtime": ^7.16.3
-    "@polkadot/types-known": 6.12.1
-    "@polkadot/util": ^8.1.2
-    "@polkadot/util-crypto": ^8.1.2
+    "@babel/runtime": ^7.16.5
+    "@polkadot/keyring": ^8.2.2
+    "@polkadot/types-augment": 7.0.2
+    "@polkadot/types-codec": 7.0.2
+    "@polkadot/types-create": 7.0.2
+    "@polkadot/util": ^8.2.2
+    "@polkadot/util-crypto": ^8.2.2
     rxjs: ^7.4.0
-  checksum: 0c067505e175c31231d083ce06f693d043e4a937075402ff6a67c84a280c8c1526ec8845f3c75fbba193464d9790bb34d65027c5c627521989b892d6e5fcb9b2
+  checksum: ff7d53688723156839160088e489c2072b4edd531dcd66f0f2bf3b9b3aa6b791689cde87a4f96c9f15b112f5b2ac98b6a7022b8abae003f9237c51a3bc5ffd79
   languageName: node
   linkType: hard
 
-"@polkadot/util-crypto@npm:8.1.2":
-  version: 8.1.2
-  resolution: "@polkadot/util-crypto@npm:8.1.2"
+"@polkadot/util-crypto@npm:8.2.2":
+  version: 8.2.2
+  resolution: "@polkadot/util-crypto@npm:8.2.2"
   dependencies:
-    "@babel/runtime": ^7.16.3
-    "@noble/hashes": 0.4.1
-    "@noble/secp256k1": ^1.3.0
-    "@polkadot/networks": 8.1.2
-    "@polkadot/util": 8.1.2
+    "@babel/runtime": ^7.16.5
+    "@noble/hashes": ^0.4.5
+    "@noble/secp256k1": ^1.3.4
+    "@polkadot/networks": 8.2.2
+    "@polkadot/util": 8.2.2
     "@polkadot/wasm-crypto": ^4.5.1
-    "@polkadot/x-bigint": 8.1.2
-    "@polkadot/x-noble-hashes": 8.1.2
-    "@polkadot/x-noble-secp256k1": 8.1.2
-    "@polkadot/x-randomvalues": 8.1.2
+    "@polkadot/x-bigint": 8.2.2
+    "@polkadot/x-randomvalues": 8.2.2
     ed2curve: ^0.3.0
-    micro-base: ^0.9.0
+    micro-base: ^0.10.0
     tweetnacl: ^1.0.3
   peerDependencies:
-    "@polkadot/util": 8.1.2
-  checksum: 9cbbb34e99377e4ea312671d6736aee2399ee3dafcc1b34204fe6b98196e97b650ec26bc0b2d278a4c74a676098e8d1cad7a0385a196968950768f76123f10d4
+    "@polkadot/util": 8.2.2
+  checksum: 04b358937570498428cd78f642cf0d8f25e44315dbfb54cfaf2de10806252f20aa8df2eda1d139d58e2efd5b1fb4d5bdc5d5756b1d25017b98fe03d2beeefbc6
   languageName: node
   linkType: hard
 
-"@polkadot/util@npm:8.1.2":
-  version: 8.1.2
-  resolution: "@polkadot/util@npm:8.1.2"
+"@polkadot/util@npm:8.2.2":
+  version: 8.2.2
+  resolution: "@polkadot/util@npm:8.2.2"
   dependencies:
-    "@babel/runtime": ^7.16.3
-    "@polkadot/x-bigint": 8.1.2
-    "@polkadot/x-global": 8.1.2
-    "@polkadot/x-textdecoder": 8.1.2
-    "@polkadot/x-textencoder": 8.1.2
+    "@babel/runtime": ^7.16.5
+    "@polkadot/x-bigint": 8.2.2
+    "@polkadot/x-global": 8.2.2
+    "@polkadot/x-textdecoder": 8.2.2
+    "@polkadot/x-textencoder": 8.2.2
     "@types/bn.js": ^4.11.6
     bn.js: ^4.12.0
     ip-regex: ^4.3.0
-  checksum: caf0271d1a665fc2dbe2e655effbef12c4dc81326c147e4afc8fc183e7f3f96824111c8e0747d2a9bd9f031a0d32038879016e3f94f1d0414194ebef131fe08d
+  checksum: c8eb0e6278557735e9785a1a81fed14c05c65a790238470763537f27fb601cbf350a8362ecc36469de08d9d61485ab7409da35fcf5acffb0c6cc88fe0ba929bf
   languageName: node
   linkType: hard
 
-"@polkadot/wasm-crypto-asmjs@npm:^4.4.1":
-  version: 4.4.1
-  resolution: "@polkadot/wasm-crypto-asmjs@npm:4.4.1"
+"@polkadot/wasm-crypto-asmjs@npm:^4.5.1":
+  version: 4.5.1
+  resolution: "@polkadot/wasm-crypto-asmjs@npm:4.5.1"
   dependencies:
     "@babel/runtime": ^7.16.3
-  checksum: 3df73641ec52d69e91be56f6010db0960556ee26ea2a43586d0dd1a2b7ec483b6bea1c7b1cf6aa6b16a88f771d3ba55b38e1b685a9d9b9a18b861de6b1e837b7
+  checksum: 93233bc91043c0023466def87a4559b98908841f0628544fcc77f4599acda1d4a0c2673948021de8b5da0c5dd10ef10a01141dfb960d5c32d95b81ac1060cfe5
   languageName: node
   linkType: hard
 
-"@polkadot/wasm-crypto-wasm@npm:^4.4.1":
-  version: 4.4.1
-  resolution: "@polkadot/wasm-crypto-wasm@npm:4.4.1"
+"@polkadot/wasm-crypto-wasm@npm:^4.5.1":
+  version: 4.5.1
+  resolution: "@polkadot/wasm-crypto-wasm@npm:4.5.1"
   dependencies:
     "@babel/runtime": ^7.16.3
-  checksum: 315696bfe78e45ef46e6f484b59eeb29afea68f635bec2916123bdba2a414c6ba557d7c8eb547c4541d663580c41ae925e839ba80a7c7f25e5ceaf53de780e15
+  checksum: b44833a47f87af19b8724d310e64a10c8a3a4499d6af247d48e76dfe0dbbf5c40a21681dbb97297f1ea31a0d66518093ed14509ace16087293cf93e97b28ee73
   languageName: node
   linkType: hard
 
-"@polkadot/wasm-crypto@npm:4.4.1":
-  version: 4.4.1
-  resolution: "@polkadot/wasm-crypto@npm:4.4.1"
+"@polkadot/wasm-crypto@npm:4.5.1":
+  version: 4.5.1
+  resolution: "@polkadot/wasm-crypto@npm:4.5.1"
   dependencies:
     "@babel/runtime": ^7.16.3
-    "@polkadot/wasm-crypto-asmjs": ^4.4.1
-    "@polkadot/wasm-crypto-wasm": ^4.4.1
+    "@polkadot/wasm-crypto-asmjs": ^4.5.1
+    "@polkadot/wasm-crypto-wasm": ^4.5.1
   peerDependencies:
     "@polkadot/util": "*"
     "@polkadot/x-randomvalues": "*"
-  checksum: 853d4e4cf291de73830cb7398f3fdcdbdb277b98f8c66f7f8555fe10e75cdfed2669df2201c361ef7a7a5972d92bc594777e08ac138660512c10c7fbf51dd920
+  checksum: d73b8696c3aa9b9bb18a1914b11ca0133d9189fd9264170912228c497517997d2b8f5f8b19eb5b1a8ef1be9edbdd63d2013633c0262167b61e2afc6333feef91
   languageName: node
   linkType: hard
 
-"@polkadot/x-bigint@npm:8.1.2":
-  version: 8.1.2
-  resolution: "@polkadot/x-bigint@npm:8.1.2"
+"@polkadot/x-bigint@npm:8.2.2":
+  version: 8.2.2
+  resolution: "@polkadot/x-bigint@npm:8.2.2"
   dependencies:
-    "@babel/runtime": ^7.16.3
-    "@polkadot/x-global": 8.1.2
-  checksum: 01724fd4a80f34f889baa99c3d824d521d628a05a89d82f370f3045ef1b44feb7e9ec1e4e7463ba0b3dcd5e52a5ea3aacb2b1a16679f3ba5f77bff03eb1a3034
+    "@babel/runtime": ^7.16.5
+    "@polkadot/x-global": 8.2.2
+  checksum: 1fd0d05848d65e6d171be0974a23c552ac14c898798ab7474d473843d4fad79cf3dc77df42673a69220904f51261c256d559d4b515fbfd8edaf8371df6b5644c
   languageName: node
   linkType: hard
 
-"@polkadot/x-fetch@npm:^8.1.2":
-  version: 8.1.2
-  resolution: "@polkadot/x-fetch@npm:8.1.2"
+"@polkadot/x-fetch@npm:^8.2.2":
+  version: 8.2.2
+  resolution: "@polkadot/x-fetch@npm:8.2.2"
   dependencies:
-    "@babel/runtime": ^7.16.3
-    "@polkadot/x-global": 8.1.2
+    "@babel/runtime": ^7.16.5
+    "@polkadot/x-global": 8.2.2
     "@types/node-fetch": ^2.5.12
     node-fetch: ^2.6.6
-  checksum: 37590d2d7f1b174a44c0ab9509e59d4a5ba037b6b43c5719e216c742e98906d0e6c660b9ea8fdd056693b619d52dd03e82e5f930cb2a97ed6c50ab01c92223aa
+  checksum: 4dbcd0449c51679140e3d37086ea753a1ebe750aeb62e81a7d2c9d78a0aae9101387009bde8f196f203bebdcfb59ba3e997d4c1e403f7c137b79d801d9a9650b
   languageName: node
   linkType: hard
 
-"@polkadot/x-global@npm:8.1.2, @polkadot/x-global@npm:^8.1.2":
-  version: 8.1.2
-  resolution: "@polkadot/x-global@npm:8.1.2"
+"@polkadot/x-global@npm:8.2.2, @polkadot/x-global@npm:^8.2.2":
+  version: 8.2.2
+  resolution: "@polkadot/x-global@npm:8.2.2"
   dependencies:
-    "@babel/runtime": ^7.16.3
-  checksum: d61d4e02e1f27e70ffb6d2d373dd03ee49859e608b7172570bfc75e7eed0620c78baf40cf3c89491fc8bec829e2cefa7fd15192ff8719ad16e6aa6a653ffea6d
+    "@babel/runtime": ^7.16.5
+  checksum: a41760e01e21c6b9c9f2412da2e73e4762c9fbf2275776204abb2bcc486f5537f857836218cffa3603eecb2e36a9e130370aabbb816c088acd50733cc09ee6b5
   languageName: node
   linkType: hard
 
-"@polkadot/x-noble-hashes@npm:8.1.2":
-  version: 8.1.2
-  resolution: "@polkadot/x-noble-hashes@npm:8.1.2"
+"@polkadot/x-randomvalues@npm:8.2.2":
+  version: 8.2.2
+  resolution: "@polkadot/x-randomvalues@npm:8.2.2"
   dependencies:
-    "@babel/runtime": ^7.16.3
-  checksum: 8f5152843ff55fd3d431b477905cb70b4de2fc5255223d055af649f7e4c5f53592c72314e3201d9ff87f8e5f762cd06a5552da8e9ddb3060b807b70e0472d433
+    "@babel/runtime": ^7.16.5
+    "@polkadot/x-global": 8.2.2
+  checksum: 18817fe2374b3e0e2bebd2df98d68720df037cbc29363d2e4701f1e894c52ddaabd41d16022cef532860b0ccbb5e6d51f6245b47f5aafc4d0eeb7285736b0309
   languageName: node
   linkType: hard
 
-"@polkadot/x-noble-secp256k1@npm:8.1.2":
-  version: 8.1.2
-  resolution: "@polkadot/x-noble-secp256k1@npm:8.1.2"
+"@polkadot/x-textdecoder@npm:8.2.2":
+  version: 8.2.2
+  resolution: "@polkadot/x-textdecoder@npm:8.2.2"
   dependencies:
-    "@babel/runtime": ^7.16.3
-  checksum: 4e88f9a740457f4617e1c688a146502f9942d96533ae5d2936a46502de93956d2f185d949a32cbc463670a0e352075aec8328e02eb60dfbd0a7a50d634177646
+    "@babel/runtime": ^7.16.5
+    "@polkadot/x-global": 8.2.2
+  checksum: 3e6ba49e71f927c1dacb352ca7d8cb4cc570a95ce51e1c6b9e4e390d454d795a8887d556a44df29359c14193ef0a1424564099acd2fd1ca2ff3561f1729940e3
   languageName: node
   linkType: hard
 
-"@polkadot/x-randomvalues@npm:8.1.2":
-  version: 8.1.2
-  resolution: "@polkadot/x-randomvalues@npm:8.1.2"
+"@polkadot/x-textencoder@npm:8.2.2":
+  version: 8.2.2
+  resolution: "@polkadot/x-textencoder@npm:8.2.2"
   dependencies:
-    "@babel/runtime": ^7.16.3
-    "@polkadot/x-global": 8.1.2
-  checksum: 08d81f49437710b899f72de04900fb2e273b5d94ec23e39f7c9042ea88ad88be05d72ecad956511119938c66370a4bfbc90f1cb781912a99a4a048cc8d86aecc
+    "@babel/runtime": ^7.16.5
+    "@polkadot/x-global": 8.2.2
+  checksum: 260cfbe56490ffd1966e30e02243b95217085598dddcf2e05bae48ef42621a3bb76ec2d31acde451693889f308b3c8a7a8fd8f7f16a7f16f724dc51d7aeee3c8
   languageName: node
   linkType: hard
 
-"@polkadot/x-textdecoder@npm:8.1.2":
-  version: 8.1.2
-  resolution: "@polkadot/x-textdecoder@npm:8.1.2"
+"@polkadot/x-ws@npm:^8.2.2":
+  version: 8.2.2
+  resolution: "@polkadot/x-ws@npm:8.2.2"
   dependencies:
-    "@babel/runtime": ^7.16.3
-    "@polkadot/x-global": 8.1.2
-  checksum: 8575115503adb9abdb9e7a9cd76837aeeba9ee76a8b58e3bd3adbe556bbf1b72b47efd8f650edad73092b36eda07e750750028bf955c74a0d0425db3b1e18848
-  languageName: node
-  linkType: hard
-
-"@polkadot/x-textencoder@npm:8.1.2":
-  version: 8.1.2
-  resolution: "@polkadot/x-textencoder@npm:8.1.2"
-  dependencies:
-    "@babel/runtime": ^7.16.3
-    "@polkadot/x-global": 8.1.2
-  checksum: 28fc2afddf1c412efbcab03dedd4fc4503355eeb48292bf37567646f2857e14d29edf96dff5341575c4d4306a60d02592cfe1c1caa76c6d1214312439e899228
-  languageName: node
-  linkType: hard
-
-"@polkadot/x-ws@npm:^8.1.2":
-  version: 8.1.2
-  resolution: "@polkadot/x-ws@npm:8.1.2"
-  dependencies:
-    "@babel/runtime": ^7.16.3
-    "@polkadot/x-global": 8.1.2
+    "@babel/runtime": ^7.16.5
+    "@polkadot/x-global": 8.2.2
     "@types/websocket": ^1.0.4
     websocket: ^1.0.34
-  checksum: 07d581634ce7f009c9e8bf50d4d177e1e814f80a6f68daed41bdbbd247a759b47395e7304182ca1cc71f059f91e91d9cb38bc7a7024985c43e37d263f43a7797
+  checksum: 0f9afac4a8c84b7b1282ad761a168bec2e450c5a39b61de1ee6c745e31ea6c1225f8e60d7c5404c4b6c09a51a68be16c51ed9939138442ff7a0dccd89af8f518
   languageName: node
   linkType: hard
 
@@ -2277,35 +2374,34 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@sora-substrate/type-definitions@npm:1.6.22":
-  version: 1.6.22
-  resolution: "@sora-substrate/type-definitions@npm:1.6.22"
+"@sora-substrate/type-definitions@npm:1.6.30":
+  version: 1.6.30
+  resolution: "@sora-substrate/type-definitions@npm:1.6.30"
   dependencies:
     "@open-web3/orml-type-definitions": ^0.9.4-35
-  checksum: ac224941c1ba18e0a8b649f8a59c0c74101d2f8dbee5a5f4f0370a06d9eac858e49c95d419a9288c23c3be39f566882b659aded5e555c868ed458419a7cf5cf6
+  checksum: 8eeabc49cb2fbec1a1641463422de632ed4f2d79f175e4b6b19e567e65d1f8f2cb12161e19686950c0a271193cd9b25a7612766d964d9568a7882fc345f973ae
   languageName: node
   linkType: hard
 
-"@subsocial/types@npm:0.6.5-dev.6":
-  version: 0.6.5-dev.6
-  resolution: "@subsocial/types@npm:0.6.5-dev.6"
+"@subsocial/types@npm:0.6.5":
+  version: 0.6.5
+  resolution: "@subsocial/types@npm:0.6.5"
   dependencies:
-    "@polkadot/types": 6.6.1
-    "@polkadot/types-known": 6.6.1
-    "@polkadot/types-support": 6.6.1
-    "@subsocial/utils": ^0.6.5-dev.6
+    "@polkadot/types": 6.9.2
+    "@polkadot/types-known": 6.9.2
+    "@polkadot/types-support": 6.9.2
+    "@subsocial/utils": ^0.6.5
     cids: ^0.7.1
-  checksum: 008f1a15c95ad87c71da1aa7cdedee99eb99566201a5cfc2a33bd1eec51e1acffea7840d049c1a5868efed7d37548d61fe5ca9bd50dcfa73d894938f93cb4ed5
+  checksum: 4a02a6a19c449bab19b6ecbac89359562e1461c76020d5f4b53a1dc9471f361f0f2f364ab48c3c852a1b8db3cd82cdbc0b6bbf08cbe268038907cbc7ca2697f3
   languageName: node
   linkType: hard
 
-"@subsocial/utils@npm:^0.6.5-dev.6":
-  version: 0.6.5-dev.12
-  resolution: "@subsocial/utils@npm:0.6.5-dev.12"
+"@subsocial/utils@npm:^0.6.5":
+  version: 0.6.5
+  resolution: "@subsocial/utils@npm:0.6.5"
   dependencies:
     "@polkadot/util-crypto": 7.8.2
     "@sindresorhus/slugify": ^1.1.0
-    bignumber.js: ^9.0.1
     bn.js: ^5.1.1
     chalk: ^3.0.0
     lodash.isempty: ^4.4.0
@@ -2317,7 +2413,7 @@ __metadata:
     remark-gfm: ^1.0.0
     remark-html: ^13.0.1
     strip-markdown: ^4.0.0
-  checksum: 9d1612bed9d41fbe3bfc88561bee91df8c96ac2224f20d73e13ebff7f10fec6e55b742f3270ef89973f11097e20b7e249535151abc0d2673583047fbec159f05
+  checksum: e303c6c8d5fa8ece95779800cf469084e5654c771119f049c1041a91e6a575420b885120e4e0bfea691d14919ce3dbb8e53ac612f26910cc9bc876f4ee149161
   languageName: node
   linkType: hard
 
@@ -2353,7 +2449,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@substrate/txwrapper-core@workspace:packages/txwrapper-core"
   dependencies:
-    "@polkadot/api": ^6.12.1
+    "@polkadot/api": ^7.0.2
     "@types/memoizee": ^0.4.3
     memoizee: 0.4.15
   languageName: unknown
@@ -2363,7 +2459,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@substrate/txwrapper-examples@workspace:packages/txwrapper-examples"
   dependencies:
-    "@polkadot/api": ^6.12.1
+    "@polkadot/api": ^7.0.2
     "@substrate/txwrapper-polkadot": ^1.3.2
     "@substrate/txwrapper-registry": ^1.3.2
   languageName: unknown
@@ -2391,8 +2487,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@substrate/txwrapper-registry@workspace:packages/txwrapper-registry"
   dependencies:
-    "@polkadot/apps-config": beta
-    "@polkadot/networks": ^8.1.2
+    "@polkadot/apps-config": 0.99.1
+    "@polkadot/networks": ^8.2.2
     "@substrate/txwrapper-core": ^1.3.2
   languageName: unknown
   linkType: soft
@@ -2749,17 +2845,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@zeitgeistpm/type-defs@npm:0.3.5":
-  version: 0.3.5
-  resolution: "@zeitgeistpm/type-defs@npm:0.3.5"
-  checksum: 08a783beedd91ca466ee36510a2edf813644235414324102f46c6f90b8c1d7ac8221b543af5efd99ee0ff64192d9cb03c474d32b92e1a41bedbd60b6b8700cbf
+"@zeitgeistpm/type-defs@npm:0.3.7":
+  version: 0.3.7
+  resolution: "@zeitgeistpm/type-defs@npm:0.3.7"
+  checksum: 361ea59705c0acbe88f1e9f01afe79a757cde4de30cd4562b6044b23d7c6ee32d6de1f3a840804c81a7cb1956903d3e0fc82e7a34c047db9c519938c04ca1b45
   languageName: node
   linkType: hard
 
-"@zeroio/type-definitions@npm:0.0.13":
-  version: 0.0.13
-  resolution: "@zeroio/type-definitions@npm:0.0.13"
-  checksum: 995b21c7e224d1b912503895f678e67028f0a0ec72efbc0b158fc095e3af90d6496a5d2cd02666f72dfa895b3a49d31aff0cd0f09e49a5768c0bb7dee429d724
+"@zeroio/type-definitions@npm:0.0.14":
+  version: 0.0.14
+  resolution: "@zeroio/type-definitions@npm:0.0.14"
+  checksum: b2729f034fbd865385309ffd9c33ec0f75eb0affdef66e970da8dc98b339c0351700c9ba6dd8d488acbd87fa2321c5061571cc2664da0ab4f0e5fe23ea805a49
   languageName: node
   linkType: hard
 
@@ -3235,13 +3331,6 @@ __metadata:
   version: 2.2.1
   resolution: "before-after-hook@npm:2.2.1"
   checksum: 2562bdcc2e4e53365fb97674410580c40b73db0c0137def18af93332ef4dd16db150c0670d0d986328cb8b0b05f4f58906895ba406ece294817f28540e19aba5
-  languageName: node
-  linkType: hard
-
-"bignumber.js@npm:^9.0.1":
-  version: 9.0.1
-  resolution: "bignumber.js@npm:9.0.1"
-  checksum: 6e72f6069d9db32fc8d27561164de9f811b15f9144be61f323d8b36150a239eea50c92e20ba38af2ba5e717af10b8ef12db8f9948fe2ff02bf17ede5239d15d3
   languageName: node
   linkType: hard
 
@@ -5429,6 +5518,15 @@ fsevents@^2.3.2:
   languageName: node
   linkType: hard
 
+"i18next@npm:^21.6.0":
+  version: 21.6.3
+  resolution: "i18next@npm:21.6.3"
+  dependencies:
+    "@babel/runtime": ^7.12.0
+  checksum: c3de927a3aa64b9c17a5b348b7a9f30fd9c88074a0c92b1eef2a879a71398e32c9cdbf660a689fc6d04ea9d6126cb8efe1f13317172625608b0d09b53b3b35c4
+  languageName: node
+  linkType: hard
+
 "iconv-lite@npm:0.4.24, iconv-lite@npm:^0.4.24":
   version: 0.4.24
   resolution: "iconv-lite@npm:0.4.24"
@@ -6860,6 +6958,13 @@ fsevents@^2.3.2:
   languageName: node
   linkType: hard
 
+"lodash.set@npm:^4.3.2":
+  version: 4.3.2
+  resolution: "lodash.set@npm:4.3.2"
+  checksum: a9122f49eef9f2d0fc9061a33d87f8e5b8c6b23d46e8b9e9ce1529d3588d79741bd1145a3abdfa3b13082703e65af27ff18d8a07bfc22b9be32f3fc36f763f70
+  languageName: node
+  linkType: hard
+
 "lodash.template@npm:^4.5.0":
   version: 4.5.0
   resolution: "lodash.template@npm:4.5.0"
@@ -7244,10 +7349,10 @@ fsevents@^2.3.2:
   languageName: node
   linkType: hard
 
-"micro-base@npm:^0.9.0":
-  version: 0.9.0
-  resolution: "micro-base@npm:0.9.0"
-  checksum: a223a83239782189fbc281c7836f30491ec120ace2a2c634290a9dc3efb82edc591ffd68e375e2c60c2fde64b84f9576a3064a42ece25e98b6ac4ff2610d6ad7
+"micro-base@npm:^0.10.0":
+  version: 0.10.0
+  resolution: "micro-base@npm:0.10.0"
+  checksum: b8892630e8fd9749f9695733a751233ade68f1fde469725d0bb52c0ac36d6ac94f51897a908adde4be4d0e3e65fc0d3ec2cf4c7b3ed6e386c7aab5eb662aa97f
   languageName: node
   linkType: hard
 
@@ -7515,6 +7620,13 @@ fsevents@^2.3.2:
   languageName: node
   linkType: hard
 
+"mock-socket@npm:^9.0.8":
+  version: 9.0.8
+  resolution: "mock-socket@npm:9.0.8"
+  checksum: 4a8e890f6e17d22636936af84015af151f791cccd430842d4d8329a95d90d9b3db7b7da9ae9fcf0f2b0254f94bb9269d0b4c35184b09e3e9bcaeeb69ddeb1358
+  languageName: node
+  linkType: hard
+
 "modify-values@npm:^1.0.0":
   version: 1.0.1
   resolution: "modify-values@npm:1.0.1"
@@ -7522,15 +7634,15 @@ fsevents@^2.3.2:
   languageName: node
   linkType: hard
 
-"moonbeam-types-bundle@npm:2.0.1":
-  version: 2.0.1
-  resolution: "moonbeam-types-bundle@npm:2.0.1"
+"moonbeam-types-bundle@npm:2.0.2":
+  version: 2.0.2
+  resolution: "moonbeam-types-bundle@npm:2.0.2"
   dependencies:
-    "@polkadot/api": ^6.8.1
+    "@polkadot/api": ^6.11.1
     "@polkadot/keyring": ^7.8.2
-    "@polkadot/types": ^5.9.1
-    typescript: ^4.3.5
-  checksum: d203be23d26c3dce8bd4d063d00bf4bb32511d665a339e2635ad3cf052c04a119e40c53d3e94c425591539704fdc601e7bba16386517050d6e168d62178fa813
+    "@polkadot/types": ^6.11.1
+    typescript: ^4.5.2
+  checksum: 105b61e76bab276fe6e5e0a5e0f8e42c285eeefdfd6f6af54db279c16748b57a8c19772354f2e9d7cf1ba228bd4d8a1670ca6994edeedd7316e6f7eed85d21b2
   languageName: node
   linkType: hard
 
@@ -7641,6 +7753,18 @@ fsevents@^2.3.2:
   version: 1.0.0
   resolution: "next-tick@npm:1.0.0"
   checksum: 83fcb3d4f8d9380210b1c2b8a610463602d80283f0c0c8571c1688e1ad6cbf3a16b345f5bb7212617d4898bedcfa10dff327dc09ec20a112a5bf43a0271375fb
+  languageName: node
+  linkType: hard
+
+"nock@npm:^13.2.1":
+  version: 13.2.1
+  resolution: "nock@npm:13.2.1"
+  dependencies:
+    debug: ^4.1.0
+    json-stringify-safe: ^5.0.1
+    lodash.set: ^4.3.2
+    propagate: ^2.0.0
+  checksum: b401fb8143ca88095ee34c715e2806eda2813dace4f4c4798961ad961c18003d1529f4507a79c429d2c3c768e136632ee19ee9ebfef71f0cb022df152594df1d
   languageName: node
   linkType: hard
 
@@ -8566,6 +8690,13 @@ fsevents@^2.3.2:
   dependencies:
     read: 1
   checksum: 443a3b39ac916099988ee0161ab4e22edd1fa27e3d39a38d60e48c11ca6df3f5a90bfe44d95af06ed8659c4050b789ffe64c3f9f8e49a4bea1ea19105c98445a
+  languageName: node
+  linkType: hard
+
+"propagate@npm:^2.0.0":
+  version: 2.0.1
+  resolution: "propagate@npm:2.0.1"
+  checksum: c4febaee2be0979e82fb6b3727878fd122a98d64a7fa3c9d09b0576751b88514a9e9275b1b92e76b364d488f508e223bd7e1dcdc616be4cdda876072fbc2a96c
   languageName: node
   linkType: hard
 
@@ -10231,13 +10362,23 @@ typescript@4.1.5:
   languageName: node
   linkType: hard
 
-"typescript@^4.3.5, typescript@^4.4.3":
+typescript@^4.4.3:
   version: 4.4.3
   resolution: "typescript@npm:4.4.3"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
   checksum: 05823f21796d450531a7e4ab299715d38fd9ded0e4ce7400876053f4b5166ca3dde7a68cecfe72d9086039f03c0b6edba36516fb10ed83c5837d9600532ea4c2
+  languageName: node
+  linkType: hard
+
+"typescript@npm:^4.5.2":
+  version: 4.5.4
+  resolution: "typescript@npm:4.5.4"
+  bin:
+    tsc: bin/tsc
+    tsserver: bin/tsserver
+  checksum: 59f3243f9cd6fe3161e6150ff6bf795fc843b4234a655dbd938a310515e0d61afd1ac942799e7415e4334255e41c2c49b7dd5d9fd38a17acd25a6779ca7e0961
   languageName: node
   linkType: hard
 
@@ -10251,13 +10392,23 @@ typescript@4.1.5:
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@^4.3.5#~builtin<compat/typescript>, typescript@patch:typescript@^4.4.3#~builtin<compat/typescript>":
+"typescript@patch:typescript@^4.4.3#~builtin<compat/typescript>":
   version: 4.4.3
   resolution: "typescript@patch:typescript@npm%3A4.4.3#~builtin<compat/typescript>::version=4.4.3&hash=ddd1e8"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
   checksum: 79f5c13d21c9dea3eb44d2b7002ff25a0569fefc432e083d65a360e3aca990aca25fc733e14aa6883b5e9a68e3e2f0330a34123e048806f91d701732ece00e6f
+  languageName: node
+  linkType: hard
+
+"typescript@patch:typescript@^4.5.2#~builtin<compat/typescript>":
+  version: 4.5.4
+  resolution: "typescript@patch:typescript@npm%3A4.5.4#~builtin<compat/typescript>::version=4.5.4&hash=ddd1e8"
+  bin:
+    tsc: bin/tsc
+    tsserver: bin/tsserver
+  checksum: 270255355c3236076dbbd0900ff0b7b159fac7e6a95f9ed8c59f57361c7dace9f1fbffd3b5eb21377c7f636027382ad89eb64b2acfbcd9e08574f04cfc75ca3d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
~~Currently, this breaks all our of registry.createType instances. Working on a fix.~~ <- This was a local issue. 

Updates the following polkadot-js deps. 

    "@polkadot/api" -> 7.0.2
    "@polkadot/networks" -> 8.2.2
    "@polkadot/apps" -> 0.99.1
    

- Add `import '@polkadot/api-augment';` as required by polkadot-js v7.0.1

- Update types import path for `AbstractInt` to use `types-codec`
