### PR TITLE
feat: add proxy::killAnonymous method

### DIFF
--- a/packages/txwrapper-substrate/src/methods/proxy/index.ts
+++ b/packages/txwrapper-substrate/src/methods/proxy/index.ts
@@ -1,6 +1,7 @@
 export * from './addProxy';
 export * from './announce';
 export * from './anonymous';
+export * from './killAnonymous';
 export * from './proxy';
 export * from './proxyAnnounced';
 export * from './rejectAnnouncement';

--- a/packages/txwrapper-substrate/src/methods/proxy/killAnonymous.spec.ts
+++ b/packages/txwrapper-substrate/src/methods/proxy/killAnonymous.spec.ts
@@ -1,0 +1,24 @@
+import {
+	itHasCorrectBaseTxInfo,
+	POLKADOT_25_TEST_OPTIONS,
+	TEST_BASE_TX_INFO,
+} from '@substrate/txwrapper-core';
+
+import { TEST_METHOD_ARGS } from '../../test-helpers';
+import { killAnonymous } from './killAnonymous';
+
+describe('proxy::killAnonymous', () => {
+	it('should work', () => {
+		const unsigned = killAnonymous(
+			TEST_METHOD_ARGS.proxy.killAnonymous,
+			TEST_BASE_TX_INFO,
+			POLKADOT_25_TEST_OPTIONS
+		);
+
+		itHasCorrectBaseTxInfo(unsigned);
+
+		expect(unsigned.method).toBe(
+			'0x1d058eaf04151687736326c9fea17e25fc5287613693c912909cb226aa4794f26a4800000002093d0000'
+		);
+	});
+});

--- a/packages/txwrapper-substrate/src/methods/proxy/killAnonymous.ts
+++ b/packages/txwrapper-substrate/src/methods/proxy/killAnonymous.ts
@@ -1,0 +1,65 @@
+import {
+	Args,
+	BaseTxInfo,
+	defineMethod,
+	OptionsWithMeta,
+	UnsignedTransaction,
+} from '@substrate/txwrapper-core';
+
+interface ProxyKillAnonymousArgs extends Args {
+	/**
+	 * The account that originally called `anonymous` to create this account.
+	 */
+	spawner: string;
+	/**
+	 * The proxy type originally passed to `anonymous`.
+	 */
+	proxyType: string;
+	/**
+	 * The disambiguation index originally passed to `anonymous`. Probably `0`
+	 */
+	index: number;
+	/**
+	 * The height of the chain when the call to `anonymous` was processed.
+	 */
+	height: number;
+	/**
+	 * The extrinsic index in which the call to `anonymous` was processed.
+	 */
+	extIndex: number;
+}
+
+/**
+ * Removes a previously spawned anonymous proxy.
+ *
+ * WARNING: **All access to this account will be lost.** Any funds held in it will be
+ * inaccessible.
+ *
+ * Requires a `Signed` origin, and the sender account must have been created by a call to
+ * `anonymous` with corresponding parameters.
+ *
+ * Fails with `NoPermission` in case the caller is not a previously created anonymous
+ * account whose `anonymous` call has corresponding parameters.
+ *
+ * @param args Arguments specific to this method.
+ * @param info Information required to construct the transaction.
+ * @param options Registry and metadata used for constructing the method.
+ * @returns
+ */
+export function killAnonymous(
+	args: ProxyKillAnonymousArgs,
+	info: BaseTxInfo,
+	options: OptionsWithMeta
+): UnsignedTransaction {
+	return defineMethod(
+		{
+			method: {
+				args,
+				name: 'killAnonymous',
+				pallet: 'proxy',
+			},
+			...info,
+		},
+		options
+	);
+}

--- a/packages/txwrapper-substrate/src/test-helpers/TEST_METHOD_ARGS.ts
+++ b/packages/txwrapper-substrate/src/test-helpers/TEST_METHOD_ARGS.ts
@@ -78,6 +78,13 @@ export const TEST_METHOD_ARGS = {
 			delay: 30,
 			index: 1,
 		},
+		killAnonymous: {
+			spawner: '14E5nqKAp3oAJcmzgZhUD2RcptBeUBScxKHgJKU4HPNcKVf3',
+			proxyType: 'Any',
+			index: 0,
+			height: 1000000,
+			extIndex: 0,
+		},
 	},
 	session: {
 		setKeys: {


### PR DESCRIPTION
closes: [#163](https://github.com/paritytech/txwrapper-core/issues/163)

ref: 
[paritytech/substrate proxy::kill_anonymous](https://github.com/paritytech/substrate/blob/master/frame/proxy/src/lib.rs#L361)
[polkadot-js/api proxy::killAnonymous](https://github.com/polkadot-js/api/blob/53eecf622029f5ba19938f340e06e7226c9ae941/packages/api-augment/src/polkadot/tx.ts#L2185)