### PR TITLE
fix: decrease npm build, bundle size

### DIFF
--- a/packages/txwrapper-core/.npmignore
+++ b/packages/txwrapper-core/.npmignore
@@ -1,0 +1,11 @@
+# Ignore the main src folder
+/src
+
+# Ignore test-helper folders 
+/lib/test-helpers
+
+# Ignore all test files
+/**/*.spec.*
+
+# Ignore tsconfig build
+/tsconfig.build.json

--- a/packages/txwrapper-core/package.json
+++ b/packages/txwrapper-core/package.json
@@ -3,9 +3,6 @@
   "version": "1.4.0",
   "author": "Parity Technologies <admin@parity.io>",
   "description": "Core components for creating a txwrapper lib.",
-  "files": [
-    "lib"
-  ],
   "license": "Apache-2.0",
   "main": "lib/index.js",
   "publishConfig": {

--- a/packages/txwrapper-polkadot/.npmignore
+++ b/packages/txwrapper-polkadot/.npmignore
@@ -1,0 +1,11 @@
+# Ignore main src folder
+/src
+
+# Ignore test-helpers
+/lib/test-helpers
+
+# Ignore all tests
+/**/*.spec.*
+
+# Ignore tsconfig build
+/tsconfig.build.json

--- a/packages/txwrapper-polkadot/package.json
+++ b/packages/txwrapper-polkadot/package.json
@@ -3,9 +3,6 @@
   "version": "1.4.0",
   "author": "Parity Technologies <admin@parity.io>",
   "description": "Helper functions for Polkadot, Kusama, Rococo and Westend offline transaction generation.",
-  "files": [
-    "lib"
-  ],
   "license": "Apache-2.0",
   "main": "lib/index.js",
   "publishConfig": {

--- a/packages/txwrapper-registry/.npmignore
+++ b/packages/txwrapper-registry/.npmignore
@@ -1,0 +1,5 @@
+# Ignore main src folder
+/src
+
+# Ignore the tsconfig build
+tsconfig.build.json

--- a/packages/txwrapper-registry/.npmignore
+++ b/packages/txwrapper-registry/.npmignore
@@ -1,5 +1,11 @@
-# Ignore main src folder
+# Ignore the main src folder
 /src
 
-# Ignore the tsconfig build
-tsconfig.build.json
+# Ignore test-helper folders 
+/lib/test-helpers
+
+# Ignore all test files
+/**/*.spec.*
+
+# Ignore tsconfig build
+/tsconfig.build.json

--- a/packages/txwrapper-registry/package.json
+++ b/packages/txwrapper-registry/package.json
@@ -3,9 +3,6 @@
   "version": "1.4.0",
   "author": "Parity Technologies <admin@parity.io>",
   "description": "Polkadot-js type registry creation assistants for txwrapper libraries.",
-  "files": [
-    "lib"
-  ],
   "license": "Apache-2.0",
   "main": "lib/index.js",
   "publishConfig": {

--- a/packages/txwrapper-substrate/.npmignore
+++ b/packages/txwrapper-substrate/.npmignore
@@ -1,0 +1,11 @@
+# Ignore the main src folder
+/src
+
+# Ignore test-helper folders 
+/lib/test-helpers
+
+# Ignore all test files
+/**/*.spec.*
+
+# Ignore tsconfig build
+/tsconfig.build.json

--- a/packages/txwrapper-substrate/package.json
+++ b/packages/txwrapper-substrate/package.json
@@ -3,9 +3,6 @@
   "version": "1.4.0",
   "author": "Parity Technologies <admin@parity.io>",
   "description": "Selected dispatchables of Substrate pallets, to be re-exported by txwrappers.",
-  "files": [
-    "lib"
-  ],
   "license": "Apache-2.0",
   "main": "lib/index.js",
   "publishConfig": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,12 +3,6 @@
   "compilerOptions": {
     "baseUrl": "./packages",
     "paths": {
-      "txwrapper-acala": [
-        "txwrapper-acala/src"
-      ],
-      "txwrapper-acala/*": [
-        "txwrapper-acala/src/*"
-      ],
       "@substrate/txwrapper-core": [
         "txwrapper-core/src"
       ],


### PR DESCRIPTION
This redirects the build source to reference `.npmignore` instead of the `package.json` -> `files`. I haven't done the exact size comparison, but were looking at a decrease in size by probably 60-70%.

All the tests will now be removed, as well as test-helpers. 