### PR TITLE
feat: support for signedExtentions, and userExtensions

### DIFF
--- a/packages/txwrapper-core/src/core/construct/createSignedTx.ts
+++ b/packages/txwrapper-core/src/core/construct/createSignedTx.ts
@@ -16,8 +16,16 @@ export function createSignedTx(
 	signature: `0x${string}`,
 	options: OptionsWithMeta
 ): string {
-	const { metadataRpc, registry, asCallsOnlyArg } = options;
-	registry.setMetadata(createMetadata(registry, metadataRpc, asCallsOnlyArg));
+	const {
+		metadataRpc,
+		registry,
+		asCallsOnlyArg,
+		signedExtensions,
+		userExtensions,
+	} = options;
+	const metadata = createMetadata(registry, metadataRpc, asCallsOnlyArg);
+
+	registry.setMetadata(metadata, signedExtensions, userExtensions);
 
 	const extrinsic = registry.createType(
 		'Extrinsic',

--- a/packages/txwrapper-core/src/core/metadata/getRegistryBase.ts
+++ b/packages/txwrapper-core/src/core/metadata/getRegistryBase.ts
@@ -1,4 +1,5 @@
 import { TypeRegistry } from '@polkadot/types';
+import { ExtDef } from '@polkadot/types/extrinsic/signedExtensions/types';
 import { AnyJson, RegistryTypes } from '@polkadot/types/types';
 
 import { ChainProperties } from '../../types';
@@ -21,6 +22,14 @@ export interface GetRegistryBaseArgs {
 	 * Used to reduce the metadata size by only having the calls
 	 */
 	asCallsOnlyArg?: boolean;
+	/**
+	 * Array of signedExtensions
+	 */
+	signedExtensions?: string[];
+	/**
+	 * User extensions used to inject into the type registry
+	 */
+	userExtensions?: ExtDef;
 }
 
 /**
@@ -31,14 +40,20 @@ export function getRegistryBase({
 	specTypes,
 	metadataRpc,
 	asCallsOnlyArg,
+	signedExtensions,
+	userExtensions,
 }: GetRegistryBaseArgs): TypeRegistry {
 	const registry = new TypeRegistry();
 
-	const metadata = createMetadata(registry, metadataRpc, asCallsOnlyArg);
+	const generatedMetadata = createMetadata(
+		registry,
+		metadataRpc,
+		asCallsOnlyArg
+	);
 
 	registry.register(specTypes);
 
-	registry.setMetadata(metadata);
+	registry.setMetadata(generatedMetadata, signedExtensions, userExtensions);
 
 	// Register the chain properties for this registry
 	registry.setChainProperties(

--- a/packages/txwrapper-core/src/core/method/defineMethod.ts
+++ b/packages/txwrapper-core/src/core/method/defineMethod.ts
@@ -32,14 +32,20 @@ export function defineMethod(
 	info: TxInfo,
 	options: OptionsWithMeta
 ): UnsignedTransaction {
-	const { metadataRpc, registry, asCallsOnlyArg } = options;
+	const {
+		metadataRpc,
+		registry,
+		asCallsOnlyArg,
+		signedExtensions,
+		userExtensions,
+	} = options;
 	const generatedMetadata = createMetadata(
 		registry,
 		metadataRpc,
 		asCallsOnlyArg
 	);
 
-	registry.setMetadata(generatedMetadata);
+	registry.setMetadata(generatedMetadata, signedExtensions, userExtensions);
 
 	const tx = createDecoratedTx(registry, metadataRpc);
 

--- a/packages/txwrapper-core/src/types/method.ts
+++ b/packages/txwrapper-core/src/types/method.ts
@@ -1,4 +1,5 @@
 import { TypeRegistry } from '@polkadot/types';
+import { ExtDef } from '@polkadot/types/extrinsic/signedExtensions/types';
 import { AnyJson } from '@polkadot/types/types';
 import { SignerPayloadJSON } from '@polkadot/types/types';
 
@@ -18,6 +19,14 @@ export interface OptionsWithMeta extends Options {
 	 * Used to reduce the metadata size by only having the calls
 	 */
 	asCallsOnlyArg?: boolean;
+	/**
+	 * Array of signedExtensions
+	 */
+	signedExtensions?: string[];
+	/**
+	 * User extensions used to inject into the type registry
+	 */
+	userExtensions?: ExtDef;
 }
 
 /**

--- a/packages/txwrapper-core/src/types/registry.ts
+++ b/packages/txwrapper-core/src/types/registry.ts
@@ -1,3 +1,5 @@
+import { ExtDef } from '@polkadot/types/extrinsic/signedExtensions/types';
+
 import { ChainProperties } from './codec';
 
 /**
@@ -28,4 +30,12 @@ export interface GetRegistryOptsCore {
 	 * Used to reduce the metadata size by only having the calls
 	 */
 	asCallsOnlyArg?: boolean;
+	/**
+	 * Array of signedExtensions
+	 */
+	signedExtensions?: string[];
+	/**
+	 * User extensions used to inject into the type registry
+	 */
+	userExtensions?: ExtDef;
 }

--- a/packages/txwrapper-polkadot/src/index.ts
+++ b/packages/txwrapper-polkadot/src/index.ts
@@ -84,6 +84,9 @@ export function getRegistry({
 	specVersion,
 	metadataRpc,
 	properties,
+	asCallsOnlyArg,
+	signedExtensions,
+	userExtensions,
 }: GetRegistryOpts): TypeRegistry {
 	// The default type registry has polkadot types
 	const registry = new TypeRegistry();
@@ -101,5 +104,8 @@ export function getRegistry({
 			specVersion
 		),
 		metadataRpc,
+		asCallsOnlyArg,
+		signedExtensions,
+		userExtensions,
 	});
 }


### PR DESCRIPTION
This PR gives support for signed, and user extensions. 

### txwrapper-core

`createSignedTx` -> its `options` param now takes in an optional `signedExtensions`, and `userExtensions` field
`getRegistryBase` -> its only param now takes in an optional `signedExtensions`, and `userExtensions` field
`defineMethod` -> its `options` param now takes in an optional `signedExtensions`, and `userExtensions` field

### txwrapper-polkadot
`getRegistry` -> its only param now takes in an optional `signedExtensions`, and `userExtensions` field, as well as `asCallsOnlyArg`

closes: [#106](https://github.com/paritytech/txwrapper-core/issues/106) [#168](https://github.com/paritytech/txwrapper-core/issues/168)
