### PR TITLE
fix(tests):  warning generated by orml package tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,14 +105,6 @@ yarn run lint --fix
     yarn run lint
     ```
 
-    Note: some tests in `txwrapper-orml/src/methods/currencies/transferNativeCurrency.spec.ts` and `txwrapper-orml/src/methods/currencies/transfer.spec.ts` emit warnings that look like:
-
-    ```
-    REGISTRY: Unknown signed extensions SetEvmOrigin found, treating them as no-effect
-    ```
-
-    These are expected, and can be ignored.
-
 6. If all tests pass and all packages build successfully, commit your changes with the following format `fix(types): Update polkadot-js deps to get the latest types`. Then push your branch up to Github for review, then merge. The release tooling takes care of bumping the version so no need for a manual update (see below).
 
 #### Publishing

--- a/packages/txwrapper-orml/src/test-helpers/constants.ts
+++ b/packages/txwrapper-orml/src/test-helpers/constants.ts
@@ -8,6 +8,7 @@ import { mandala722MetadataRpc as metadataRpc } from './mandala722MetadataRpc';
 export const MANDALA_722_TEST_OPTIONS = {
 	metadataRpc,
 	registry: getRegistryMandala(602, metadataRpc),
+	userExtensions: { SetEvmOrigin: { payload: {}, extrinsic: {} } },
 };
 
 /**

--- a/packages/txwrapper-orml/src/test-helpers/getRegistryMandala.ts
+++ b/packages/txwrapper-orml/src/test-helpers/getRegistryMandala.ts
@@ -28,5 +28,6 @@ export function getRegistryMandala(
 		},
 		specTypes: getSpecTypes(registry, 'Mandala', 'mandala', specVersion),
 		metadataRpc,
+		userExtensions: { SetEvmOrigin: { payload: {}, extrinsic: {} } },
 	});
 }


### PR DESCRIPTION
Now that https://github.com/paritytech/txwrapper-core/pull/170 is in, we can add the options to remove the warnings in our tests for the `txwrapper-orml` package. 