### PR TITLE
fix: txwrapper-orml bundle

### DIFF
--- a/packages/txwrapper-orml/.npmignore
+++ b/packages/txwrapper-orml/.npmignore
@@ -1,0 +1,11 @@
+# Ignore the main src folder
+/src
+
+# Ignore test-helper folders 
+/lib/test-helpers
+
+# Ignore all test files
+/**/*.spec.*
+
+# Ignore tsconfig build
+/tsconfig.build.json

--- a/packages/txwrapper-orml/package.json
+++ b/packages/txwrapper-orml/package.json
@@ -3,9 +3,6 @@
   "version": "1.4.0",
   "author": "Parity Technologies <admin@parity.io>",
   "description": "Selected dispatchables of ORML pallets, to be re-exported by txwrappers.",
-  "files": [
-    "lib"
-  ],
   "license": "Apache-2.0",
   "main": "lib/index.js",
   "publishConfig": {


### PR DESCRIPTION
Follow up to this https://github.com/paritytech/txwrapper-core/pull/169. 

Sets `.npmignore` the source of truth for bundling our txwrapper-orml package. 