### PR TITLE
fix: update shelljs according to security advisory

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -9302,15 +9302,15 @@ fsevents@^2.3.2:
   linkType: hard
 
 "shelljs@npm:^0.8.3":
-  version: 0.8.4
-  resolution: "shelljs@npm:0.8.4"
+  version: 0.8.5
+  resolution: "shelljs@npm:0.8.5"
   dependencies:
     glob: ^7.0.0
     interpret: ^1.0.0
     rechoir: ^0.6.2
   bin:
     shjs: bin/shjs
-  checksum: 27f83206ef6a4f5b74a493726c3e6b4c3e07a9c2aac94c5e692d800a61353c18a8234967bd8523b1346abe718beb563843687fb57f466529ba06db3cae6f0bb3
+  checksum: 7babc46f732a98f4c054ec1f048b55b9149b98aa2da32f6cf9844c434b43c6251efebd6eec120937bd0999e13811ebd45efe17410edb3ca938f82f9381302748
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This updates shelljs from 0.8.4 -> 0.8.5. 

shelljs is inherited via lerna.