### PR TITLE
fix(bug): remove enum from test-helpers, and into util

### DIFF
--- a/packages/txwrapper-core/src/core/util/deriveAddress.spec.ts
+++ b/packages/txwrapper-core/src/core/util/deriveAddress.spec.ts
@@ -1,4 +1,4 @@
-import { PolkadotSS58Format } from '../../test-helpers';
+import { PolkadotSS58Format } from '../util';
 import { deriveAddress } from './deriveAddress';
 
 describe('deriveAddress', () => {

--- a/packages/txwrapper-core/src/core/util/importPrivateKey.spec.ts
+++ b/packages/txwrapper-core/src/core/util/importPrivateKey.spec.ts
@@ -1,4 +1,4 @@
-import { PolkadotSS58Format } from '../../test-helpers';
+import { PolkadotSS58Format } from '../util';
 import { importPrivateKey } from './importPrivateKey';
 
 const PRIVATE_KEY =

--- a/packages/txwrapper-core/src/core/util/index.ts
+++ b/packages/txwrapper-core/src/core/util/index.ts
@@ -1,2 +1,3 @@
 export * from './deriveAddress';
 export * from './importPrivateKey';
+export * from './polkadotSS58Format';

--- a/packages/txwrapper-core/src/core/util/polkadotSS58Format.ts
+++ b/packages/txwrapper-core/src/core/util/polkadotSS58Format.ts
@@ -1,0 +1,10 @@
+/**
+ * Prefix for ss58-encoded addresses on Polkadot, Kusama, and Westend. Note:
+ * 42, the Westend prefix, is also the default for Substrate-based chains.
+ */
+export enum PolkadotSS58Format {
+    polkadot = 0,
+    kusama = 2,
+    westend = 42,
+    substrate = 42,
+}

--- a/packages/txwrapper-core/src/core/util/polkadotSS58Format.ts
+++ b/packages/txwrapper-core/src/core/util/polkadotSS58Format.ts
@@ -3,8 +3,8 @@
  * 42, the Westend prefix, is also the default for Substrate-based chains.
  */
 export enum PolkadotSS58Format {
-    polkadot = 0,
-    kusama = 2,
-    westend = 42,
-    substrate = 42,
+	polkadot = 0,
+	kusama = 2,
+	westend = 42,
+	substrate = 42,
 }

--- a/packages/txwrapper-core/src/test-helpers/constants.ts
+++ b/packages/txwrapper-core/src/test-helpers/constants.ts
@@ -84,14 +84,3 @@ export const TEST_METHOD_ARGS = {
 		},
 	},
 };
-
-/**
- * Prefix for ss58-encoded addresses on Polkadot, Kusama, and Westend. Note:
- * 42, the Westend prefix, is also the default for Substrate-based chains.
- */
-export enum PolkadotSS58Format {
-	polkadot = 0,
-	kusama = 2,
-	westend = 42,
-	substrate = 42,
-}


### PR DESCRIPTION
This will fix the release, as I removed test-helper directories from the bundled release package, there was one enum that slipped through that is used in the txwrapper-polkadot package, and some of our tests in core.. I changed it to be in the `util` directory so that txwrapper-polkadot can have access to it. 

This is causing the release to fail, and 1.5.1 will need to be published right after. 