### PR TITLE
fix: update polkadot-js deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,18 +17,18 @@
     "docs": "typedoc"
   },
   "resolutions": {
-    "@polkadot/api": "7.2.1",
-    "@polkadot/keyring": "8.2.2",
-    "@polkadot/networks": "8.2.2",
-    "@polkadot/types": "7.2.1",
-    "@polkadot/types-known": "7.2.1",
-    "@polkadot/util": "8.2.2",
-    "@polkadot/util-crypto": "8.2.2",
+    "@polkadot/api": "7.7.1",
+    "@polkadot/keyring": "8.3.3",
+    "@polkadot/networks": "8.3.3",
+    "@polkadot/types": "7.7.1",
+    "@polkadot/types-known": "7.7.1",
+    "@polkadot/util": "8.3.3",
+    "@polkadot/util-crypto": "8.3.3",
     "@polkadot/wasm-crypto": "4.5.1"
   },
   "devDependencies": {
     "@babel/plugin-transform-modules-commonjs": "^7.15.4",
-    "@polkadot/util-crypto": "^8.2.2",
+    "@polkadot/util-crypto": "^8.3.3",
     "@substrate/dev": "^0.5.6",
     "@types/jest": "^27.0.1",
     "@typescript-eslint/eslint-plugin": "^4.31.1",

--- a/packages/txwrapper-core/package.json
+++ b/packages/txwrapper-core/package.json
@@ -18,7 +18,7 @@
     "build": "yarn build:workspace"
   },
   "dependencies": {
-    "@polkadot/api": "^7.2.1",
+    "@polkadot/api": "^7.7.1",
     "memoizee": "0.4.15"
   },
   "devDependencies": {

--- a/packages/txwrapper-core/src/core/method/toTxMethod.ts
+++ b/packages/txwrapper-core/src/core/method/toTxMethod.ts
@@ -19,6 +19,8 @@ import { Args, TxMethod } from '../../types/method';
  * @param method - The method to serialize
  */
 export function toTxMethod(registry: TypeRegistry, method: Call): TxMethod {
+	// Used to ensure when using `toString` that the return value is in base10
+	const RADIX_PARAM = 10;
 	// Mapping of argName->argType
 	// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
 	const argsDef = JSON.parse(method.Type.args as unknown as string);
@@ -36,12 +38,13 @@ export function toTxMethod(registry: TypeRegistry, method: Call): TxMethod {
 		// Forcibly serialize all integers to strings
 		let jsonArg =
 			codec instanceof AbstractInt
-				? codec.toString(10)
+				? codec.toString(RADIX_PARAM)
 				: (codec as BN).toJSON();
 
-		// Sanity check to ensure `jsonArg` is not a number
+		// Sanity check to check that `jsonArg` is a number, and if it is
+		// to change it to a string
 		if (!Number.isNaN(jsonArg)) {
-			jsonArg = (jsonArg as unknown as number).toString(10);
+			jsonArg = (jsonArg as unknown as number).toString(RADIX_PARAM);
 		}
 
 		accumulator[stringCamelCase(key)] = jsonArg;

--- a/packages/txwrapper-core/src/core/method/toTxMethod.ts
+++ b/packages/txwrapper-core/src/core/method/toTxMethod.ts
@@ -34,10 +34,15 @@ export function toTxMethod(registry: TypeRegistry, method: Call): TxMethod {
 		}
 
 		// Forcibly serialize all integers to strings
-		const jsonArg =
+		let jsonArg =
 			codec instanceof AbstractInt
 				? codec.toString(10)
 				: (codec as BN).toJSON();
+
+		// Sanity check to ensure `jsonArg` is not a number
+		if (Number.isInteger(jsonArg)) {
+			jsonArg = (jsonArg as unknown as number).toString(10);
+		}
 
 		accumulator[stringCamelCase(key)] = jsonArg;
 		return accumulator;

--- a/packages/txwrapper-core/src/core/method/toTxMethod.ts
+++ b/packages/txwrapper-core/src/core/method/toTxMethod.ts
@@ -40,7 +40,7 @@ export function toTxMethod(registry: TypeRegistry, method: Call): TxMethod {
 				: (codec as BN).toJSON();
 
 		// Sanity check to ensure `jsonArg` is not a number
-		if (Number.isInteger(jsonArg)) {
+		if (!Number.isNaN(jsonArg)) {
 			jsonArg = (jsonArg as unknown as number).toString(10);
 		}
 

--- a/packages/txwrapper-examples/package.json
+++ b/packages/txwrapper-examples/package.json
@@ -19,7 +19,7 @@
     "mandala": "node lib/mandala"
   },
   "dependencies": {
-    "@polkadot/api": "^7.2.1",
+    "@polkadot/api": "^7.7.1",
     "@substrate/txwrapper-polkadot": "^1.5.1",
     "@substrate/txwrapper-registry": "^1.5.1"
   }

--- a/packages/txwrapper-registry/package.json
+++ b/packages/txwrapper-registry/package.json
@@ -18,8 +18,8 @@
     "build": "yarn build:workspace"
   },
   "dependencies": {
-    "@polkadot/apps-config": "^0.100.2-30",
-    "@polkadot/networks": "^8.2.2",
+    "@polkadot/apps-config": "^0.105.1",
+    "@polkadot/networks": "^8.3.3",
     "@substrate/txwrapper-core": "^1.5.1"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -407,12 +407,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/runtime@npm:^7.12.0, @babel/runtime@npm:^7.16.3, @babel/runtime@npm:^7.16.5, @babel/runtime@npm:^7.16.7, @babel/runtime@npm:^7.9.6":
+"@babel/runtime@npm:^7.12.0, @babel/runtime@npm:^7.16.3, @babel/runtime@npm:^7.16.7, @babel/runtime@npm:^7.9.6":
   version: 7.16.7
   resolution: "@babel/runtime@npm:7.16.7"
   dependencies:
     regenerator-runtime: ^0.13.4
   checksum: 47912f0aaacd1cab2e2552aaf3e6eaffbcaf2d5ac9b07a89a12ac0d42029cb92c070b0d16f825e4277c4a34677c54d8ffe85e1f7c6feb57de58f700eec67ce2f
+  languageName: node
+  linkType: hard
+
+"@babel/runtime@npm:^7.17.0":
+  version: 7.17.0
+  resolution: "@babel/runtime@npm:7.17.0"
+  dependencies:
+    regenerator-runtime: ^0.13.4
+  checksum: 1864ac3c6aa061798c706ce858af311f06f6ad6efafc20cca7029fdaa9786c58ccaf5bdb8bd133cb505f27bed7659b65f1503b8da58adbd1eb88f7333644e6ed
   languageName: node
   linkType: hard
 
@@ -461,12 +470,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@bifrost-finance/type-definitions@npm:1.3.18":
-  version: 1.3.18
-  resolution: "@bifrost-finance/type-definitions@npm:1.3.18"
+"@bifrost-finance/type-definitions@npm:1.3.21":
+  version: 1.3.21
+  resolution: "@bifrost-finance/type-definitions@npm:1.3.21"
   dependencies:
     "@open-web3/orml-type-definitions": ^0.9.4-7
-  checksum: 3f07cec1be18406fd378d9367be91011afb18f2a3b691a41aaf2554b98d881d65bbc5955db83a495d933b315fdf4c47d10be9e7db690d7426518a87cf5833058
+  checksum: c591c92a386a2966138a5b90bff46b8885bdeb75686c443e76f67f8e6f757920df0297093cb23f79928ed00ba34f45dc11cdc810bf33bf9a1e7d8e2fca264d32
   languageName: node
   linkType: hard
 
@@ -566,10 +575,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@interlay/interbtc-types@npm:1.5.9":
-  version: 1.5.9
-  resolution: "@interlay/interbtc-types@npm:1.5.9"
-  checksum: 36c4c8406f9bc9a2edb03e457fd65d3a69f6c65567b097d50e63ab23b3aa73a0070d8cbc311b9e32f46dea72c3473a8d0b418b1d2a6f5a04a565a7898102a9b0
+"@interlay/interbtc-types@npm:1.5.10":
+  version: 1.5.10
+  resolution: "@interlay/interbtc-types@npm:1.5.10"
+  checksum: d6868921b18a2ae1adbce1dd3763774f07f7edd0fc1701db11644730d0de63dfa5c52ae7610c7515deb518ffe4e2a308254268e50248129d7e1e4a8fd66eccdc
   languageName: node
   linkType: hard
 
@@ -1608,14 +1617,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@noble/hashes@npm:^0.4.5":
-  version: 0.4.5
-  resolution: "@noble/hashes@npm:0.4.5"
-  checksum: 0de28bda5517989d4893db2f1913ca052d22f549a530965599b36f946753bef1d552d60a4be831723a0d81f9bcca3a5f7c9a1d30d4308d11657f9879ad288d03
+"@noble/hashes@npm:0.5.7":
+  version: 0.5.7
+  resolution: "@noble/hashes@npm:0.5.7"
+  checksum: d7c86669b326da14f0e68d77f8f5c2888c0ca910830a9d2d40a7f6364a76d9b194bb4afda36a2d0ff8cb4ef1a1c023efd4c261276b15a5a88fcfb45f5cc49a85
   languageName: node
   linkType: hard
 
-"@noble/secp256k1@npm:^1.3.4":
+"@noble/secp256k1@npm:1.3.4":
   version: 1.3.4
   resolution: "@noble/secp256k1@npm:1.3.4"
   checksum: af1f1e76387f1a081315550a938b6cee58ea9d844472eadde0a3cb42ad317bd5d824748e7ff96bcf23e45a346bd5a2aed536b450c635f664f3a1dce674ce7648
@@ -1902,232 +1911,233 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@polkadot/api-augment@npm:7.2.1":
-  version: 7.2.1
-  resolution: "@polkadot/api-augment@npm:7.2.1"
+"@polkadot/api-augment@npm:7.7.1":
+  version: 7.7.1
+  resolution: "@polkadot/api-augment@npm:7.7.1"
   dependencies:
-    "@babel/runtime": ^7.16.7
-    "@polkadot/api-base": 7.2.1
-    "@polkadot/rpc-augment": 7.2.1
-    "@polkadot/types": 7.2.1
-    "@polkadot/types-augment": 7.2.1
-    "@polkadot/types-codec": 7.2.1
-    "@polkadot/util": ^8.2.2
-  checksum: 103fe6cf69887a27b6287a37f2bfaf11307e7b665204908079d8d4335bf9dfc51c2619642e2a270f07f249d393df9cd5fcc8e4a4089507ab35c74527973224d1
+    "@babel/runtime": ^7.17.0
+    "@polkadot/api-base": 7.7.1
+    "@polkadot/rpc-augment": 7.7.1
+    "@polkadot/types": 7.7.1
+    "@polkadot/types-augment": 7.7.1
+    "@polkadot/types-codec": 7.7.1
+    "@polkadot/util": ^8.3.3
+  checksum: 90323373b2ca8f8174ccffdf4098b3cddce38b7e5d021294e11093a47086acf75c153e36b0357e05aa8f034779986f6a98917a1ed777f1abca6f5ca972d56ec9
   languageName: node
   linkType: hard
 
-"@polkadot/api-base@npm:7.2.1":
-  version: 7.2.1
-  resolution: "@polkadot/api-base@npm:7.2.1"
+"@polkadot/api-base@npm:7.7.1":
+  version: 7.7.1
+  resolution: "@polkadot/api-base@npm:7.7.1"
   dependencies:
-    "@babel/runtime": ^7.16.7
-    "@polkadot/rpc-core": 7.2.1
-    "@polkadot/types": 7.2.1
-    "@polkadot/util": ^8.2.2
-    rxjs: ^7.5.1
-  checksum: 7eddf57f4b39a0eac74fd25c891c5dc5250b39234839c0bd2518ddd9164d8d766dcdffa09646dfd10ce5a7af7ec7798123d05b6c002edde2a668ad47f90b8172
+    "@babel/runtime": ^7.17.0
+    "@polkadot/rpc-core": 7.7.1
+    "@polkadot/types": 7.7.1
+    "@polkadot/util": ^8.3.3
+    rxjs: ^7.5.2
+  checksum: 57f893fff3787290c6ecfb06699b36ccba76a4af06f3806eb06f9aa14a0cd0384b01b9d8b3a11ef2f916f272a651d4c97ebdd250accd442525e40d15567c12c4
   languageName: node
   linkType: hard
 
-"@polkadot/api-derive@npm:7.2.1, @polkadot/api-derive@npm:^7.2.1":
-  version: 7.2.1
-  resolution: "@polkadot/api-derive@npm:7.2.1"
+"@polkadot/api-derive@npm:7.7.1, @polkadot/api-derive@npm:^7.7.1":
+  version: 7.7.1
+  resolution: "@polkadot/api-derive@npm:7.7.1"
   dependencies:
-    "@babel/runtime": ^7.16.7
-    "@polkadot/api": 7.2.1
-    "@polkadot/api-augment": 7.2.1
-    "@polkadot/api-base": 7.2.1
-    "@polkadot/rpc-core": 7.2.1
-    "@polkadot/types": 7.2.1
-    "@polkadot/types-codec": 7.2.1
-    "@polkadot/util": ^8.2.2
-    "@polkadot/util-crypto": ^8.2.2
-    rxjs: ^7.5.1
-  checksum: cf39d23a63f2c8a2806f401e351be3df4479e5d050931ade61d322dbfc29424e6acd48049d4e852c8ddf3fda531e3f25b77c5e6164637ec9df129efcc50e9ec5
+    "@babel/runtime": ^7.17.0
+    "@polkadot/api": 7.7.1
+    "@polkadot/api-augment": 7.7.1
+    "@polkadot/api-base": 7.7.1
+    "@polkadot/rpc-core": 7.7.1
+    "@polkadot/types": 7.7.1
+    "@polkadot/types-codec": 7.7.1
+    "@polkadot/util": ^8.3.3
+    "@polkadot/util-crypto": ^8.3.3
+    rxjs: ^7.5.2
+  checksum: 707e64ee9722f72ef3f96456fb2603644ce7f44b2b5055be000f7e2cbf020b7a3191ce752819848ed7879063fa4d133f4d95edd07afb59528b5373b5b70c19a5
   languageName: node
   linkType: hard
 
-"@polkadot/api@npm:7.2.1":
-  version: 7.2.1
-  resolution: "@polkadot/api@npm:7.2.1"
+"@polkadot/api@npm:7.7.1":
+  version: 7.7.1
+  resolution: "@polkadot/api@npm:7.7.1"
   dependencies:
-    "@babel/runtime": ^7.16.7
-    "@polkadot/api-augment": 7.2.1
-    "@polkadot/api-base": 7.2.1
-    "@polkadot/api-derive": 7.2.1
-    "@polkadot/keyring": ^8.2.2
-    "@polkadot/rpc-augment": 7.2.1
-    "@polkadot/rpc-core": 7.2.1
-    "@polkadot/rpc-provider": 7.2.1
-    "@polkadot/types": 7.2.1
-    "@polkadot/types-augment": 7.2.1
-    "@polkadot/types-codec": 7.2.1
-    "@polkadot/types-create": 7.2.1
-    "@polkadot/types-known": 7.2.1
-    "@polkadot/util": ^8.2.2
-    "@polkadot/util-crypto": ^8.2.2
+    "@babel/runtime": ^7.17.0
+    "@polkadot/api-augment": 7.7.1
+    "@polkadot/api-base": 7.7.1
+    "@polkadot/api-derive": 7.7.1
+    "@polkadot/keyring": ^8.3.3
+    "@polkadot/rpc-augment": 7.7.1
+    "@polkadot/rpc-core": 7.7.1
+    "@polkadot/rpc-provider": 7.7.1
+    "@polkadot/types": 7.7.1
+    "@polkadot/types-augment": 7.7.1
+    "@polkadot/types-codec": 7.7.1
+    "@polkadot/types-create": 7.7.1
+    "@polkadot/types-known": 7.7.1
+    "@polkadot/util": ^8.3.3
+    "@polkadot/util-crypto": ^8.3.3
     eventemitter3: ^4.0.7
-    rxjs: ^7.5.1
-  checksum: c7905b86747a1bd19acdd9f77e16b2d50e56c4f3eec65a6dc82e6dba6eb27ff149a3d8cee6c1a21dff9556ed1f7fe2fe940ab7de12c09fb9d0d76ee376031d56
+    rxjs: ^7.5.2
+  checksum: b6a5e01d28cc847d87cece2b6496e383493ab26d909314c5a06721a01011472ca148054bd6bf9798b3cd486ec5a4638fcd457a33f5c1ef58e28ca60c8f5069ff
   languageName: node
   linkType: hard
 
-"@polkadot/apps-config@npm:^0.100.2-30":
-  version: 0.100.2-30
-  resolution: "@polkadot/apps-config@npm:0.100.2-30"
+"@polkadot/apps-config@npm:^0.105.1":
+  version: 0.105.1
+  resolution: "@polkadot/apps-config@npm:0.105.1"
   dependencies:
     "@acala-network/type-definitions": ^3.0.2-4
-    "@babel/runtime": ^7.16.7
-    "@bifrost-finance/type-definitions": 1.3.18
+    "@babel/runtime": ^7.17.0
+    "@bifrost-finance/type-definitions": 1.3.21
     "@crustio/type-definitions": 1.2.0
     "@darwinia/types": 2.7.2
     "@digitalnative/type-definitions": 1.1.27
     "@docknetwork/node-types": 0.6.0
     "@edgeware/node-types": 3.6.2-wako
     "@equilab/definitions": 1.4.6
-    "@interlay/interbtc-types": 1.5.9
+    "@interlay/interbtc-types": 1.5.10
     "@kiltprotocol/type-definitions": 0.1.23
     "@laminar/type-definitions": 0.3.1
     "@metaverse-network-sdk/type-definitions": ^0.0.1-6
     "@parallel-finance/type-definitions": 1.4.4
     "@phala/typedefs": 0.2.30
-    "@polkadot/api": ^7.2.1
-    "@polkadot/api-derive": ^7.2.1
-    "@polkadot/networks": ^8.2.2
-    "@polkadot/types": ^7.2.1
-    "@polkadot/util": ^8.2.2
-    "@polkadot/x-fetch": ^8.2.2
+    "@polkadot/api": ^7.7.1
+    "@polkadot/api-derive": ^7.7.1
+    "@polkadot/networks": ^8.3.3
+    "@polkadot/types": ^7.7.1
+    "@polkadot/util": ^8.3.3
+    "@polkadot/x-fetch": ^8.3.3
     "@polymathnetwork/polymesh-types": 0.0.2
-    "@snowfork/snowbridge-types": 0.2.6
-    "@sora-substrate/type-definitions": 1.7.4
+    "@snowfork/snowbridge-types": 0.2.7
+    "@sora-substrate/type-definitions": 1.7.28
     "@subsocial/types": 0.6.5
     "@unique-nft/types": 0.2.0
-    "@zeitgeistpm/type-defs": 0.3.10
+    "@zeitgeistpm/type-defs": 0.4.0
     "@zeroio/type-definitions": 0.0.14
-    i18next: ^21.6.5
+    i18next: ^21.6.10
     lodash: ^4.17.21
-    moonbeam-types-bundle: 2.0.2
+    moonbeam-types-bundle: 2.0.3
     pontem-types-bundle: 1.0.15
-    rxjs: ^7.5.1
-  checksum: fcf57db22dbb6273fe41f0f322382bf4425a15173fb0150c5ee3361d96be84b4a0e15f92b2161a8cad81ecf5d8c10ace60f08c3f22be0c63f0d20f2fcfb35afe
+    rxjs: ^7.5.2
+  checksum: 4dfefad1f3563fc193cb40e391c893cfbcf3768a4c653fc106bbfb49f6364a91b60dd22d905761f4a5b61ff98e4469de946441f333c4d82f9172cf8551cfcc19
   languageName: node
   linkType: hard
 
-"@polkadot/keyring@npm:8.2.2":
-  version: 8.2.2
-  resolution: "@polkadot/keyring@npm:8.2.2"
+"@polkadot/keyring@npm:8.3.3":
+  version: 8.3.3
+  resolution: "@polkadot/keyring@npm:8.3.3"
   dependencies:
-    "@babel/runtime": ^7.16.5
-    "@polkadot/util": 8.2.2
-    "@polkadot/util-crypto": 8.2.2
+    "@babel/runtime": ^7.16.7
+    "@polkadot/util": 8.3.3
+    "@polkadot/util-crypto": 8.3.3
   peerDependencies:
-    "@polkadot/util": 8.2.2
-    "@polkadot/util-crypto": 8.2.2
-  checksum: 9ed75d2dbe69adac418c3f4f26932eea381c3a90ff7b55b42a0b73ad2525ae628f5673eb95cbf784aeafcbdbd10c650ee301740391a4cb63b8d5616a479489c8
+    "@polkadot/util": 8.3.3
+    "@polkadot/util-crypto": 8.3.3
+  checksum: 5e40f25a494c26c2d503cf374e5826c50f83df73af084641329b3dfe7fe9376807e80aa3e99169ff388f86ef4f909acb855084274b99c56cef85ef3ef3418c0f
   languageName: node
   linkType: hard
 
-"@polkadot/networks@npm:8.2.2":
-  version: 8.2.2
-  resolution: "@polkadot/networks@npm:8.2.2"
-  dependencies:
-    "@babel/runtime": ^7.16.5
-  checksum: 0aa898b80d5effa4099bea93ae5de5ed9abbe87f38b1d0d36a6c55470ea3bd0e84c1941a51fd2960f8063aa3e03ef242d26576eeaa5ab8368d9f9f912bb41dd1
-  languageName: node
-  linkType: hard
-
-"@polkadot/rpc-augment@npm:7.2.1":
-  version: 7.2.1
-  resolution: "@polkadot/rpc-augment@npm:7.2.1"
+"@polkadot/networks@npm:8.3.3":
+  version: 8.3.3
+  resolution: "@polkadot/networks@npm:8.3.3"
   dependencies:
     "@babel/runtime": ^7.16.7
-    "@polkadot/rpc-core": 7.2.1
-    "@polkadot/types": 7.2.1
-    "@polkadot/types-codec": 7.2.1
-    "@polkadot/util": ^8.2.2
-  checksum: 397ea807b6837439f1322ec10dcf07dc4495f4b1454710c3d3f217c703c41bfcbf6d0c550ec417053079ebb1901208f7a75af2e0347e86ac5dd0055636233c2c
+    "@polkadot/util": 8.3.3
+  checksum: 731772f55f9e19c7120319dd64e70baa584ec9fcca8af3b2abde0f71a38cae2296e8cfd971cdb2a37d35ea2fffb3907b628bb563b2cfe19b4131f9b071b3f627
   languageName: node
   linkType: hard
 
-"@polkadot/rpc-core@npm:7.2.1":
-  version: 7.2.1
-  resolution: "@polkadot/rpc-core@npm:7.2.1"
+"@polkadot/rpc-augment@npm:7.7.1":
+  version: 7.7.1
+  resolution: "@polkadot/rpc-augment@npm:7.7.1"
   dependencies:
-    "@babel/runtime": ^7.16.7
-    "@polkadot/rpc-augment": 7.2.1
-    "@polkadot/rpc-provider": 7.2.1
-    "@polkadot/types": 7.2.1
-    "@polkadot/util": ^8.2.2
-    rxjs: ^7.5.1
-  checksum: 4faa3e2c1668d5bfbbcd7743a820d366d52067bf72063edf9525ef02a16f2ae6ecf280e8051b41821a5196aad05ebfb4fc56b27d6b2ed5209384d0ab520078e3
+    "@babel/runtime": ^7.17.0
+    "@polkadot/rpc-core": 7.7.1
+    "@polkadot/types": 7.7.1
+    "@polkadot/types-codec": 7.7.1
+    "@polkadot/util": ^8.3.3
+  checksum: 515afaec5c09e4124447860206e26079892d37c97924d498560bbc9dae26c274d3136e9b2fd07b5b204a05a08bd523e9ddec7e9647e8b67aeb93b4bee9f30898
   languageName: node
   linkType: hard
 
-"@polkadot/rpc-provider@npm:7.2.1":
-  version: 7.2.1
-  resolution: "@polkadot/rpc-provider@npm:7.2.1"
+"@polkadot/rpc-core@npm:7.7.1":
+  version: 7.7.1
+  resolution: "@polkadot/rpc-core@npm:7.7.1"
   dependencies:
-    "@babel/runtime": ^7.16.7
-    "@polkadot/keyring": ^8.2.2
-    "@polkadot/types": 7.2.1
-    "@polkadot/types-support": 7.2.1
-    "@polkadot/util": ^8.2.2
-    "@polkadot/util-crypto": ^8.2.2
-    "@polkadot/x-fetch": ^8.2.2
-    "@polkadot/x-global": ^8.2.2
-    "@polkadot/x-ws": ^8.2.2
+    "@babel/runtime": ^7.17.0
+    "@polkadot/rpc-augment": 7.7.1
+    "@polkadot/rpc-provider": 7.7.1
+    "@polkadot/types": 7.7.1
+    "@polkadot/util": ^8.3.3
+    rxjs: ^7.5.2
+  checksum: 11679e4799acfcc37eb9f0a94f0eb8e86681fdb6e0560354f00c945e90d5eb6a8bd43b5add82a0c0f85ddb475ac113fc8e7ddf4fb569629a77a6680c30a9b684
+  languageName: node
+  linkType: hard
+
+"@polkadot/rpc-provider@npm:7.7.1":
+  version: 7.7.1
+  resolution: "@polkadot/rpc-provider@npm:7.7.1"
+  dependencies:
+    "@babel/runtime": ^7.17.0
+    "@polkadot/keyring": ^8.3.3
+    "@polkadot/types": 7.7.1
+    "@polkadot/types-support": 7.7.1
+    "@polkadot/util": ^8.3.3
+    "@polkadot/util-crypto": ^8.3.3
+    "@polkadot/x-fetch": ^8.3.3
+    "@polkadot/x-global": ^8.3.3
+    "@polkadot/x-ws": ^8.3.3
     eventemitter3: ^4.0.7
-    mock-socket: ^9.0.8
-    nock: ^13.2.1
-  checksum: b3ee2174ad7d576d1bfac1d768f75ed7a6272b2f212d60c905d36ba51bcc2f67f42b16dd4090b3f7eb9cbd11a4ad0215a83edb9a6241fd1a10204e26e66c5dc7
+    mock-socket: ^9.1.2
+    nock: ^13.2.4
+  checksum: 958ae8093bcc51c248ada6ebd72a295c87cac47a683bdd762e99c327d50d2576a93f5c2028efd88f3ba829b4357da01a7958290317b357310dabfc3eebfcd759
   languageName: node
   linkType: hard
 
-"@polkadot/types-augment@npm:7.2.1":
-  version: 7.2.1
-  resolution: "@polkadot/types-augment@npm:7.2.1"
+"@polkadot/types-augment@npm:7.7.1":
+  version: 7.7.1
+  resolution: "@polkadot/types-augment@npm:7.7.1"
   dependencies:
-    "@babel/runtime": ^7.16.7
-    "@polkadot/types": 7.2.1
-    "@polkadot/types-codec": 7.2.1
-    "@polkadot/util": ^8.2.2
-  checksum: fea27b8b52f2b5f729f9b98fcf22cdf79925686461a9466b2924ae0029767805c56d52ebb74c54913625912f088d1fa18c9991cf7951a94c692b231229b2c056
+    "@babel/runtime": ^7.17.0
+    "@polkadot/types": 7.7.1
+    "@polkadot/types-codec": 7.7.1
+    "@polkadot/util": ^8.3.3
+  checksum: 2b59652f1376ee0dd8b5eabc9e39e3d6d15ea2644b904bcdde1c212e2c31e55b66ae76966ebf6560c56ecb2494325fa4384c515c5cddbe2fd53e88e76823d314
   languageName: node
   linkType: hard
 
-"@polkadot/types-codec@npm:7.2.1":
-  version: 7.2.1
-  resolution: "@polkadot/types-codec@npm:7.2.1"
+"@polkadot/types-codec@npm:7.7.1":
+  version: 7.7.1
+  resolution: "@polkadot/types-codec@npm:7.7.1"
   dependencies:
-    "@babel/runtime": ^7.16.7
-    "@polkadot/util": ^8.2.2
-  checksum: 25cdb8a47ccd4d1831d57910c9226dc2af379643e8110f8cdeaa652b825fdcadaad403aad451322f47296a840584e9097097307922a3d4d6f3c881c9a0eaa528
+    "@babel/runtime": ^7.17.0
+    "@polkadot/util": ^8.3.3
+  checksum: 71a341a9fb8693e37e9afb981e32924d93977543a10dba206abfab9f7a3f1a14633e1311603509a35757b5d8f09e6ec5d8e8fe925f5f672e447c2e2f85edc6a7
   languageName: node
   linkType: hard
 
-"@polkadot/types-create@npm:7.2.1":
-  version: 7.2.1
-  resolution: "@polkadot/types-create@npm:7.2.1"
+"@polkadot/types-create@npm:7.7.1":
+  version: 7.7.1
+  resolution: "@polkadot/types-create@npm:7.7.1"
   dependencies:
-    "@babel/runtime": ^7.16.7
-    "@polkadot/types-codec": 7.2.1
-    "@polkadot/util": ^8.2.2
-  checksum: ae8d64b845c23a674112fce13e10e0bc512c3a2770eebbc54706bd75d031f19405abc04e8b9fa613ad9b2dcc5e3834b17e3fdd82ac7723d3269f009593a2b0f9
+    "@babel/runtime": ^7.17.0
+    "@polkadot/types-codec": 7.7.1
+    "@polkadot/util": ^8.3.3
+  checksum: e0f6d42da3c0dff6ea852ca20b42963c4651ef322161602ab1c873632e648f769c90b03eedcb187d5f9dbbbd5cb73c5d549f91b0bc3dfca5ef08ddd7864d0077
   languageName: node
   linkType: hard
 
-"@polkadot/types-known@npm:7.2.1":
-  version: 7.2.1
-  resolution: "@polkadot/types-known@npm:7.2.1"
+"@polkadot/types-known@npm:7.7.1":
+  version: 7.7.1
+  resolution: "@polkadot/types-known@npm:7.7.1"
   dependencies:
-    "@babel/runtime": ^7.16.7
-    "@polkadot/networks": ^8.2.2
-    "@polkadot/types": 7.2.1
-    "@polkadot/types-codec": 7.2.1
-    "@polkadot/types-create": 7.2.1
-    "@polkadot/util": ^8.2.2
-  checksum: f3c908e1933e153218649a0e3ba58eb203b57ecd6c36e7cefa06dfabc4191a4ce8ef0a7e3ce56262449220091d8ee73d0e5ee226c22e30da62edb5d0af9b953c
+    "@babel/runtime": ^7.17.0
+    "@polkadot/networks": ^8.3.3
+    "@polkadot/types": 7.7.1
+    "@polkadot/types-codec": 7.7.1
+    "@polkadot/types-create": 7.7.1
+    "@polkadot/util": ^8.3.3
+  checksum: 61a23612dbf013fe7e0405395d8d59f2215165ac817cd35e236c6a30b93f5751bba010566abefae46e6dfa6862015a324ab626974ad7c7d4782bce1dc56ca212
   languageName: node
   linkType: hard
 
@@ -2141,66 +2151,66 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@polkadot/types-support@npm:7.2.1":
-  version: 7.2.1
-  resolution: "@polkadot/types-support@npm:7.2.1"
+"@polkadot/types-support@npm:7.7.1":
+  version: 7.7.1
+  resolution: "@polkadot/types-support@npm:7.7.1"
   dependencies:
-    "@babel/runtime": ^7.16.7
-    "@polkadot/util": ^8.2.2
-  checksum: 66920d3c77680a4391aa885d28d1ec6c24a9442b66714b8361b21e09c9a81c9dfa8b1637e16e7135c5cefb6ddd4b2ad003c9c6ca35a76ae40c75bd630d0d65ba
+    "@babel/runtime": ^7.17.0
+    "@polkadot/util": ^8.3.3
+  checksum: 01cd4cf1d0db1c1d0bc8e46bc064fe4ba7696c473e4abf4e3ae4d1b7ea0f1b60c525de540554d31231855923ae69996519341a038382965d07516ab5f0e08387
   languageName: node
   linkType: hard
 
-"@polkadot/types@npm:7.2.1":
-  version: 7.2.1
-  resolution: "@polkadot/types@npm:7.2.1"
+"@polkadot/types@npm:7.7.1":
+  version: 7.7.1
+  resolution: "@polkadot/types@npm:7.7.1"
   dependencies:
-    "@babel/runtime": ^7.16.7
-    "@polkadot/keyring": ^8.2.2
-    "@polkadot/types-augment": 7.2.1
-    "@polkadot/types-codec": 7.2.1
-    "@polkadot/types-create": 7.2.1
-    "@polkadot/util": ^8.2.2
-    "@polkadot/util-crypto": ^8.2.2
-    rxjs: ^7.5.1
-  checksum: f736cbef11c39bbc6669e8503a22e7ec5082ed5a4baf04ecd774fbf9cc32a7125236c0662e82691501b30d01cbdecd3376f468532e15dd43d46fa4861707de6f
+    "@babel/runtime": ^7.17.0
+    "@polkadot/keyring": ^8.3.3
+    "@polkadot/types-augment": 7.7.1
+    "@polkadot/types-codec": 7.7.1
+    "@polkadot/types-create": 7.7.1
+    "@polkadot/util": ^8.3.3
+    "@polkadot/util-crypto": ^8.3.3
+    rxjs: ^7.5.2
+  checksum: f7650c31bebbfb8b3ff38ee18d0584e37d4c888dc44370c60fda7bb3069bf0ca2a692611d0ce6dde8ada65c8f70e17b9e5c8dd36a093dd623324896b2e924705
   languageName: node
   linkType: hard
 
-"@polkadot/util-crypto@npm:8.2.2":
-  version: 8.2.2
-  resolution: "@polkadot/util-crypto@npm:8.2.2"
+"@polkadot/util-crypto@npm:8.3.3":
+  version: 8.3.3
+  resolution: "@polkadot/util-crypto@npm:8.3.3"
   dependencies:
-    "@babel/runtime": ^7.16.5
-    "@noble/hashes": ^0.4.5
-    "@noble/secp256k1": ^1.3.4
-    "@polkadot/networks": 8.2.2
-    "@polkadot/util": 8.2.2
+    "@babel/runtime": ^7.16.7
+    "@noble/hashes": 0.5.7
+    "@noble/secp256k1": 1.3.4
+    "@polkadot/networks": 8.3.3
+    "@polkadot/util": 8.3.3
     "@polkadot/wasm-crypto": ^4.5.1
-    "@polkadot/x-bigint": 8.2.2
-    "@polkadot/x-randomvalues": 8.2.2
+    "@polkadot/x-bigint": 8.3.3
+    "@polkadot/x-randomvalues": 8.3.3
     ed2curve: ^0.3.0
-    micro-base: ^0.10.0
+    micro-base: ^0.10.2
     tweetnacl: ^1.0.3
   peerDependencies:
-    "@polkadot/util": 8.2.2
-  checksum: 04b358937570498428cd78f642cf0d8f25e44315dbfb54cfaf2de10806252f20aa8df2eda1d139d58e2efd5b1fb4d5bdc5d5756b1d25017b98fe03d2beeefbc6
+    "@polkadot/util": 8.3.3
+  checksum: 57c15a4b4ffac2fb037ef9f7d3f27d8c79e291352b73f85d2c54845d29fec4bf690fac43bda1e2e0b9fa56701c03393bc0fb6d3dcda56fd1142c85273f9c2220
   languageName: node
   linkType: hard
 
-"@polkadot/util@npm:8.2.2":
-  version: 8.2.2
-  resolution: "@polkadot/util@npm:8.2.2"
+"@polkadot/util@npm:8.3.3":
+  version: 8.3.3
+  resolution: "@polkadot/util@npm:8.3.3"
   dependencies:
-    "@babel/runtime": ^7.16.5
-    "@polkadot/x-bigint": 8.2.2
-    "@polkadot/x-global": 8.2.2
-    "@polkadot/x-textdecoder": 8.2.2
-    "@polkadot/x-textencoder": 8.2.2
+    "@babel/runtime": ^7.16.7
+    "@polkadot/x-bigint": 8.3.3
+    "@polkadot/x-global": 8.3.3
+    "@polkadot/x-textdecoder": 8.3.3
+    "@polkadot/x-textencoder": 8.3.3
     "@types/bn.js": ^4.11.6
     bn.js: ^4.12.0
     ip-regex: ^4.3.0
-  checksum: c8eb0e6278557735e9785a1a81fed14c05c65a790238470763537f27fb601cbf350a8362ecc36469de08d9d61485ab7409da35fcf5acffb0c6cc88fe0ba929bf
+  checksum: 7ce0efe911fb528800ed01fc501b5eca340722fc12c8c7ee9dee6637260e669b59242183caade532431e5b63631f83fd53bcfd93b29b86cb9119e0469ccf735c
   languageName: node
   linkType: hard
 
@@ -2236,76 +2246,76 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@polkadot/x-bigint@npm:8.2.2":
-  version: 8.2.2
-  resolution: "@polkadot/x-bigint@npm:8.2.2"
+"@polkadot/x-bigint@npm:8.3.3":
+  version: 8.3.3
+  resolution: "@polkadot/x-bigint@npm:8.3.3"
   dependencies:
-    "@babel/runtime": ^7.16.5
-    "@polkadot/x-global": 8.2.2
-  checksum: 1fd0d05848d65e6d171be0974a23c552ac14c898798ab7474d473843d4fad79cf3dc77df42673a69220904f51261c256d559d4b515fbfd8edaf8371df6b5644c
+    "@babel/runtime": ^7.16.7
+    "@polkadot/x-global": 8.3.3
+  checksum: 43cdb0572ab7dd4e77b3af5f4421ee804ad52fc6121415f09c851e1c431574bc7f5bf92cef9f1f0573ba8115ce4d1200273b23e15eb695781ad7dc54eb7970ab
   languageName: node
   linkType: hard
 
-"@polkadot/x-fetch@npm:^8.2.2":
-  version: 8.2.2
-  resolution: "@polkadot/x-fetch@npm:8.2.2"
+"@polkadot/x-fetch@npm:^8.3.3":
+  version: 8.3.3
+  resolution: "@polkadot/x-fetch@npm:8.3.3"
   dependencies:
-    "@babel/runtime": ^7.16.5
-    "@polkadot/x-global": 8.2.2
+    "@babel/runtime": ^7.16.7
+    "@polkadot/x-global": 8.3.3
     "@types/node-fetch": ^2.5.12
-    node-fetch: ^2.6.6
-  checksum: 4dbcd0449c51679140e3d37086ea753a1ebe750aeb62e81a7d2c9d78a0aae9101387009bde8f196f203bebdcfb59ba3e997d4c1e403f7c137b79d801d9a9650b
+    node-fetch: ^2.6.7
+  checksum: d4959fa6de1b13da6d581e820003049f5e1574b1a87d38e2c733ead1b966a6355dc1fa2e29a921bd74392dc436abd7e5a75f203397ae050422f15f54d79b1f9a
   languageName: node
   linkType: hard
 
-"@polkadot/x-global@npm:8.2.2, @polkadot/x-global@npm:^8.2.2":
-  version: 8.2.2
-  resolution: "@polkadot/x-global@npm:8.2.2"
+"@polkadot/x-global@npm:8.3.3, @polkadot/x-global@npm:^8.3.3":
+  version: 8.3.3
+  resolution: "@polkadot/x-global@npm:8.3.3"
   dependencies:
-    "@babel/runtime": ^7.16.5
-  checksum: a41760e01e21c6b9c9f2412da2e73e4762c9fbf2275776204abb2bcc486f5537f857836218cffa3603eecb2e36a9e130370aabbb816c088acd50733cc09ee6b5
+    "@babel/runtime": ^7.16.7
+  checksum: 992cea4d1e9442195648ae3aac9cd9afa657897e3e6d25f1870690e99bf687555e2296295c9b53ac0694c10ddbce20e158b659c510ae5e0688a5774c9bfac6e9
   languageName: node
   linkType: hard
 
-"@polkadot/x-randomvalues@npm:8.2.2":
-  version: 8.2.2
-  resolution: "@polkadot/x-randomvalues@npm:8.2.2"
+"@polkadot/x-randomvalues@npm:8.3.3":
+  version: 8.3.3
+  resolution: "@polkadot/x-randomvalues@npm:8.3.3"
   dependencies:
-    "@babel/runtime": ^7.16.5
-    "@polkadot/x-global": 8.2.2
-  checksum: 18817fe2374b3e0e2bebd2df98d68720df037cbc29363d2e4701f1e894c52ddaabd41d16022cef532860b0ccbb5e6d51f6245b47f5aafc4d0eeb7285736b0309
+    "@babel/runtime": ^7.16.7
+    "@polkadot/x-global": 8.3.3
+  checksum: 54546db40525efaadf16035cf23a747229e0a308aac41af8c1852df94123ee6d1a5155bdb2c0cc0bb5599b58e31fbdc8a3d653d5ad34a57b51bd3581cdbd40ed
   languageName: node
   linkType: hard
 
-"@polkadot/x-textdecoder@npm:8.2.2":
-  version: 8.2.2
-  resolution: "@polkadot/x-textdecoder@npm:8.2.2"
+"@polkadot/x-textdecoder@npm:8.3.3":
+  version: 8.3.3
+  resolution: "@polkadot/x-textdecoder@npm:8.3.3"
   dependencies:
-    "@babel/runtime": ^7.16.5
-    "@polkadot/x-global": 8.2.2
-  checksum: 3e6ba49e71f927c1dacb352ca7d8cb4cc570a95ce51e1c6b9e4e390d454d795a8887d556a44df29359c14193ef0a1424564099acd2fd1ca2ff3561f1729940e3
+    "@babel/runtime": ^7.16.7
+    "@polkadot/x-global": 8.3.3
+  checksum: 88df61f32e5ea1f348a4d27bf123bae3bfcf147023b337cb5c0b12660155e92b85e7747085e60cfd724d3365d8507a6003a7f6a7e1d3f5da4754ee389242a82e
   languageName: node
   linkType: hard
 
-"@polkadot/x-textencoder@npm:8.2.2":
-  version: 8.2.2
-  resolution: "@polkadot/x-textencoder@npm:8.2.2"
+"@polkadot/x-textencoder@npm:8.3.3":
+  version: 8.3.3
+  resolution: "@polkadot/x-textencoder@npm:8.3.3"
   dependencies:
-    "@babel/runtime": ^7.16.5
-    "@polkadot/x-global": 8.2.2
-  checksum: 260cfbe56490ffd1966e30e02243b95217085598dddcf2e05bae48ef42621a3bb76ec2d31acde451693889f308b3c8a7a8fd8f7f16a7f16f724dc51d7aeee3c8
+    "@babel/runtime": ^7.16.7
+    "@polkadot/x-global": 8.3.3
+  checksum: b9a044f0afd6ce13faa62b90b627caea3c4cdb40ce72df54ffb096ab222a667cf47ff28d59f6b9c81e2c186f40c67c07fe40fcfa44d564dcebb3af41fe79c8a9
   languageName: node
   linkType: hard
 
-"@polkadot/x-ws@npm:^8.2.2":
-  version: 8.2.2
-  resolution: "@polkadot/x-ws@npm:8.2.2"
+"@polkadot/x-ws@npm:^8.3.3":
+  version: 8.3.3
+  resolution: "@polkadot/x-ws@npm:8.3.3"
   dependencies:
-    "@babel/runtime": ^7.16.5
-    "@polkadot/x-global": 8.2.2
+    "@babel/runtime": ^7.16.7
+    "@polkadot/x-global": 8.3.3
     "@types/websocket": ^1.0.4
     websocket: ^1.0.34
-  checksum: 0f9afac4a8c84b7b1282ad761a168bec2e450c5a39b61de1ee6c745e31ea6c1225f8e60d7c5404c4b6c09a51a68be16c51ed9939138442ff7a0dccd89af8f518
+  checksum: 0f78be78e6fa85beded0bffcd066ee453574e18f032e8b29add5c9fe9a7b4c87680015cd8e88be6a107e310e7970ec7bdb53a7f96a6e5c347780e65a943ff74c
   languageName: node
   linkType: hard
 
@@ -2354,22 +2364,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@snowfork/snowbridge-types@npm:0.2.6":
-  version: 0.2.6
-  resolution: "@snowfork/snowbridge-types@npm:0.2.6"
+"@snowfork/snowbridge-types@npm:0.2.7":
+  version: 0.2.7
+  resolution: "@snowfork/snowbridge-types@npm:0.2.7"
   dependencies:
-    "@polkadot/keyring": ^7.1.1
-    "@polkadot/types": ^5.3.2
-  checksum: 29896c3d3a44d6fe3fd369413b2bb1249a65cc24065b49db322dd739763059526886690712b8c5ee7cafc058b77c04d4c4fb376c6340b2ad68875a65d6baa30d
+    "@polkadot/api": ^7.2.1
+    "@polkadot/keyring": ^8.2.2
+    "@polkadot/types": ^7.2.1
+  checksum: 2b2b692d3b38a1f9d781bd76ace4ef79582b3861d551c520c6c99f3c7745922aacb346261d9f671890378c08002bb5a7b63bb41bf3d483407d15bf5c7aeb06ff
   languageName: node
   linkType: hard
 
-"@sora-substrate/type-definitions@npm:1.7.4":
-  version: 1.7.4
-  resolution: "@sora-substrate/type-definitions@npm:1.7.4"
+"@sora-substrate/type-definitions@npm:1.7.28":
+  version: 1.7.28
+  resolution: "@sora-substrate/type-definitions@npm:1.7.28"
   dependencies:
     "@open-web3/orml-type-definitions": ^0.9.4-35
-  checksum: 56ae0a8a6284a297bee9e16edd9efcd6e0d3d0ce0bc0eb322275296717fcb2f119edf4ac5ce2b7fd8242fb18c09799499aa1a0ffdba22782557b2f4fd14d72da
+  checksum: b1b119b723a059c07a7056d03a631d19f7dd5b64e32c60dfe4cc0b5d36b0408d89a268e433db0f5630ab8f899fe97b395f79e1df8c8ed0cc11c8c739f8bbd894
   languageName: node
   linkType: hard
 
@@ -2439,7 +2450,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@substrate/txwrapper-core@workspace:packages/txwrapper-core"
   dependencies:
-    "@polkadot/api": ^7.2.1
+    "@polkadot/api": ^7.7.1
     "@types/memoizee": ^0.4.3
     memoizee: 0.4.15
   languageName: unknown
@@ -2449,7 +2460,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@substrate/txwrapper-examples@workspace:packages/txwrapper-examples"
   dependencies:
-    "@polkadot/api": ^7.2.1
+    "@polkadot/api": ^7.7.1
     "@substrate/txwrapper-polkadot": ^1.5.1
     "@substrate/txwrapper-registry": ^1.5.1
   languageName: unknown
@@ -2477,8 +2488,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@substrate/txwrapper-registry@workspace:packages/txwrapper-registry"
   dependencies:
-    "@polkadot/apps-config": ^0.100.2-30
-    "@polkadot/networks": ^8.2.2
+    "@polkadot/apps-config": ^0.105.1
+    "@polkadot/networks": ^8.3.3
     "@substrate/txwrapper-core": ^1.5.1
   languageName: unknown
   linkType: soft
@@ -2835,10 +2846,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@zeitgeistpm/type-defs@npm:0.3.10":
-  version: 0.3.10
-  resolution: "@zeitgeistpm/type-defs@npm:0.3.10"
-  checksum: cce2c872e9cfbf55e32588e61bd48670216deb33ea9b899b8eaae0bef3c1b1a84760aedac5ea4f2849d16dd871b089cad8cfc327e042c3d87f7c6f429f2001c3
+"@zeitgeistpm/type-defs@npm:0.4.0":
+  version: 0.4.0
+  resolution: "@zeitgeistpm/type-defs@npm:0.4.0"
+  checksum: bb331c18f0aa934a02083b8d3fc6a9a411b32ad825e2b0331ce47ea3f66f84a2b002b223931f39a2e36846814fb638d0cf8f9a30f7dd58dbf03111e7177576fe
   languageName: node
   linkType: hard
 
@@ -5501,12 +5512,12 @@ fsevents@^2.3.2:
   languageName: node
   linkType: hard
 
-"i18next@npm:^21.6.5":
-  version: 21.6.5
-  resolution: "i18next@npm:21.6.5"
+"i18next@npm:^21.6.10":
+  version: 21.6.11
+  resolution: "i18next@npm:21.6.11"
   dependencies:
     "@babel/runtime": ^7.12.0
-  checksum: 1897f751d346c692cae70e977f64982862114fc0453a75fe89f31b8029cf39606aa663f33495172eccb02c9297a089110f14a11e38be3e66092c0510ab616a06
+  checksum: 42716a7519d6066a8c9400639ab80fba0b568ae02205b1155ec9c4e627704bb2181dd182ff5eb0c91f6c67c8038ddd0754214e1932de5699d488c21ffd617c5e
   languageName: node
   linkType: hard
 
@@ -7330,10 +7341,10 @@ fsevents@^2.3.2:
   languageName: node
   linkType: hard
 
-"micro-base@npm:^0.10.0":
-  version: 0.10.0
-  resolution: "micro-base@npm:0.10.0"
-  checksum: b8892630e8fd9749f9695733a751233ade68f1fde469725d0bb52c0ac36d6ac94f51897a908adde4be4d0e3e65fc0d3ec2cf4c7b3ed6e386c7aab5eb662aa97f
+"micro-base@npm:^0.10.2":
+  version: 0.10.2
+  resolution: "micro-base@npm:0.10.2"
+  checksum: 4fcc9fb80cca021c5157e63d76188e3742a8f1ac5a90b1022a34cd715bf8ab19bbd82b71b908f0cf1cf6983d39533fe1aef4f24f2c0b09ec9d862fdaf5bf26ab
   languageName: node
   linkType: hard
 
@@ -7601,10 +7612,10 @@ fsevents@^2.3.2:
   languageName: node
   linkType: hard
 
-"mock-socket@npm:^9.0.8":
-  version: 9.0.8
-  resolution: "mock-socket@npm:9.0.8"
-  checksum: 4a8e890f6e17d22636936af84015af151f791cccd430842d4d8329a95d90d9b3db7b7da9ae9fcf0f2b0254f94bb9269d0b4c35184b09e3e9bcaeeb69ddeb1358
+"mock-socket@npm:^9.1.2":
+  version: 9.1.2
+  resolution: "mock-socket@npm:9.1.2"
+  checksum: ef25dbd57b7360a0c1e0bb072aa0d73ac53d11d88c1efebedd48da006ccff77327628d707fecf651906e81cc488e8929c733bdb9f2c4c4f3772e99d6b903aace
   languageName: node
   linkType: hard
 
@@ -7615,15 +7626,15 @@ fsevents@^2.3.2:
   languageName: node
   linkType: hard
 
-"moonbeam-types-bundle@npm:2.0.2":
-  version: 2.0.2
-  resolution: "moonbeam-types-bundle@npm:2.0.2"
+"moonbeam-types-bundle@npm:2.0.3":
+  version: 2.0.3
+  resolution: "moonbeam-types-bundle@npm:2.0.3"
   dependencies:
     "@polkadot/api": ^6.11.1
     "@polkadot/keyring": ^7.8.2
     "@polkadot/types": ^6.11.1
     typescript: ^4.5.2
-  checksum: 105b61e76bab276fe6e5e0a5e0f8e42c285eeefdfd6f6af54db279c16748b57a8c19772354f2e9d7cf1ba228bd4d8a1670ca6994edeedd7316e6f7eed85d21b2
+  checksum: 49ec1258d3512641b053ed33e7420d9fbaade1615dbbc2202bc8ca7d40cfa462afc90e9f624e549ec59774fcf11502412ebdf9e34e041cec7d780c5d535a28f5
   languageName: node
   linkType: hard
 
@@ -7737,24 +7748,38 @@ fsevents@^2.3.2:
   languageName: node
   linkType: hard
 
-"nock@npm:^13.2.1":
-  version: 13.2.1
-  resolution: "nock@npm:13.2.1"
+"nock@npm:^13.2.4":
+  version: 13.2.4
+  resolution: "nock@npm:13.2.4"
   dependencies:
     debug: ^4.1.0
     json-stringify-safe: ^5.0.1
     lodash.set: ^4.3.2
     propagate: ^2.0.0
-  checksum: b401fb8143ca88095ee34c715e2806eda2813dace4f4c4798961ad961c18003d1529f4507a79c429d2c3c768e136632ee19ee9ebfef71f0cb022df152594df1d
+  checksum: 2750a82ea22eebd8203eb1d7669ae09c3daae1fd573026372bad2515adad48d723a804f647bd45d7a499eb3a9a632560da406bde05bca9df762d3027db9099b5
   languageName: node
   linkType: hard
 
-"node-fetch@npm:^2.6.1, node-fetch@npm:^2.6.6":
+"node-fetch@npm:^2.6.1":
   version: 2.6.6
   resolution: "node-fetch@npm:2.6.6"
   dependencies:
     whatwg-url: ^5.0.0
   checksum: ee8290626bdb73629c59722b75dcf4b9b6a67c1ed7eb9102e368479c4a13b56a48c2bb3ad71571e378e98c8b2c64c820e11f9cd39e4b8557dd138ad571ef9a42
+  languageName: node
+  linkType: hard
+
+"node-fetch@npm:^2.6.7":
+  version: 2.6.7
+  resolution: "node-fetch@npm:2.6.7"
+  dependencies:
+    whatwg-url: ^5.0.0
+  peerDependencies:
+    encoding: ^0.1.0
+  peerDependenciesMeta:
+    encoding:
+      optional: true
+  checksum: 8d816ffd1ee22cab8301c7756ef04f3437f18dace86a1dae22cf81db8ef29c0bf6655f3215cb0cdb22b420b6fe141e64b26905e7f33f9377a7fa59135ea3e10b
   languageName: node
   linkType: hard
 
@@ -9201,12 +9226,12 @@ fsevents@^2.3.2:
   languageName: node
   linkType: hard
 
-"rxjs@npm:^7.5.1":
-  version: 7.5.1
-  resolution: "rxjs@npm:7.5.1"
+"rxjs@npm:^7.5.2":
+  version: 7.5.2
+  resolution: "rxjs@npm:7.5.2"
   dependencies:
     tslib: ^2.1.0
-  checksum: 78e3eecb1644dd83adabc8d956f879dca62eb19c8afcd6acac71cf6d94534c33ea201e65387494fdeb1332395cba081e194f5a9699d58a5d48e416b8b52372aa
+  checksum: daf1fe7289de500b25d822fd96cde3c138c7902e8bf0e6aa12a3e70847a5cabeeb4d677f10e19387e1db44b12c5b1be0ff5c79b8cd63ed6ce891d765e566cf4d
   languageName: node
   linkType: hard
 
@@ -10165,7 +10190,7 @@ fsevents@^2.3.2:
   resolution: "txwrapper-core@workspace:."
   dependencies:
     "@babel/plugin-transform-modules-commonjs": ^7.15.4
-    "@polkadot/util-crypto": ^8.2.2
+    "@polkadot/util-crypto": ^8.3.3
     "@substrate/dev": ^0.5.6
     "@types/jest": ^27.0.1
     "@typescript-eslint/eslint-plugin": ^4.31.1

--- a/yarn.lock
+++ b/yarn.lock
@@ -407,16 +407,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/runtime@npm:^7.12.0, @babel/runtime@npm:^7.16.3, @babel/runtime@npm:^7.16.7, @babel/runtime@npm:^7.9.6":
-  version: 7.16.7
-  resolution: "@babel/runtime@npm:7.16.7"
-  dependencies:
-    regenerator-runtime: ^0.13.4
-  checksum: 47912f0aaacd1cab2e2552aaf3e6eaffbcaf2d5ac9b07a89a12ac0d42029cb92c070b0d16f825e4277c4a34677c54d8ffe85e1f7c6feb57de58f700eec67ce2f
-  languageName: node
-  linkType: hard
-
-"@babel/runtime@npm:^7.17.0":
+"@babel/runtime@npm:^7.12.0, @babel/runtime@npm:^7.16.3, @babel/runtime@npm:^7.16.7, @babel/runtime@npm:^7.17.0, @babel/runtime@npm:^7.9.6":
   version: 7.17.0
   resolution: "@babel/runtime@npm:7.17.0"
   dependencies:
@@ -7760,16 +7751,7 @@ fsevents@^2.3.2:
   languageName: node
   linkType: hard
 
-"node-fetch@npm:^2.6.1":
-  version: 2.6.6
-  resolution: "node-fetch@npm:2.6.6"
-  dependencies:
-    whatwg-url: ^5.0.0
-  checksum: ee8290626bdb73629c59722b75dcf4b9b6a67c1ed7eb9102e368479c4a13b56a48c2bb3ad71571e378e98c8b2c64c820e11f9cd39e4b8557dd138ad571ef9a42
-  languageName: node
-  linkType: hard
-
-"node-fetch@npm:^2.6.7":
+"node-fetch@npm:^2.6.1, node-fetch@npm:^2.6.7":
   version: 2.6.7
   resolution: "node-fetch@npm:2.6.7"
   dependencies:


### PR DESCRIPTION
This updates the polkadot-js deps to the following:

    "@polkadot/api": "^7.7.1",
    "@polkadot/apps-config": "^0.105.1",
    "@polkadot/networks": "^8.3.3",
    
I also added an extra step of validation for the `jsonArg` inside of `toTxMethod` which was failing to serialize the number to string in some cases. I dont think this is a be all end all solution, as toTxMethod needs a little rework, and I dont want to cloud this PR with that logic. I mention it in this issue https://github.com/paritytech/txwrapper-core/issues/126