### PR TITLE
fix(examples): replaced localhost with 0.0.0.0

### DIFF
--- a/packages/txwrapper-examples/src/polkadot.ts
+++ b/packages/txwrapper-examples/src/polkadot.ts
@@ -20,7 +20,7 @@ import { rpcToLocalNode, signWith } from './util';
 
 /**
  * Entry point of the script. This script assumes a Polkadot node is running
- * locally on `http://localhost:9933`.
+ * locally on `http://127.0.0.1:9933`.
  */
 async function main(): Promise<void> {
 	// Wait for the promise to resolve async WASM

--- a/packages/txwrapper-examples/src/polkadot.ts
+++ b/packages/txwrapper-examples/src/polkadot.ts
@@ -20,7 +20,7 @@ import { rpcToLocalNode, signWith } from './util';
 
 /**
  * Entry point of the script. This script assumes a Polkadot node is running
- * locally on `http://127.0.0.1:9933`.
+ * locally on `http://0.0.0.0:9933`.
  */
 async function main(): Promise<void> {
 	// Wait for the promise to resolve async WASM

--- a/packages/txwrapper-examples/src/polkadotBatchAll.ts
+++ b/packages/txwrapper-examples/src/polkadotBatchAll.ts
@@ -20,7 +20,7 @@ import { rpcToLocalNode, signWith } from './util';
 
 /**
  * Entry point of the script. This script assumes a Polkadot node is running
- * locally on `http://localhost:9933`.
+ * locally on `http://127.0.0.1:9933`.
  */
 async function main(): Promise<void> {
 	// Wait for the promise to resolve async WASM

--- a/packages/txwrapper-examples/src/polkadotBatchAll.ts
+++ b/packages/txwrapper-examples/src/polkadotBatchAll.ts
@@ -20,7 +20,7 @@ import { rpcToLocalNode, signWith } from './util';
 
 /**
  * Entry point of the script. This script assumes a Polkadot node is running
- * locally on `http://127.0.0.1:9933`.
+ * locally on `http://0.0.0.0:9933`.
  */
 async function main(): Promise<void> {
 	// Wait for the promise to resolve async WASM

--- a/packages/txwrapper-examples/src/util.ts
+++ b/packages/txwrapper-examples/src/util.ts
@@ -11,7 +11,7 @@ import { createMetadata, OptionsWithMeta } from '@substrate/txwrapper-polkadot';
 import fetch from 'node-fetch';
 
 /**
- * Send a JSONRPC request to the node at http://127.0.0.1:9933.
+ * Send a JSONRPC request to the node at http://0.0.0.0:9933.
  *
  * @param method - The JSONRPC request method.
  * @param params - The JSONRPC request params.

--- a/packages/txwrapper-examples/src/util.ts
+++ b/packages/txwrapper-examples/src/util.ts
@@ -11,7 +11,7 @@ import { createMetadata, OptionsWithMeta } from '@substrate/txwrapper-polkadot';
 import fetch from 'node-fetch';
 
 /**
- * Send a JSONRPC request to the node at http://localhost:9933.
+ * Send a JSONRPC request to the node at http://127.0.0.1:9933.
  *
  * @param method - The JSONRPC request method.
  * @param params - The JSONRPC request params.
@@ -20,7 +20,7 @@ export function rpcToLocalNode(
 	method: string,
 	params: any[] = []
 ): Promise<any> {
-	return fetch('http://localhost:9933', {
+	return fetch('http://127.0.0.1:9933', {
 		body: JSON.stringify({
 			id: 1,
 			jsonrpc: '2.0',

--- a/packages/txwrapper-examples/src/util.ts
+++ b/packages/txwrapper-examples/src/util.ts
@@ -20,7 +20,7 @@ export function rpcToLocalNode(
 	method: string,
 	params: any[] = []
 ): Promise<any> {
-	return fetch('http://127.0.0.1:9933', {
+	return fetch('http://0.0.0.0:9933', {
 		body: JSON.stringify({
 			id: 1,
 			jsonrpc: '2.0',

--- a/packages/txwrapper-template/examples/template-example.ts
+++ b/packages/txwrapper-template/examples/template-example.ts
@@ -13,7 +13,7 @@ import { rpcToLocalNode, signWith } from './util';
 
 /**
  * Entry point of the script. This script assumes a [TODO CHAIN NAME] node is running
- * locally on `http://localhost:9933`.
+ * locally on `http://127.0.0.1:9933`.
  */
 async function main(): Promise<void> {
 	// Wait for the promise to resolve async WASM

--- a/packages/txwrapper-template/examples/template-example.ts
+++ b/packages/txwrapper-template/examples/template-example.ts
@@ -13,7 +13,7 @@ import { rpcToLocalNode, signWith } from './util';
 
 /**
  * Entry point of the script. This script assumes a [TODO CHAIN NAME] node is running
- * locally on `http://127.0.0.1:9933`.
+ * locally on `http://0.0.0.0:9933`.
  */
 async function main(): Promise<void> {
 	// Wait for the promise to resolve async WASM

--- a/packages/txwrapper-template/examples/util.ts
+++ b/packages/txwrapper-template/examples/util.ts
@@ -11,7 +11,7 @@ import { createMetadata, OptionsWithMeta } from '@substrate/txwrapper-polkadot';
 import fetch from 'node-fetch';
 
 /**
- * Send a JSONRPC request to the node at http://127.0.0.1:9933.
+ * Send a JSONRPC request to the node at http://0.0.0.0:9933.
  *
  * @param method - The JSONRPC request method.
  * @param params - The JSONRPC request params.
@@ -20,7 +20,7 @@ export function rpcToLocalNode(
 	method: string,
 	params: any[] = []
 ): Promise<any> {
-	return fetch('http://127.0.0.1:9933', {
+	return fetch('http://0.0.0.0:9933', {
 		body: JSON.stringify({
 			id: 1,
 			jsonrpc: '2.0',

--- a/packages/txwrapper-template/examples/util.ts
+++ b/packages/txwrapper-template/examples/util.ts
@@ -11,7 +11,7 @@ import { createMetadata, OptionsWithMeta } from '@substrate/txwrapper-polkadot';
 import fetch from 'node-fetch';
 
 /**
- * Send a JSONRPC request to the node at http://localhost:9933.
+ * Send a JSONRPC request to the node at http://127.0.0.1:9933.
  *
  * @param method - The JSONRPC request method.
  * @param params - The JSONRPC request params.
@@ -20,7 +20,7 @@ export function rpcToLocalNode(
 	method: string,
 	params: any[] = []
 ): Promise<any> {
-	return fetch('http://localhost:9933', {
+	return fetch('http://127.0.0.1:9933', {
 		body: JSON.stringify({
 			id: 1,
 			jsonrpc: '2.0',


### PR DESCRIPTION
### Issue
When I first tried to run the examples, `txwrapper` could not connect to my local running node and I was getting the following error :
```
FetchError: request to http://localhost:9933/ failed, reason: connect ECONNREFUSED ::1:9933 at ClientRequest <anonymous>
```
### Proposed Solution 
As soon as I replaced in this [line](https://github.com/paritytech/txwrapper-core/blob/d590b0912ee0bf9f357233024c064138cff36cd2/packages/txwrapper-examples/src/util.ts#L23) of code, the `localhost` with `127.0.0.1` or `0.0.0.0`, the connection was established successfully and I could also run the examples.

### Cause of the problem
I suspect that the error appears due to some kind of local settings I have (in vscode or node-js or lack of some dns settings) so it is not an actual error in the code. However, I thought it would be a good practice to still `fetch` from `127.0.0.1` or `0.0.0.0` instead of `localhost` so that is why I opened the current PR. 
