### PR TITLE
Update polkadot deps 14 march 2022

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,19 +20,19 @@
     "docs": "typedoc"
   },
   "resolutions": {
-    "@polkadot/api": "^7.11.1",
-    "@polkadot/keyring": "8.4.1",
-    "@polkadot/networks": "8.4.1",
-    "@polkadot/types": "7.11.1",
-    "@polkadot/types-known": "7.11.1",
-    "@polkadot/util": "8.4.1",
-    "@polkadot/util-crypto": "8.4.1",
-    "@polkadot/wasm-crypto": "4.5.1",
-    "@polkadot/apps-config": "^0.108.1"
+    "@polkadot/api": "^7.12.1",
+    "@polkadot/keyring": "8.5.1",
+    "@polkadot/networks": "^8.5.1",
+    "@polkadot/types": "7.12.1",
+    "@polkadot/types-known": "7.12.1",
+    "@polkadot/util": "8.5.1",
+    "@polkadot/util-crypto": "8.5.1",
+    "@polkadot/wasm-crypto": "4.6.1",
+    "@polkadot/apps-config": "^0.109.1"
   },
   "devDependencies": {
     "@babel/plugin-transform-modules-commonjs": "^7.15.4",
-    "@polkadot/util-crypto": "^8.4.1",
+    "@polkadot/util-crypto": "^8.5.1",
     "@substrate/dev": "^0.5.6",
     "@types/jest": "^27.0.1",
     "@typescript-eslint/eslint-plugin": "^4.31.1",

--- a/packages/txwrapper-core/package.json
+++ b/packages/txwrapper-core/package.json
@@ -18,7 +18,7 @@
     "build": "yarn build:workspace"
   },
   "dependencies": {
-    "@polkadot/api": "^7.11.1",
+    "@polkadot/api": "^7.12.1",
     "memoizee": "0.4.15"
   },
   "devDependencies": {

--- a/packages/txwrapper-examples/package.json
+++ b/packages/txwrapper-examples/package.json
@@ -19,7 +19,7 @@
     "mandala": "node lib/mandala"
   },
   "dependencies": {
-    "@polkadot/api": "^7.11.1",
+    "@polkadot/api": "^7.12.1",
     "@substrate/txwrapper-polkadot": "^1.5.6",
     "@substrate/txwrapper-registry": "^1.5.6"
   }

--- a/packages/txwrapper-registry/package.json
+++ b/packages/txwrapper-registry/package.json
@@ -18,8 +18,8 @@
     "build": "yarn build:workspace"
   },
   "dependencies": {
-    "@polkadot/apps-config": "^0.108.1",
-    "@polkadot/networks": "^8.4.1",
+    "@polkadot/apps-config": "^0.109.1",
+    "@polkadot/networks": "^8.5.1",
     "@substrate/txwrapper-core": "^1.5.6"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2456,7 +2456,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@substrate/txwrapper-core@workspace:packages/txwrapper-core"
   dependencies:
-    "@polkadot/api": ^7.11.1
+    "@polkadot/api": ^7.12.1
     "@types/memoizee": ^0.4.3
     memoizee: 0.4.15
   languageName: unknown
@@ -2466,7 +2466,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@substrate/txwrapper-examples@workspace:packages/txwrapper-examples"
   dependencies:
-    "@polkadot/api": ^7.11.1
+    "@polkadot/api": ^7.12.1
     "@substrate/txwrapper-polkadot": ^1.5.6
     "@substrate/txwrapper-registry": ^1.5.6
   languageName: unknown
@@ -2494,8 +2494,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@substrate/txwrapper-registry@workspace:packages/txwrapper-registry"
   dependencies:
-    "@polkadot/apps-config": ^0.108.1
-    "@polkadot/networks": ^8.4.1
+    "@polkadot/apps-config": ^0.109.1
+    "@polkadot/networks": ^8.5.1
     "@substrate/txwrapper-core": ^1.5.6
   languageName: unknown
   linkType: soft
@@ -10173,7 +10173,7 @@ fsevents@^2.3.2:
   resolution: "txwrapper-core@workspace:."
   dependencies:
     "@babel/plugin-transform-modules-commonjs": ^7.15.4
-    "@polkadot/util-crypto": ^8.4.1
+    "@polkadot/util-crypto": ^8.5.1
     "@substrate/dev": ^0.5.6
     "@types/jest": ^27.0.1
     "@typescript-eslint/eslint-plugin": ^4.31.1

--- a/yarn.lock
+++ b/yarn.lock
@@ -407,7 +407,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/runtime@npm:^7.12.0, @babel/runtime@npm:^7.16.3, @babel/runtime@npm:^7.17.2, @babel/runtime@npm:^7.9.6":
+"@babel/runtime@npm:^7.16.3, @babel/runtime@npm:^7.17.2, @babel/runtime@npm:^7.9.6":
   version: 7.17.2
   resolution: "@babel/runtime@npm:7.17.2"
   dependencies:
@@ -1615,10 +1615,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@noble/secp256k1@npm:1.5.2":
-  version: 1.5.2
-  resolution: "@noble/secp256k1@npm:1.5.2"
-  checksum: 9514a9bb08275e25b9e4a2cde4d03823102a50e0ee31dde165ed9536f39aa1879b236cdf69c84b9267d73ce1a39bbb1d44457191dd57f963d0f9c3d038ccd28b
+"@noble/secp256k1@npm:1.5.5":
+  version: 1.5.5
+  resolution: "@noble/secp256k1@npm:1.5.5"
+  checksum: 8a144e8469b29e94107ca4bcf442fc5d9410974239f8e42013f8604d602ab73cfc0c113c24170d41c25e2c40d6d1c46319c439c3bc26a7581c79060fabc3ea8c
   languageName: node
   linkType: hard
 
@@ -1886,12 +1886,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@parallel-finance/type-definitions@npm:1.5.4":
-  version: 1.5.4
-  resolution: "@parallel-finance/type-definitions@npm:1.5.4"
+"@parallel-finance/type-definitions@npm:1.5.7":
+  version: 1.5.7
+  resolution: "@parallel-finance/type-definitions@npm:1.5.7"
   dependencies:
     "@open-web3/orml-type-definitions": ^1.0.2-3
-  checksum: 8140026b920e89e7e6c3f1b424a1c23edf735ab0eedee8dcc4ed5a72d58d310b76a5a5a2c3fa8841c54dcab58a2a692a9fc2c38c257578e56fac0cf1834c2b3b
+  checksum: d4a45c6838d911957973b4aecd6445951528c9aa0c2ecf6735123bbf68f354a6a5663eb843b185c927ad1095b5e903ad922cfffcabc9449933d979d3c43c5216
   languageName: node
   linkType: hard
 
@@ -1902,80 +1902,80 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@polkadot/api-augment@npm:7.11.1":
-  version: 7.11.1
-  resolution: "@polkadot/api-augment@npm:7.11.1"
+"@polkadot/api-augment@npm:7.12.1":
+  version: 7.12.1
+  resolution: "@polkadot/api-augment@npm:7.12.1"
   dependencies:
     "@babel/runtime": ^7.17.2
-    "@polkadot/api-base": 7.11.1
-    "@polkadot/rpc-augment": 7.11.1
-    "@polkadot/types": 7.11.1
-    "@polkadot/types-augment": 7.11.1
-    "@polkadot/types-codec": 7.11.1
-    "@polkadot/util": ^8.4.1
-  checksum: 376fef0b3063b2fe78d579aaff78e2f19fb63b19bad1e25f6e1afb0c22cc14883633d091fb4074945801ba4dcdb3fa5bae65b217942a0b277fdee0643dd7cd92
+    "@polkadot/api-base": 7.12.1
+    "@polkadot/rpc-augment": 7.12.1
+    "@polkadot/types": 7.12.1
+    "@polkadot/types-augment": 7.12.1
+    "@polkadot/types-codec": 7.12.1
+    "@polkadot/util": ^8.5.1
+  checksum: 4330f854ccf12a19e1a3e46690a831936e949b63a111406c077440632b6d2a961378bbb0067124a2bfe556b31becd8717879c4eed1e1a031fd1ff84769378626
   languageName: node
   linkType: hard
 
-"@polkadot/api-base@npm:7.11.1":
-  version: 7.11.1
-  resolution: "@polkadot/api-base@npm:7.11.1"
+"@polkadot/api-base@npm:7.12.1":
+  version: 7.12.1
+  resolution: "@polkadot/api-base@npm:7.12.1"
   dependencies:
     "@babel/runtime": ^7.17.2
-    "@polkadot/rpc-core": 7.11.1
-    "@polkadot/types": 7.11.1
-    "@polkadot/util": ^8.4.1
-    rxjs: ^7.5.4
-  checksum: e5a5e9b3af5732cfa6332057a85a9e08e3866ef4315c6f34cd240479a8e9004228fc3c1b4e4b8d406e85ff15d6c761f6d8e3222a25b9df2df9a65603695d3027
+    "@polkadot/rpc-core": 7.12.1
+    "@polkadot/types": 7.12.1
+    "@polkadot/util": ^8.5.1
+    rxjs: ^7.5.5
+  checksum: cd6cfa7b3774a5e9e5e8c893f1594d1710b50f3182f41fe381bc6a82230c1d0aaab2f41a63b2a61fe79aeae109bdb2dd10eaaa7f323f33fc01666a1abc57c682
   languageName: node
   linkType: hard
 
-"@polkadot/api-derive@npm:7.11.1, @polkadot/api-derive@npm:^7.11.1":
-  version: 7.11.1
-  resolution: "@polkadot/api-derive@npm:7.11.1"
+"@polkadot/api-derive@npm:7.12.1, @polkadot/api-derive@npm:^7.12.1":
+  version: 7.12.1
+  resolution: "@polkadot/api-derive@npm:7.12.1"
   dependencies:
     "@babel/runtime": ^7.17.2
-    "@polkadot/api": 7.11.1
-    "@polkadot/api-augment": 7.11.1
-    "@polkadot/api-base": 7.11.1
-    "@polkadot/rpc-core": 7.11.1
-    "@polkadot/types": 7.11.1
-    "@polkadot/types-codec": 7.11.1
-    "@polkadot/util": ^8.4.1
-    "@polkadot/util-crypto": ^8.4.1
-    rxjs: ^7.5.4
-  checksum: 80993ef5b448db9824f51d9df231ecb1fce7c8e8b1cbaf74481fadd1113c74420748baeb46b1ad8faf8c3c1796ef168c230b9f24d946aa79ad508e77f60dad61
+    "@polkadot/api": 7.12.1
+    "@polkadot/api-augment": 7.12.1
+    "@polkadot/api-base": 7.12.1
+    "@polkadot/rpc-core": 7.12.1
+    "@polkadot/types": 7.12.1
+    "@polkadot/types-codec": 7.12.1
+    "@polkadot/util": ^8.5.1
+    "@polkadot/util-crypto": ^8.5.1
+    rxjs: ^7.5.5
+  checksum: 871e563064750f18c5ba4c1565bbd343ddba880ac2f5b539531dccf9348f8c234f8f8699b6269a06cd735890f0ac10fcd9ec78ede3a7ec0efb41bea29e403a3b
   languageName: node
   linkType: hard
 
-"@polkadot/api@npm:^7.11.1":
-  version: 7.11.1
-  resolution: "@polkadot/api@npm:7.11.1"
+"@polkadot/api@npm:^7.12.1":
+  version: 7.12.1
+  resolution: "@polkadot/api@npm:7.12.1"
   dependencies:
     "@babel/runtime": ^7.17.2
-    "@polkadot/api-augment": 7.11.1
-    "@polkadot/api-base": 7.11.1
-    "@polkadot/api-derive": 7.11.1
-    "@polkadot/keyring": ^8.4.1
-    "@polkadot/rpc-augment": 7.11.1
-    "@polkadot/rpc-core": 7.11.1
-    "@polkadot/rpc-provider": 7.11.1
-    "@polkadot/types": 7.11.1
-    "@polkadot/types-augment": 7.11.1
-    "@polkadot/types-codec": 7.11.1
-    "@polkadot/types-create": 7.11.1
-    "@polkadot/types-known": 7.11.1
-    "@polkadot/util": ^8.4.1
-    "@polkadot/util-crypto": ^8.4.1
+    "@polkadot/api-augment": 7.12.1
+    "@polkadot/api-base": 7.12.1
+    "@polkadot/api-derive": 7.12.1
+    "@polkadot/keyring": ^8.5.1
+    "@polkadot/rpc-augment": 7.12.1
+    "@polkadot/rpc-core": 7.12.1
+    "@polkadot/rpc-provider": 7.12.1
+    "@polkadot/types": 7.12.1
+    "@polkadot/types-augment": 7.12.1
+    "@polkadot/types-codec": 7.12.1
+    "@polkadot/types-create": 7.12.1
+    "@polkadot/types-known": 7.12.1
+    "@polkadot/util": ^8.5.1
+    "@polkadot/util-crypto": ^8.5.1
     eventemitter3: ^4.0.7
-    rxjs: ^7.5.4
-  checksum: 3c4601528958e3e5e01a5fe0898dba44380a1fb5484097f4223e0945eb9ef5db54dfdaf186d235acbbb87729573beea47523e023df6c73a03c9cea59d95588b8
+    rxjs: ^7.5.5
+  checksum: 0895fd7beaf3ae7b85a107edf6ac610f7ab6d035dd2cd1c91737e06af40fb35f6a72c40e0db8b1cc4867a5f514076a16887e8280c82cc4b2f2582b179b212488
   languageName: node
   linkType: hard
 
-"@polkadot/apps-config@npm:^0.108.1":
-  version: 0.108.1
-  resolution: "@polkadot/apps-config@npm:0.108.1"
+"@polkadot/apps-config@npm:^0.109.1":
+  version: 0.109.1
+  resolution: "@polkadot/apps-config@npm:0.109.1"
   dependencies:
     "@acala-network/type-definitions": ^3.0.2-4
     "@babel/runtime": ^7.17.2
@@ -1990,146 +1990,146 @@ __metadata:
     "@kiltprotocol/type-definitions": 0.1.23
     "@laminar/type-definitions": 0.3.1
     "@metaverse-network-sdk/type-definitions": ^0.0.1-6
-    "@parallel-finance/type-definitions": 1.5.4
+    "@parallel-finance/type-definitions": 1.5.7
     "@phala/typedefs": 0.2.30
-    "@polkadot/api": ^7.11.1
-    "@polkadot/api-derive": ^7.11.1
-    "@polkadot/networks": ^8.4.1
-    "@polkadot/types": ^7.11.1
-    "@polkadot/util": ^8.4.1
-    "@polkadot/x-fetch": ^8.4.1
+    "@polkadot/api": ^7.12.1
+    "@polkadot/api-derive": ^7.12.1
+    "@polkadot/networks": ^8.5.1
+    "@polkadot/types": ^7.12.1
+    "@polkadot/util": ^8.5.1
+    "@polkadot/x-fetch": ^8.5.1
     "@polymathnetwork/polymesh-types": 0.0.2
     "@snowfork/snowbridge-types": 0.2.7
-    "@sora-substrate/type-definitions": 1.7.48
+    "@sora-substrate/type-definitions": 1.7.49
     "@subsocial/types": 0.6.5
     "@unique-nft/types": 0.3.1
     "@zeitgeistpm/type-defs": 0.4.5
     "@zeroio/type-definitions": 0.0.14
-    i18next: ^21.6.13
+    i18next: ^21.6.14
     lodash: ^4.17.21
     moonbeam-types-bundle: 2.0.3
     pontem-types-bundle: 1.0.15
-    rxjs: ^7.5.4
-  checksum: 731935e01b3bad322c49e5f92d389b257a4edd3a90ca7cebd01347420aeb070e55ca06e2908a0ac7aaf758235b77d082467d7d2330e727c9dc528b6c3d375ece
+    rxjs: ^7.5.5
+  checksum: 84a5320bdb843fce2c6a0e3014ba93297cbfdb23a40b7330ca13cd76b152537ef5bbb2f7944d54840ca944b4e91d88b322148210ad362952b99258ac4624beda
   languageName: node
   linkType: hard
 
-"@polkadot/keyring@npm:8.4.1":
-  version: 8.4.1
-  resolution: "@polkadot/keyring@npm:8.4.1"
+"@polkadot/keyring@npm:8.5.1":
+  version: 8.5.1
+  resolution: "@polkadot/keyring@npm:8.5.1"
   dependencies:
     "@babel/runtime": ^7.17.2
-    "@polkadot/util": 8.4.1
-    "@polkadot/util-crypto": 8.4.1
+    "@polkadot/util": 8.5.1
+    "@polkadot/util-crypto": 8.5.1
   peerDependencies:
-    "@polkadot/util": 8.4.1
-    "@polkadot/util-crypto": 8.4.1
-  checksum: 0608648e0fcc5a3c8994b12384dc2426b9b4e8ba3097e01a61cbd2226169d4526c68e201229b05b275f243de610c8f57079a2911b60dfdd3737a1617bc2b4dc0
+    "@polkadot/util": 8.5.1
+    "@polkadot/util-crypto": 8.5.1
+  checksum: 24884985bebb0cfa759e83faebf4987cf96acffc0cedb5f87dfdd4d7a1fef326307967d7934755720062def7979b62127ad0a70a44d31875820e5cdb245b8a33
   languageName: node
   linkType: hard
 
-"@polkadot/networks@npm:8.4.1":
-  version: 8.4.1
-  resolution: "@polkadot/networks@npm:8.4.1"
+"@polkadot/networks@npm:^8.5.1":
+  version: 8.5.1
+  resolution: "@polkadot/networks@npm:8.5.1"
   dependencies:
     "@babel/runtime": ^7.17.2
-    "@polkadot/util": 8.4.1
-    "@substrate/ss58-registry": ^1.14.0
-  checksum: c80b0c266544287ba47ba4d1410b86adc8c1814efe8d5704c17a1731773d9892ae5259e7e7cf42e6c86ae555ed7e4a955efaf51fe0306ad7477513b7810f5df5
+    "@polkadot/util": 8.5.1
+    "@substrate/ss58-registry": ^1.16.0
+  checksum: f6eafb87b21baa69515291049262f17873b80515f882974d6c9515ef44529d7037e3268d8989050c2976ddeb4823092b1aea65b152b6e761fdcbed2c8cd775b6
   languageName: node
   linkType: hard
 
-"@polkadot/rpc-augment@npm:7.11.1":
-  version: 7.11.1
-  resolution: "@polkadot/rpc-augment@npm:7.11.1"
+"@polkadot/rpc-augment@npm:7.12.1":
+  version: 7.12.1
+  resolution: "@polkadot/rpc-augment@npm:7.12.1"
   dependencies:
     "@babel/runtime": ^7.17.2
-    "@polkadot/rpc-core": 7.11.1
-    "@polkadot/types": 7.11.1
-    "@polkadot/types-codec": 7.11.1
-    "@polkadot/util": ^8.4.1
-  checksum: b258009145c848292ee4f738bc16d06542dab25c848d8daff132b2c175a36e9a1f5d32596415cd32bce24778fcb3a9a8b7b1fde8c9e2ab448d66296f7a20a146
+    "@polkadot/rpc-core": 7.12.1
+    "@polkadot/types": 7.12.1
+    "@polkadot/types-codec": 7.12.1
+    "@polkadot/util": ^8.5.1
+  checksum: 2ea961aee478ae4ffb565b3510cc499a6af61e3ac9221f42ff27c7e83e39d96e055b67e38fa05e164c76534b092ac8dacb4a5efe7ad4a1b94ec0d88195c36adc
   languageName: node
   linkType: hard
 
-"@polkadot/rpc-core@npm:7.11.1":
-  version: 7.11.1
-  resolution: "@polkadot/rpc-core@npm:7.11.1"
+"@polkadot/rpc-core@npm:7.12.1":
+  version: 7.12.1
+  resolution: "@polkadot/rpc-core@npm:7.12.1"
   dependencies:
     "@babel/runtime": ^7.17.2
-    "@polkadot/rpc-augment": 7.11.1
-    "@polkadot/rpc-provider": 7.11.1
-    "@polkadot/types": 7.11.1
-    "@polkadot/util": ^8.4.1
-    rxjs: ^7.5.4
-  checksum: 720592664f452f100029cc708b42c3de876364ff797fc21bfa4a6b927c07099eeaf17b5a92edea83e4a5f84fe53a310927cf35446603452387d14df9602b945b
+    "@polkadot/rpc-augment": 7.12.1
+    "@polkadot/rpc-provider": 7.12.1
+    "@polkadot/types": 7.12.1
+    "@polkadot/util": ^8.5.1
+    rxjs: ^7.5.5
+  checksum: c05efc30891d2194dc76a212e9535ee2597210585e3cf80bea64f9126bc8fec528ab0d53f527f8d39badf1b4af986272f0c1bc813b0c7c7d3546ac824b032d2d
   languageName: node
   linkType: hard
 
-"@polkadot/rpc-provider@npm:7.11.1":
-  version: 7.11.1
-  resolution: "@polkadot/rpc-provider@npm:7.11.1"
+"@polkadot/rpc-provider@npm:7.12.1":
+  version: 7.12.1
+  resolution: "@polkadot/rpc-provider@npm:7.12.1"
   dependencies:
     "@babel/runtime": ^7.17.2
-    "@polkadot/keyring": ^8.4.1
-    "@polkadot/types": 7.11.1
-    "@polkadot/types-support": 7.11.1
-    "@polkadot/util": ^8.4.1
-    "@polkadot/util-crypto": ^8.4.1
-    "@polkadot/x-fetch": ^8.4.1
-    "@polkadot/x-global": ^8.4.1
-    "@polkadot/x-ws": ^8.4.1
+    "@polkadot/keyring": ^8.5.1
+    "@polkadot/types": 7.12.1
+    "@polkadot/types-support": 7.12.1
+    "@polkadot/util": ^8.5.1
+    "@polkadot/util-crypto": ^8.5.1
+    "@polkadot/x-fetch": ^8.5.1
+    "@polkadot/x-global": ^8.5.1
+    "@polkadot/x-ws": ^8.5.1
     eventemitter3: ^4.0.7
     mock-socket: ^9.1.2
     nock: ^13.2.4
-  checksum: 225c682da016164a1f9b87c39fc9e2d13a4c3cf98e081fa13faad4e5c53eb99ba327d38f74e0ec7734b2724deb47d63c350c31a9920eb2ae130a5a8e2bf6f6f7
+  checksum: 92aa8033b9594d61f0d094920b5547bf9cc8f6a63667d746adde8396ad70168fe37f4cbf779b6bdda1561b30dd24e42e94477bae22e4b2937ff310339c942b68
   languageName: node
   linkType: hard
 
-"@polkadot/types-augment@npm:7.11.1":
-  version: 7.11.1
-  resolution: "@polkadot/types-augment@npm:7.11.1"
+"@polkadot/types-augment@npm:7.12.1":
+  version: 7.12.1
+  resolution: "@polkadot/types-augment@npm:7.12.1"
   dependencies:
     "@babel/runtime": ^7.17.2
-    "@polkadot/types": 7.11.1
-    "@polkadot/types-codec": 7.11.1
-    "@polkadot/util": ^8.4.1
-  checksum: 6924ab2eb87a44e3da9ba2b58b1dced477c2785c0433eceda5f6ce8f1bac966cc470976cc3aaba7ece5d9c12a42a1727bf154e7a1af7569036a39f4d201580ee
+    "@polkadot/types": 7.12.1
+    "@polkadot/types-codec": 7.12.1
+    "@polkadot/util": ^8.5.1
+  checksum: c9636ead28e15e36872d11946ec71bc53fdbe3d0858fbc90aede36ba7ee857538045518dd25ad3fb7898adb130e7304bd1a4c54ce5decc631268afc548fb9dc0
   languageName: node
   linkType: hard
 
-"@polkadot/types-codec@npm:7.11.1":
-  version: 7.11.1
-  resolution: "@polkadot/types-codec@npm:7.11.1"
+"@polkadot/types-codec@npm:7.12.1":
+  version: 7.12.1
+  resolution: "@polkadot/types-codec@npm:7.12.1"
   dependencies:
     "@babel/runtime": ^7.17.2
-    "@polkadot/util": ^8.4.1
-  checksum: 831b00031c551576e811dc66bfe2c018d5f98d86293b621bbfff4c4c867b6f43525b9baa3db7bc8f1f32c53f34ee892c4648a8093fba952048d99ebf65898c3e
+    "@polkadot/util": ^8.5.1
+  checksum: bd377fd343dbedd3d77245ef155a83959c72cab23157e431d34fd7a476a40f510850361d69f52d7e3fc1fe5374d96a503831bb73a215f13f21fcfa8ea513855a
   languageName: node
   linkType: hard
 
-"@polkadot/types-create@npm:7.11.1":
-  version: 7.11.1
-  resolution: "@polkadot/types-create@npm:7.11.1"
+"@polkadot/types-create@npm:7.12.1":
+  version: 7.12.1
+  resolution: "@polkadot/types-create@npm:7.12.1"
   dependencies:
     "@babel/runtime": ^7.17.2
-    "@polkadot/types-codec": 7.11.1
-    "@polkadot/util": ^8.4.1
-  checksum: b7cb20bd5c9cd33f38063b7cb723229ce288fad90f2e435d51f0e1e30cffdac5b03059aef0325c3fb9f9fad2e9f573dfb72570bc26a94ec5f346c687143c3b4a
+    "@polkadot/types-codec": 7.12.1
+    "@polkadot/util": ^8.5.1
+  checksum: 8a860159f3b2f32d1f869ae9f0779f90dc6d60e71da4053f99084f900f181742e55feb655bfa496b25c50b87b8d259314c51b3353ba5adff01cd44d604dc97be
   languageName: node
   linkType: hard
 
-"@polkadot/types-known@npm:7.11.1":
-  version: 7.11.1
-  resolution: "@polkadot/types-known@npm:7.11.1"
+"@polkadot/types-known@npm:7.12.1":
+  version: 7.12.1
+  resolution: "@polkadot/types-known@npm:7.12.1"
   dependencies:
     "@babel/runtime": ^7.17.2
-    "@polkadot/networks": ^8.4.1
-    "@polkadot/types": 7.11.1
-    "@polkadot/types-codec": 7.11.1
-    "@polkadot/types-create": 7.11.1
-    "@polkadot/util": ^8.4.1
-  checksum: 7e37205929eacb333e50b8908736df8a6df9b3961c0232f3f576f2aa822fe0c3c2c145f536728fdfee0a0d39e783c18c207ca1833404c62a46f43fcae640d01b
+    "@polkadot/networks": ^8.5.1
+    "@polkadot/types": 7.12.1
+    "@polkadot/types-codec": 7.12.1
+    "@polkadot/types-create": 7.12.1
+    "@polkadot/util": ^8.5.1
+  checksum: fb929773568e3972ba01624aaae541b0cc31f9e0fc3ddefe7b6c1959eadcb8a7051d8f508b914c42ec116e6ce7f4c3b275c15af6fce65841979c9039f5706070
   languageName: node
   linkType: hard
 
@@ -2143,171 +2143,175 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@polkadot/types-support@npm:7.11.1":
-  version: 7.11.1
-  resolution: "@polkadot/types-support@npm:7.11.1"
+"@polkadot/types-support@npm:7.12.1":
+  version: 7.12.1
+  resolution: "@polkadot/types-support@npm:7.12.1"
   dependencies:
     "@babel/runtime": ^7.17.2
-    "@polkadot/util": ^8.4.1
-  checksum: 096fa261d7fa0f9d92034d69beec1e5f1c99fa4ef43a96984e258134529437cdcbae169215be842c72723b49d5b23cc7d4307fa7c398b4275c9ab08d7868eba9
+    "@polkadot/util": ^8.5.1
+  checksum: 9c41f7a02825efa2b8311d3edd99324578499dea8de006596e41fb297c1d07b404437eb0a0ced5af3cf9a28e3bd73480d22a36f597584557e77fd3fd9ab0d9da
   languageName: node
   linkType: hard
 
-"@polkadot/types@npm:7.11.1":
-  version: 7.11.1
-  resolution: "@polkadot/types@npm:7.11.1"
+"@polkadot/types@npm:7.12.1":
+  version: 7.12.1
+  resolution: "@polkadot/types@npm:7.12.1"
   dependencies:
     "@babel/runtime": ^7.17.2
-    "@polkadot/keyring": ^8.4.1
-    "@polkadot/types-augment": 7.11.1
-    "@polkadot/types-codec": 7.11.1
-    "@polkadot/types-create": 7.11.1
-    "@polkadot/util": ^8.4.1
-    "@polkadot/util-crypto": ^8.4.1
-    rxjs: ^7.5.4
-  checksum: a19203fb2e93e75315d60130c973e68d369f02baff5f89bdd63c896573bfa36ce25c32468dbd0d147970897cec8cc274ac58eccb39a67de316f456fe590bb372
+    "@polkadot/keyring": ^8.5.1
+    "@polkadot/types-augment": 7.12.1
+    "@polkadot/types-codec": 7.12.1
+    "@polkadot/types-create": 7.12.1
+    "@polkadot/util": ^8.5.1
+    "@polkadot/util-crypto": ^8.5.1
+    rxjs: ^7.5.5
+  checksum: f935285cbc1fedda4af25b78871c608d22810dc55e1c8895ef574ac1cebc39bf05e78d1bc028befea9796d3c26190bd21ea2f823a57955ea2eca62b5cf1227f0
   languageName: node
   linkType: hard
 
-"@polkadot/util-crypto@npm:8.4.1":
-  version: 8.4.1
-  resolution: "@polkadot/util-crypto@npm:8.4.1"
+"@polkadot/util-crypto@npm:8.5.1":
+  version: 8.5.1
+  resolution: "@polkadot/util-crypto@npm:8.5.1"
   dependencies:
     "@babel/runtime": ^7.17.2
     "@noble/hashes": 1.0.0
-    "@noble/secp256k1": 1.5.2
-    "@polkadot/networks": 8.4.1
-    "@polkadot/util": 8.4.1
-    "@polkadot/wasm-crypto": ^4.5.1
-    "@polkadot/x-bigint": 8.4.1
-    "@polkadot/x-randomvalues": 8.4.1
+    "@noble/secp256k1": 1.5.5
+    "@polkadot/networks": 8.5.1
+    "@polkadot/util": 8.5.1
+    "@polkadot/wasm-crypto": ^4.6.1
+    "@polkadot/x-bigint": 8.5.1
+    "@polkadot/x-randomvalues": 8.5.1
     "@scure/base": 1.0.0
     ed2curve: ^0.3.0
     tweetnacl: ^1.0.3
   peerDependencies:
-    "@polkadot/util": 8.4.1
-  checksum: 19e23d88c3552d15decaa6cb354f7534864172a430e2e3c8cdf1e8c6946f19e259d871e27c00fcf72670becdec944346d469e0b6b2de7f19da370ddd4ee85b59
+    "@polkadot/util": 8.5.1
+  checksum: 80e3fe141ebb8273701d8b3f8d36c9416b47846a7bb8843a410a96e896727b38407238a3e16a7f380aa33a413fe2f4042ed972aea1576a5205784cc9e652b75d
   languageName: node
   linkType: hard
 
-"@polkadot/util@npm:8.4.1":
-  version: 8.4.1
-  resolution: "@polkadot/util@npm:8.4.1"
+"@polkadot/util@npm:8.5.1":
+  version: 8.5.1
+  resolution: "@polkadot/util@npm:8.5.1"
   dependencies:
     "@babel/runtime": ^7.17.2
-    "@polkadot/x-bigint": 8.4.1
-    "@polkadot/x-global": 8.4.1
-    "@polkadot/x-textdecoder": 8.4.1
-    "@polkadot/x-textencoder": 8.4.1
+    "@polkadot/x-bigint": 8.5.1
+    "@polkadot/x-global": 8.5.1
+    "@polkadot/x-textdecoder": 8.5.1
+    "@polkadot/x-textencoder": 8.5.1
     "@types/bn.js": ^5.1.0
     bn.js: ^5.2.0
     ip-regex: ^4.3.0
-  checksum: 3699147c8f23846e3b8f8560d553ce9902412bde092f724c719fbbfcffb5a538e87a9923018b2ef53357ae04296e438eee39d3e328dbd9060ea664649e1990c5
+  checksum: 089dadfab22ebb8351da2bab8e2272ca210429ec85b66665590275db65b2ac0fc482e710247f512f6adf64b5d6c6a49a1cef7d7b964a8ff68c42984e53befcba
   languageName: node
   linkType: hard
 
-"@polkadot/wasm-crypto-asmjs@npm:^4.5.1":
-  version: 4.5.1
-  resolution: "@polkadot/wasm-crypto-asmjs@npm:4.5.1"
+"@polkadot/wasm-crypto-asmjs@npm:^4.6.1":
+  version: 4.6.1
+  resolution: "@polkadot/wasm-crypto-asmjs@npm:4.6.1"
   dependencies:
-    "@babel/runtime": ^7.16.3
-  checksum: 93233bc91043c0023466def87a4559b98908841f0628544fcc77f4599acda1d4a0c2673948021de8b5da0c5dd10ef10a01141dfb960d5c32d95b81ac1060cfe5
+    "@babel/runtime": ^7.17.2
+  peerDependencies:
+    "@polkadot/util": "*"
+  checksum: b5b0cba3a71e614a0d6eafd9fd51a1432f21c2834fd91c8c42399eee3a1ec761b5234528057a66ef1a730642f8afa5067eb670f97e1174a7657818ecf4d328f5
   languageName: node
   linkType: hard
 
-"@polkadot/wasm-crypto-wasm@npm:^4.5.1":
-  version: 4.5.1
-  resolution: "@polkadot/wasm-crypto-wasm@npm:4.5.1"
+"@polkadot/wasm-crypto-wasm@npm:^4.6.1":
+  version: 4.6.1
+  resolution: "@polkadot/wasm-crypto-wasm@npm:4.6.1"
   dependencies:
-    "@babel/runtime": ^7.16.3
-  checksum: b44833a47f87af19b8724d310e64a10c8a3a4499d6af247d48e76dfe0dbbf5c40a21681dbb97297f1ea31a0d66518093ed14509ace16087293cf93e97b28ee73
+    "@babel/runtime": ^7.17.2
+  peerDependencies:
+    "@polkadot/util": "*"
+  checksum: 5b896a8c0fc025e8999689f89bea4c8437228f37ed8bb267749b1786e4b5c40c80b321d8bdc45fd3f69bfc64a74c015db023454ee574f18b4b82fcb4aea76f38
   languageName: node
   linkType: hard
 
-"@polkadot/wasm-crypto@npm:4.5.1":
-  version: 4.5.1
-  resolution: "@polkadot/wasm-crypto@npm:4.5.1"
+"@polkadot/wasm-crypto@npm:4.6.1":
+  version: 4.6.1
+  resolution: "@polkadot/wasm-crypto@npm:4.6.1"
   dependencies:
-    "@babel/runtime": ^7.16.3
-    "@polkadot/wasm-crypto-asmjs": ^4.5.1
-    "@polkadot/wasm-crypto-wasm": ^4.5.1
+    "@babel/runtime": ^7.17.2
+    "@polkadot/wasm-crypto-asmjs": ^4.6.1
+    "@polkadot/wasm-crypto-wasm": ^4.6.1
   peerDependencies:
     "@polkadot/util": "*"
     "@polkadot/x-randomvalues": "*"
-  checksum: d73b8696c3aa9b9bb18a1914b11ca0133d9189fd9264170912228c497517997d2b8f5f8b19eb5b1a8ef1be9edbdd63d2013633c0262167b61e2afc6333feef91
+  checksum: 785b2261d8363687c67e16c8e09f9342460228bce9069870c77d4d1d6b77d4c0a14436e2d94b03c228ffc184a6a6628c15f46672be09aafa6112d2247b8c81a5
   languageName: node
   linkType: hard
 
-"@polkadot/x-bigint@npm:8.4.1":
-  version: 8.4.1
-  resolution: "@polkadot/x-bigint@npm:8.4.1"
+"@polkadot/x-bigint@npm:8.5.1":
+  version: 8.5.1
+  resolution: "@polkadot/x-bigint@npm:8.5.1"
   dependencies:
     "@babel/runtime": ^7.17.2
-    "@polkadot/x-global": 8.4.1
-  checksum: fe3acdce1e1ac39cdee6531ec6a0a32316d86587e1ad0b0e22ae9a3e8fdeaf8046bfcc9867d8f93c94526eb389f821cc59303b38a234cb62d0d45ed7d986f54d
+    "@polkadot/x-global": 8.5.1
+  checksum: 72e4b8b4626e230f76adb6f840230bdb6b6d8a89ab9ec75be0d798accb16e1ae3a6c93b0a6358dac6ac2b3fe4c42d353a00384d07a8c3ac40b245047ce63e1f7
   languageName: node
   linkType: hard
 
-"@polkadot/x-fetch@npm:^8.4.1":
-  version: 8.4.1
-  resolution: "@polkadot/x-fetch@npm:8.4.1"
+"@polkadot/x-fetch@npm:^8.5.1":
+  version: 8.5.1
+  resolution: "@polkadot/x-fetch@npm:8.5.1"
   dependencies:
     "@babel/runtime": ^7.17.2
-    "@polkadot/x-global": 8.4.1
-    "@types/node-fetch": ^2.5.12
+    "@polkadot/x-global": 8.5.1
+    "@types/node-fetch": ^2.6.1
     node-fetch: ^2.6.7
-  checksum: f4eddf58e814570638cd3688c33be051993bcbe9b5091ba8eb718ca6f85efc345c27a26fb36277b8ad9a0cd95262590888fe4f38a64ea15311d12a26116e0087
+  checksum: 4f598556461c8979eed6a957332d83d58512bcdc61eb86b4872021fb65f6a9259eb4d0932f69aff4df51f651b7add12ac963eba6e39494c1343f2083dce7fe14
   languageName: node
   linkType: hard
 
-"@polkadot/x-global@npm:8.4.1, @polkadot/x-global@npm:^8.4.1":
-  version: 8.4.1
-  resolution: "@polkadot/x-global@npm:8.4.1"
+"@polkadot/x-global@npm:8.5.1, @polkadot/x-global@npm:^8.5.1":
+  version: 8.5.1
+  resolution: "@polkadot/x-global@npm:8.5.1"
   dependencies:
     "@babel/runtime": ^7.17.2
-  checksum: 39e4e661843c782420e73a2a384872403394d6b18e1fdfdc2996223df2ea5ce3a78aa616df9836567f5e83dc6a13b0b2a2d5126be5fc17c94312c837a066b068
+  checksum: 7937f11327af5f9cd214ec34f136fd24f5ae6b375fb716fa4e8c67193f1a036afab1225169e72c84e9cb3d28f08d3043cfc3840ccd1c52f5c39177a0a70f375c
   languageName: node
   linkType: hard
 
-"@polkadot/x-randomvalues@npm:8.4.1":
-  version: 8.4.1
-  resolution: "@polkadot/x-randomvalues@npm:8.4.1"
+"@polkadot/x-randomvalues@npm:8.5.1":
+  version: 8.5.1
+  resolution: "@polkadot/x-randomvalues@npm:8.5.1"
   dependencies:
     "@babel/runtime": ^7.17.2
-    "@polkadot/x-global": 8.4.1
-  checksum: 3f2cbdbcf2e65e718736a05a171a15e93954756065fb55b2d21e04b3a986aa283704535102943eedd840330d676f72503dd19980b37a8c3fa9a1c727ccaeca40
+    "@polkadot/x-global": 8.5.1
+  checksum: b90a262adedabea03d19df367a6a192dc6bc322b2374b6f14c6bd4cb06ff6b1a2e81deef414c13b6d3147306e15ed964f9ed2dff4451067541164be942a9d8f9
   languageName: node
   linkType: hard
 
-"@polkadot/x-textdecoder@npm:8.4.1":
-  version: 8.4.1
-  resolution: "@polkadot/x-textdecoder@npm:8.4.1"
+"@polkadot/x-textdecoder@npm:8.5.1":
+  version: 8.5.1
+  resolution: "@polkadot/x-textdecoder@npm:8.5.1"
   dependencies:
     "@babel/runtime": ^7.17.2
-    "@polkadot/x-global": 8.4.1
-  checksum: f3a8a67686dbc8f3f064860fc1260a4f5aaee11e22143400c10e4eb962976c9f94df0edb6deb3c89ee320c1479f1a42420b8a29b73b4b7a02a9b5f4973dbdbc3
+    "@polkadot/x-global": 8.5.1
+  checksum: 00175d0d472fe2f4f26ff4e631aa9fef93a3b146e7bbef0878ed9dc09fce51b43528131ddbaa7ae0c4e7244956e5f46a00602fa72849f01c025c467808ceb487
   languageName: node
   linkType: hard
 
-"@polkadot/x-textencoder@npm:8.4.1":
-  version: 8.4.1
-  resolution: "@polkadot/x-textencoder@npm:8.4.1"
+"@polkadot/x-textencoder@npm:8.5.1":
+  version: 8.5.1
+  resolution: "@polkadot/x-textencoder@npm:8.5.1"
   dependencies:
     "@babel/runtime": ^7.17.2
-    "@polkadot/x-global": 8.4.1
-  checksum: f40b492c370ca99ee3f75a54e966815dc8d8f8132a7c8f6150bb782edfc9ed86d8afe2e59e5f939206eb4fb5ca92433ab9c2deec36e6ff5838a5e3cc7709bdd6
+    "@polkadot/x-global": 8.5.1
+  checksum: 4eddf9a4e0c3a8fb1cd0150acb748cf130dc77b0f1aa96a16352ac5caff5b79cb70ff9fb9c17ef2f26fc1cb4245d51bd4f0b47b1f5193243abe632ff938c8cb5
   languageName: node
   linkType: hard
 
-"@polkadot/x-ws@npm:^8.4.1":
-  version: 8.4.1
-  resolution: "@polkadot/x-ws@npm:8.4.1"
+"@polkadot/x-ws@npm:^8.5.1":
+  version: 8.5.1
+  resolution: "@polkadot/x-ws@npm:8.5.1"
   dependencies:
     "@babel/runtime": ^7.17.2
-    "@polkadot/x-global": 8.4.1
+    "@polkadot/x-global": 8.5.1
     "@types/websocket": ^1.0.5
     websocket: ^1.0.34
-  checksum: 9a5d2215ef172bbd4ac6c1165c0a10f2dc7445e39b512632042a0deec6b9cda18959732909c3b411dda57b211505c9e2f3012e1c9892de470f85c0bed0bd6d38
+  checksum: 56a0bb79a852e1ac6572405e2bbba23334455789f53d1529709d024c6ced4b76fc0e331ca4810c69bd03b00a97b3c6e50d1dea138aaca4a0f69f816d331efc6d
   languageName: node
   linkType: hard
 
@@ -2374,12 +2378,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@sora-substrate/type-definitions@npm:1.7.48":
-  version: 1.7.48
-  resolution: "@sora-substrate/type-definitions@npm:1.7.48"
+"@sora-substrate/type-definitions@npm:1.7.49":
+  version: 1.7.49
+  resolution: "@sora-substrate/type-definitions@npm:1.7.49"
   dependencies:
     "@open-web3/orml-type-definitions": ^0.9.4-35
-  checksum: 0c7d816b4d499d46c1beccc058f737bf34a1aa4f6a6e95c148f495bf185212d0b53338cd10c8584a7dfffc6112de275bfca384469e6ce852f5fccf98da0ca0d5
+  checksum: b6e77270c1b8251973f4704e5f119d1d56b7a6ca2e690631ed0bb2a52032578e7fb2bfbd45b950902da36f37fc3fc9ecbc5b3ea9e22b30d771cdec52ae64c86f
   languageName: node
   linkType: hard
 
@@ -2445,10 +2449,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@substrate/ss58-registry@npm:^1.14.0":
-  version: 1.15.0
-  resolution: "@substrate/ss58-registry@npm:1.15.0"
-  checksum: 37397d038c5024280bd426ecc6e47e16f4a564a59656bc5c0c83935ec04a6dc92832684b93f8c25b0714840ff47c2d4d69478bda68a364eeb9db8891cd8b43df
+"@substrate/ss58-registry@npm:^1.16.0":
+  version: 1.16.0
+  resolution: "@substrate/ss58-registry@npm:1.16.0"
+  checksum: 3777de20eb3be3aa17b088e4786900bc7f57884c660e942596569fe886b4fc9c2381dd480db06ffddad1ab6f108ead3b162f4a8b111f6f8ffbec7982b818a5d6
   languageName: node
   linkType: hard
 
@@ -2665,13 +2669,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/node-fetch@npm:^2.5.12":
-  version: 2.5.12
-  resolution: "@types/node-fetch@npm:2.5.12"
+"@types/node-fetch@npm:^2.6.1":
+  version: 2.6.1
+  resolution: "@types/node-fetch@npm:2.6.1"
   dependencies:
     "@types/node": "*"
     form-data: ^3.0.0
-  checksum: ad63c85ba6a9477b8e057ec8682257738130d98e8ece4e31141789bd99df9d9147985cc8bc0cb5c8983ed5aa6bb95d46df23d1e055f4ad5cf8b82fc69cf626c7
+  checksum: a3e5d7f413d1638d795dff03f7b142b1b0e0c109ed210479000ce7b3ea11f9a6d89d9a024c96578d9249570c5fe5287a5f0f4aaba98199222230196ff2d6b283
   languageName: node
   linkType: hard
 
@@ -5511,12 +5515,12 @@ fsevents@^2.3.2:
   languageName: node
   linkType: hard
 
-"i18next@npm:^21.6.13":
-  version: 21.6.13
-  resolution: "i18next@npm:21.6.13"
+"i18next@npm:^21.6.14":
+  version: 21.6.14
+  resolution: "i18next@npm:21.6.14"
   dependencies:
-    "@babel/runtime": ^7.12.0
-  checksum: ede7280351e4bb63cf746b6772996258771c6ea36921fd700ae8d79b6868f85411031fc3c4169f129dad8e21e52b925447fdb19709b205cbbcffcaf23b86cc0b
+    "@babel/runtime": ^7.17.2
+  checksum: bc6e117874d9b69a39d6ad322851d25f75908c7fa977c8771b98ba7b0273aceba96e82326ed0855b8db098b1490c5a0decbe62b4f61dac84fdc677c2fdc52bb8
   languageName: node
   linkType: hard
 
@@ -9209,12 +9213,12 @@ fsevents@^2.3.2:
   languageName: node
   linkType: hard
 
-"rxjs@npm:^7.5.4":
-  version: 7.5.4
-  resolution: "rxjs@npm:7.5.4"
+"rxjs@npm:^7.5.5":
+  version: 7.5.5
+  resolution: "rxjs@npm:7.5.5"
   dependencies:
     tslib: ^2.1.0
-  checksum: 6f55f835f2543bc8214900f9e28b6320e6adc95875011fbca63e80a66eb18c9ff7cfdccb23b2180cbb6412762b98ed158c89fd51cb020799d127c66ea38c3c0e
+  checksum: e034f60805210cce756dd2f49664a8108780b117cf5d0e2281506e9e6387f7b4f1532d974a8c8b09314fa7a16dd2f6cff3462072a5789672b5dcb45c4173f3c6
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This updates the polkadot-js deps to the following:

    "@polkadot/api": "^7.12.1",
    "@polkadot/keyring": "8.5.1",
    "@polkadot/networks": "^8.5.1",
    "@polkadot/types": "7.12.1",
    "@polkadot/types-known": "7.12.1",
    "@polkadot/util": "8.5.1",
    "@polkadot/util-crypto": "8.5.1",
    "@polkadot/wasm-crypto": "4.6.1",
    "@polkadot/apps-config": "^0.109.1"
    