### PR TITLE
Update polkadot deps 23 march 2022

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,19 +20,19 @@
     "docs": "typedoc"
   },
   "resolutions": {
-    "@polkadot/api": "^7.12.1",
-    "@polkadot/keyring": "8.5.1",
-    "@polkadot/networks": "^8.5.1",
-    "@polkadot/types": "7.12.1",
-    "@polkadot/types-known": "7.12.1",
-    "@polkadot/util": "8.5.1",
-    "@polkadot/util-crypto": "8.5.1",
-    "@polkadot/wasm-crypto": "4.6.1",
-    "@polkadot/apps-config": "^0.109.1"
+    "@polkadot/api": "7.13.1",
+    "@polkadot/keyring": "8.6.1",
+    "@polkadot/networks": "8.6.1",
+    "@polkadot/types": "7.13.1",
+    "@polkadot/types-known": "7.13.1",
+    "@polkadot/util": "8.6.1",
+    "@polkadot/util-crypto": "8.6.1",
+    "@polkadot/wasm-crypto": "5.0.1",
+    "@polkadot/apps-config": "0.110.1"
   },
   "devDependencies": {
     "@babel/plugin-transform-modules-commonjs": "^7.15.4",
-    "@polkadot/util-crypto": "^8.5.1",
+    "@polkadot/util-crypto": "^8.6.1",
     "@substrate/dev": "^0.5.6",
     "@types/jest": "^27.0.1",
     "@typescript-eslint/eslint-plugin": "^4.31.1",

--- a/packages/txwrapper-core/package.json
+++ b/packages/txwrapper-core/package.json
@@ -18,7 +18,7 @@
     "build": "yarn build:workspace"
   },
   "dependencies": {
-    "@polkadot/api": "^7.12.1",
+    "@polkadot/api": "^7.13.1",
     "memoizee": "0.4.15"
   },
   "devDependencies": {

--- a/packages/txwrapper-examples/package.json
+++ b/packages/txwrapper-examples/package.json
@@ -19,7 +19,7 @@
     "mandala": "node lib/mandala"
   },
   "dependencies": {
-    "@polkadot/api": "^7.12.1",
+    "@polkadot/api": "^7.13.1",
     "@substrate/txwrapper-polkadot": "^1.5.7",
     "@substrate/txwrapper-registry": "^1.5.7"
   }

--- a/packages/txwrapper-registry/package.json
+++ b/packages/txwrapper-registry/package.json
@@ -18,8 +18,8 @@
     "build": "yarn build:workspace"
   },
   "dependencies": {
-    "@polkadot/apps-config": "^0.109.1",
-    "@polkadot/networks": "^8.5.1",
+    "@polkadot/apps-config": "^0.110.1",
+    "@polkadot/networks": "^8.6.1",
     "@substrate/txwrapper-core": "^1.5.7"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -14,12 +14,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@acala-network/type-definitions@npm:^3.0.2-4":
-  version: 3.0.2
-  resolution: "@acala-network/type-definitions@npm:3.0.2"
+"@acala-network/type-definitions@npm:^4.0.1":
+  version: 4.0.1
+  resolution: "@acala-network/type-definitions@npm:4.0.1"
   dependencies:
     "@open-web3/orml-type-definitions": ^1.0.2-0
-  checksum: 621254cb540298beefbc60bfb09c9122e237b5122bc3ce3e941a74efe1e501da34a8f17038933befc3b9f3fc0d2404beea04d3f77875dbe3dbf23742e07a51c2
+  checksum: f50cf6b8ebf5d3d0d523c7a1059697ce474c8f7a4cfb02bdacaa12edb2b6865c1f515cae86fc817e6d9dd68f61518a35528ceb7dd58b48a10d657f6959ba6d58
   languageName: node
   linkType: hard
 
@@ -413,6 +413,15 @@ __metadata:
   dependencies:
     regenerator-runtime: ^0.13.4
   checksum: a48702d271ecc59c09c397856407afa29ff980ab537b3da58eeee1aeaa0f545402d340a1680c9af58aec94dfdcbccfb6abb211991b74686a86d03d3f6956cacd
+  languageName: node
+  linkType: hard
+
+"@babel/runtime@npm:^7.17.8":
+  version: 7.17.8
+  resolution: "@babel/runtime@npm:7.17.8"
+  dependencies:
+    regenerator-runtime: ^0.13.4
+  checksum: 68d195c1630bb91ac20e86635d292a17ebab7f361cfe79406b3f5a6cc2e59fa283ae5006568899abf869312c2b35b744bd407aea8ffdb650f1a68d07785d47e9
   languageName: node
   linkType: hard
 
@@ -1599,12 +1608,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metaverse-network-sdk/type-definitions@npm:^0.0.1-6":
-  version: 0.0.1-8
-  resolution: "@metaverse-network-sdk/type-definitions@npm:0.0.1-8"
+"@metaverse-network-sdk/type-definitions@npm:^0.0.1-13":
+  version: 0.0.1-13
+  resolution: "@metaverse-network-sdk/type-definitions@npm:0.0.1-13"
   dependencies:
     lodash.merge: ^4.6.2
-  checksum: 43b36f10196d180ff13dab40617ee0f2f0a122073a49f6d41984f7bf5f165f2c0c75da6234284a7ec6f9f05c858ade31f7d37ba0ab0ab1786def6d9a16058585
+  checksum: 8c4527c2e95eb11aa03207c694fd89d35361c110906c057b75976a308a65d72d0b145fdc0871a868a10db4bf3a7f6abbdf94100b7378addd88c0b3fc8a05dbee
   languageName: node
   linkType: hard
 
@@ -1886,12 +1895,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@parallel-finance/type-definitions@npm:1.5.7":
-  version: 1.5.7
-  resolution: "@parallel-finance/type-definitions@npm:1.5.7"
+"@parallel-finance/type-definitions@npm:1.5.9":
+  version: 1.5.9
+  resolution: "@parallel-finance/type-definitions@npm:1.5.9"
   dependencies:
     "@open-web3/orml-type-definitions": ^1.0.2-3
-  checksum: d4a45c6838d911957973b4aecd6445951528c9aa0c2ecf6735123bbf68f354a6a5663eb843b185c927ad1095b5e903ad922cfffcabc9449933d979d3c43c5216
+  checksum: f290d86e41ade8dc1f26aca0ba0d41d239dc2a81e73ad259c54bf535df38e5e85cf8ce7f110db4a6aa1c8181ee0ac818060dbfedcda24a12b222fb69b8871d68
   languageName: node
   linkType: hard
 
@@ -1902,83 +1911,83 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@polkadot/api-augment@npm:7.12.1":
-  version: 7.12.1
-  resolution: "@polkadot/api-augment@npm:7.12.1"
+"@polkadot/api-augment@npm:7.13.1":
+  version: 7.13.1
+  resolution: "@polkadot/api-augment@npm:7.13.1"
   dependencies:
-    "@babel/runtime": ^7.17.2
-    "@polkadot/api-base": 7.12.1
-    "@polkadot/rpc-augment": 7.12.1
-    "@polkadot/types": 7.12.1
-    "@polkadot/types-augment": 7.12.1
-    "@polkadot/types-codec": 7.12.1
-    "@polkadot/util": ^8.5.1
-  checksum: 4330f854ccf12a19e1a3e46690a831936e949b63a111406c077440632b6d2a961378bbb0067124a2bfe556b31becd8717879c4eed1e1a031fd1ff84769378626
+    "@babel/runtime": ^7.17.8
+    "@polkadot/api-base": 7.13.1
+    "@polkadot/rpc-augment": 7.13.1
+    "@polkadot/types": 7.13.1
+    "@polkadot/types-augment": 7.13.1
+    "@polkadot/types-codec": 7.13.1
+    "@polkadot/util": ^8.6.1
+  checksum: d2cf5a1fb1253f0028962e54068b457d1b9941053def3f0f92be67ce132cc0a06851cb9e96362a5be35b9383f7b8d3eb86e5f24257d68e92f9cc780f6af435e8
   languageName: node
   linkType: hard
 
-"@polkadot/api-base@npm:7.12.1":
-  version: 7.12.1
-  resolution: "@polkadot/api-base@npm:7.12.1"
+"@polkadot/api-base@npm:7.13.1":
+  version: 7.13.1
+  resolution: "@polkadot/api-base@npm:7.13.1"
   dependencies:
-    "@babel/runtime": ^7.17.2
-    "@polkadot/rpc-core": 7.12.1
-    "@polkadot/types": 7.12.1
-    "@polkadot/util": ^8.5.1
+    "@babel/runtime": ^7.17.8
+    "@polkadot/rpc-core": 7.13.1
+    "@polkadot/types": 7.13.1
+    "@polkadot/util": ^8.6.1
     rxjs: ^7.5.5
-  checksum: cd6cfa7b3774a5e9e5e8c893f1594d1710b50f3182f41fe381bc6a82230c1d0aaab2f41a63b2a61fe79aeae109bdb2dd10eaaa7f323f33fc01666a1abc57c682
+  checksum: 9e4f7e9f71e962c2acbab19637bc56c7b23b19b365f66611b4f597b2cd9373c01a0283c99e363b005e8c9b490e5880c5a322eddd17cb2afe1c52698b20ad1ba7
   languageName: node
   linkType: hard
 
-"@polkadot/api-derive@npm:7.12.1, @polkadot/api-derive@npm:^7.12.1":
-  version: 7.12.1
-  resolution: "@polkadot/api-derive@npm:7.12.1"
+"@polkadot/api-derive@npm:7.13.1, @polkadot/api-derive@npm:^7.13.1":
+  version: 7.13.1
+  resolution: "@polkadot/api-derive@npm:7.13.1"
   dependencies:
-    "@babel/runtime": ^7.17.2
-    "@polkadot/api": 7.12.1
-    "@polkadot/api-augment": 7.12.1
-    "@polkadot/api-base": 7.12.1
-    "@polkadot/rpc-core": 7.12.1
-    "@polkadot/types": 7.12.1
-    "@polkadot/types-codec": 7.12.1
-    "@polkadot/util": ^8.5.1
-    "@polkadot/util-crypto": ^8.5.1
+    "@babel/runtime": ^7.17.8
+    "@polkadot/api": 7.13.1
+    "@polkadot/api-augment": 7.13.1
+    "@polkadot/api-base": 7.13.1
+    "@polkadot/rpc-core": 7.13.1
+    "@polkadot/types": 7.13.1
+    "@polkadot/types-codec": 7.13.1
+    "@polkadot/util": ^8.6.1
+    "@polkadot/util-crypto": ^8.6.1
     rxjs: ^7.5.5
-  checksum: 871e563064750f18c5ba4c1565bbd343ddba880ac2f5b539531dccf9348f8c234f8f8699b6269a06cd735890f0ac10fcd9ec78ede3a7ec0efb41bea29e403a3b
+  checksum: cf405ea70a4d84c761e6b2f40a416aa76bdaf5481a848cbe2afb05d9d800695421b80e1e9f442f478b429ac925b755d095778f3931aaddff47c9bf84185fc506
   languageName: node
   linkType: hard
 
-"@polkadot/api@npm:^7.12.1":
-  version: 7.12.1
-  resolution: "@polkadot/api@npm:7.12.1"
+"@polkadot/api@npm:7.13.1":
+  version: 7.13.1
+  resolution: "@polkadot/api@npm:7.13.1"
   dependencies:
-    "@babel/runtime": ^7.17.2
-    "@polkadot/api-augment": 7.12.1
-    "@polkadot/api-base": 7.12.1
-    "@polkadot/api-derive": 7.12.1
-    "@polkadot/keyring": ^8.5.1
-    "@polkadot/rpc-augment": 7.12.1
-    "@polkadot/rpc-core": 7.12.1
-    "@polkadot/rpc-provider": 7.12.1
-    "@polkadot/types": 7.12.1
-    "@polkadot/types-augment": 7.12.1
-    "@polkadot/types-codec": 7.12.1
-    "@polkadot/types-create": 7.12.1
-    "@polkadot/types-known": 7.12.1
-    "@polkadot/util": ^8.5.1
-    "@polkadot/util-crypto": ^8.5.1
+    "@babel/runtime": ^7.17.8
+    "@polkadot/api-augment": 7.13.1
+    "@polkadot/api-base": 7.13.1
+    "@polkadot/api-derive": 7.13.1
+    "@polkadot/keyring": ^8.6.1
+    "@polkadot/rpc-augment": 7.13.1
+    "@polkadot/rpc-core": 7.13.1
+    "@polkadot/rpc-provider": 7.13.1
+    "@polkadot/types": 7.13.1
+    "@polkadot/types-augment": 7.13.1
+    "@polkadot/types-codec": 7.13.1
+    "@polkadot/types-create": 7.13.1
+    "@polkadot/types-known": 7.13.1
+    "@polkadot/util": ^8.6.1
+    "@polkadot/util-crypto": ^8.6.1
     eventemitter3: ^4.0.7
     rxjs: ^7.5.5
-  checksum: 0895fd7beaf3ae7b85a107edf6ac610f7ab6d035dd2cd1c91737e06af40fb35f6a72c40e0db8b1cc4867a5f514076a16887e8280c82cc4b2f2582b179b212488
+  checksum: e9e5c59a0662dbb6f5396d6e0fe5ef82d0fe40acb3602da2601792f13e6c06c50ae809d23a8ac05fafbffcbd5d3bad40f39df36753a63d6cf7def1cafa4d3a5a
   languageName: node
   linkType: hard
 
-"@polkadot/apps-config@npm:^0.109.1":
-  version: 0.109.1
-  resolution: "@polkadot/apps-config@npm:0.109.1"
+"@polkadot/apps-config@npm:0.110.1":
+  version: 0.110.1
+  resolution: "@polkadot/apps-config@npm:0.110.1"
   dependencies:
-    "@acala-network/type-definitions": ^3.0.2-4
-    "@babel/runtime": ^7.17.2
+    "@acala-network/type-definitions": ^4.0.1
+    "@babel/runtime": ^7.17.8
     "@bifrost-finance/type-definitions": 1.4.0
     "@crustio/type-definitions": 1.2.0
     "@darwinia/types": 2.7.2
@@ -1989,18 +1998,18 @@ __metadata:
     "@interlay/interbtc-types": 1.5.10
     "@kiltprotocol/type-definitions": 0.1.23
     "@laminar/type-definitions": 0.3.1
-    "@metaverse-network-sdk/type-definitions": ^0.0.1-6
-    "@parallel-finance/type-definitions": 1.5.7
+    "@metaverse-network-sdk/type-definitions": ^0.0.1-13
+    "@parallel-finance/type-definitions": 1.5.9
     "@phala/typedefs": 0.2.30
-    "@polkadot/api": ^7.12.1
-    "@polkadot/api-derive": ^7.12.1
-    "@polkadot/networks": ^8.5.1
-    "@polkadot/types": ^7.12.1
-    "@polkadot/util": ^8.5.1
-    "@polkadot/x-fetch": ^8.5.1
+    "@polkadot/api": ^7.13.1
+    "@polkadot/api-derive": ^7.13.1
+    "@polkadot/networks": ^8.6.1
+    "@polkadot/types": ^7.13.1
+    "@polkadot/util": ^8.6.1
+    "@polkadot/x-fetch": ^8.6.1
     "@polymathnetwork/polymesh-types": 0.0.2
     "@snowfork/snowbridge-types": 0.2.7
-    "@sora-substrate/type-definitions": 1.7.49
+    "@sora-substrate/type-definitions": 1.8.1
     "@subsocial/types": 0.6.5
     "@unique-nft/types": 0.3.1
     "@zeitgeistpm/type-defs": 0.4.5
@@ -2010,126 +2019,126 @@ __metadata:
     moonbeam-types-bundle: 2.0.3
     pontem-types-bundle: 1.0.15
     rxjs: ^7.5.5
-  checksum: 84a5320bdb843fce2c6a0e3014ba93297cbfdb23a40b7330ca13cd76b152537ef5bbb2f7944d54840ca944b4e91d88b322148210ad362952b99258ac4624beda
+  checksum: 6341c6554f455831e1a09896818924e18297c931982a39ca922e5e62f8e2adce3a8bef5acf18cb34ccde93318db2095cdabd16183e51e8f1270ab9bd31c06364
   languageName: node
   linkType: hard
 
-"@polkadot/keyring@npm:8.5.1":
-  version: 8.5.1
-  resolution: "@polkadot/keyring@npm:8.5.1"
+"@polkadot/keyring@npm:8.6.1":
+  version: 8.6.1
+  resolution: "@polkadot/keyring@npm:8.6.1"
   dependencies:
-    "@babel/runtime": ^7.17.2
-    "@polkadot/util": 8.5.1
-    "@polkadot/util-crypto": 8.5.1
+    "@babel/runtime": ^7.17.8
+    "@polkadot/util": 8.6.1
+    "@polkadot/util-crypto": 8.6.1
   peerDependencies:
-    "@polkadot/util": 8.5.1
-    "@polkadot/util-crypto": 8.5.1
-  checksum: 24884985bebb0cfa759e83faebf4987cf96acffc0cedb5f87dfdd4d7a1fef326307967d7934755720062def7979b62127ad0a70a44d31875820e5cdb245b8a33
+    "@polkadot/util": 8.6.1
+    "@polkadot/util-crypto": 8.6.1
+  checksum: 12307cea2aaef2d153605a7653a21a6dab0f506f0e5f57f2a45def30d15ff3ebefeb591ae10002397ab3dd1ff13f9c17afa8fc93b074d0b91327dc068ac60cfc
   languageName: node
   linkType: hard
 
-"@polkadot/networks@npm:^8.5.1":
-  version: 8.5.1
-  resolution: "@polkadot/networks@npm:8.5.1"
+"@polkadot/networks@npm:8.6.1":
+  version: 8.6.1
+  resolution: "@polkadot/networks@npm:8.6.1"
   dependencies:
-    "@babel/runtime": ^7.17.2
-    "@polkadot/util": 8.5.1
-    "@substrate/ss58-registry": ^1.16.0
-  checksum: f6eafb87b21baa69515291049262f17873b80515f882974d6c9515ef44529d7037e3268d8989050c2976ddeb4823092b1aea65b152b6e761fdcbed2c8cd775b6
+    "@babel/runtime": ^7.17.8
+    "@polkadot/util": 8.6.1
+    "@substrate/ss58-registry": ^1.17.0
+  checksum: 9f7dd054bae8a66048f86aaa25050e9e8ffda9ad3b5d3eeeaedc6022d8e4165a000bf51e5d877aa18cff807b581ee78c0b9883d61f1f3c0617ef9ed0b016b9bb
   languageName: node
   linkType: hard
 
-"@polkadot/rpc-augment@npm:7.12.1":
-  version: 7.12.1
-  resolution: "@polkadot/rpc-augment@npm:7.12.1"
+"@polkadot/rpc-augment@npm:7.13.1":
+  version: 7.13.1
+  resolution: "@polkadot/rpc-augment@npm:7.13.1"
   dependencies:
-    "@babel/runtime": ^7.17.2
-    "@polkadot/rpc-core": 7.12.1
-    "@polkadot/types": 7.12.1
-    "@polkadot/types-codec": 7.12.1
-    "@polkadot/util": ^8.5.1
-  checksum: 2ea961aee478ae4ffb565b3510cc499a6af61e3ac9221f42ff27c7e83e39d96e055b67e38fa05e164c76534b092ac8dacb4a5efe7ad4a1b94ec0d88195c36adc
+    "@babel/runtime": ^7.17.8
+    "@polkadot/rpc-core": 7.13.1
+    "@polkadot/types": 7.13.1
+    "@polkadot/types-codec": 7.13.1
+    "@polkadot/util": ^8.6.1
+  checksum: 678167a051e89433cbc9f9d1c3ca4337a488193c9896df4bc79fb12594e0c0fdad394efa13f2c03ba9bf14e5ea5bdf2e10064b927341b6ca3e7db4c17b442809
   languageName: node
   linkType: hard
 
-"@polkadot/rpc-core@npm:7.12.1":
-  version: 7.12.1
-  resolution: "@polkadot/rpc-core@npm:7.12.1"
+"@polkadot/rpc-core@npm:7.13.1":
+  version: 7.13.1
+  resolution: "@polkadot/rpc-core@npm:7.13.1"
   dependencies:
-    "@babel/runtime": ^7.17.2
-    "@polkadot/rpc-augment": 7.12.1
-    "@polkadot/rpc-provider": 7.12.1
-    "@polkadot/types": 7.12.1
-    "@polkadot/util": ^8.5.1
+    "@babel/runtime": ^7.17.8
+    "@polkadot/rpc-augment": 7.13.1
+    "@polkadot/rpc-provider": 7.13.1
+    "@polkadot/types": 7.13.1
+    "@polkadot/util": ^8.6.1
     rxjs: ^7.5.5
-  checksum: c05efc30891d2194dc76a212e9535ee2597210585e3cf80bea64f9126bc8fec528ab0d53f527f8d39badf1b4af986272f0c1bc813b0c7c7d3546ac824b032d2d
+  checksum: 67c784ac9bbb1e0de4a78e995f5495707e1deed138c367b029a474dcc168e756ed584076475d3112d1f1308b915cecfd436e8810e04404a1491f605966747d17
   languageName: node
   linkType: hard
 
-"@polkadot/rpc-provider@npm:7.12.1":
-  version: 7.12.1
-  resolution: "@polkadot/rpc-provider@npm:7.12.1"
+"@polkadot/rpc-provider@npm:7.13.1":
+  version: 7.13.1
+  resolution: "@polkadot/rpc-provider@npm:7.13.1"
   dependencies:
-    "@babel/runtime": ^7.17.2
-    "@polkadot/keyring": ^8.5.1
-    "@polkadot/types": 7.12.1
-    "@polkadot/types-support": 7.12.1
-    "@polkadot/util": ^8.5.1
-    "@polkadot/util-crypto": ^8.5.1
-    "@polkadot/x-fetch": ^8.5.1
-    "@polkadot/x-global": ^8.5.1
-    "@polkadot/x-ws": ^8.5.1
+    "@babel/runtime": ^7.17.8
+    "@polkadot/keyring": ^8.6.1
+    "@polkadot/types": 7.13.1
+    "@polkadot/types-support": 7.13.1
+    "@polkadot/util": ^8.6.1
+    "@polkadot/util-crypto": ^8.6.1
+    "@polkadot/x-fetch": ^8.6.1
+    "@polkadot/x-global": ^8.6.1
+    "@polkadot/x-ws": ^8.6.1
     eventemitter3: ^4.0.7
     mock-socket: ^9.1.2
     nock: ^13.2.4
-  checksum: 92aa8033b9594d61f0d094920b5547bf9cc8f6a63667d746adde8396ad70168fe37f4cbf779b6bdda1561b30dd24e42e94477bae22e4b2937ff310339c942b68
+  checksum: 370389e801abd30236b702f38c661344261a0138a4fa878e951acbe187066dee5b6f22b0ae2f5c8d17ca12cd5207cac83e5656bdbbecc4a75efa1ebcf569d3d9
   languageName: node
   linkType: hard
 
-"@polkadot/types-augment@npm:7.12.1":
-  version: 7.12.1
-  resolution: "@polkadot/types-augment@npm:7.12.1"
+"@polkadot/types-augment@npm:7.13.1":
+  version: 7.13.1
+  resolution: "@polkadot/types-augment@npm:7.13.1"
   dependencies:
-    "@babel/runtime": ^7.17.2
-    "@polkadot/types": 7.12.1
-    "@polkadot/types-codec": 7.12.1
-    "@polkadot/util": ^8.5.1
-  checksum: c9636ead28e15e36872d11946ec71bc53fdbe3d0858fbc90aede36ba7ee857538045518dd25ad3fb7898adb130e7304bd1a4c54ce5decc631268afc548fb9dc0
+    "@babel/runtime": ^7.17.8
+    "@polkadot/types": 7.13.1
+    "@polkadot/types-codec": 7.13.1
+    "@polkadot/util": ^8.6.1
+  checksum: 4991e46235d7d42b898f98e0f9a90c1ee4a199c604ab6ce9027b7d8d9be91cc7546ca8014ca8719be80f9df977f542dd448e0a728537210b6cf5d6459b566bf3
   languageName: node
   linkType: hard
 
-"@polkadot/types-codec@npm:7.12.1":
-  version: 7.12.1
-  resolution: "@polkadot/types-codec@npm:7.12.1"
+"@polkadot/types-codec@npm:7.13.1":
+  version: 7.13.1
+  resolution: "@polkadot/types-codec@npm:7.13.1"
   dependencies:
-    "@babel/runtime": ^7.17.2
-    "@polkadot/util": ^8.5.1
-  checksum: bd377fd343dbedd3d77245ef155a83959c72cab23157e431d34fd7a476a40f510850361d69f52d7e3fc1fe5374d96a503831bb73a215f13f21fcfa8ea513855a
+    "@babel/runtime": ^7.17.8
+    "@polkadot/util": ^8.6.1
+  checksum: ce098af762c439649bfd24b826baf6531bc7e5d0fd02a2c1dcbdb6237d7991853fbdd44dd50b082bdec051b9ab4e7cbfc152b68c8e2b475f10a5529b5bb176f9
   languageName: node
   linkType: hard
 
-"@polkadot/types-create@npm:7.12.1":
-  version: 7.12.1
-  resolution: "@polkadot/types-create@npm:7.12.1"
+"@polkadot/types-create@npm:7.13.1":
+  version: 7.13.1
+  resolution: "@polkadot/types-create@npm:7.13.1"
   dependencies:
-    "@babel/runtime": ^7.17.2
-    "@polkadot/types-codec": 7.12.1
-    "@polkadot/util": ^8.5.1
-  checksum: 8a860159f3b2f32d1f869ae9f0779f90dc6d60e71da4053f99084f900f181742e55feb655bfa496b25c50b87b8d259314c51b3353ba5adff01cd44d604dc97be
+    "@babel/runtime": ^7.17.8
+    "@polkadot/types-codec": 7.13.1
+    "@polkadot/util": ^8.6.1
+  checksum: 374301abd0888d964df092a736adff792135ece44116b93a902d16ef5a4aed176a83d39c9d23c91ea2be7360b20937e8017d38e7e10eeec1520a072170f2d423
   languageName: node
   linkType: hard
 
-"@polkadot/types-known@npm:7.12.1":
-  version: 7.12.1
-  resolution: "@polkadot/types-known@npm:7.12.1"
+"@polkadot/types-known@npm:7.13.1":
+  version: 7.13.1
+  resolution: "@polkadot/types-known@npm:7.13.1"
   dependencies:
-    "@babel/runtime": ^7.17.2
-    "@polkadot/networks": ^8.5.1
-    "@polkadot/types": 7.12.1
-    "@polkadot/types-codec": 7.12.1
-    "@polkadot/types-create": 7.12.1
-    "@polkadot/util": ^8.5.1
-  checksum: fb929773568e3972ba01624aaae541b0cc31f9e0fc3ddefe7b6c1959eadcb8a7051d8f508b914c42ec116e6ce7f4c3b275c15af6fce65841979c9039f5706070
+    "@babel/runtime": ^7.17.8
+    "@polkadot/networks": ^8.6.1
+    "@polkadot/types": 7.13.1
+    "@polkadot/types-codec": 7.13.1
+    "@polkadot/types-create": 7.13.1
+    "@polkadot/util": ^8.6.1
+  checksum: 97123e132d84760013ed531f3653001af98147c3fcbd2c2c72dd284ddded51f3d23c982e1ca53ed9dfa5a44ce8e3e4184dbab6846248dc101f251d2ea5883df6
   languageName: node
   linkType: hard
 
@@ -2143,175 +2152,175 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@polkadot/types-support@npm:7.12.1":
-  version: 7.12.1
-  resolution: "@polkadot/types-support@npm:7.12.1"
+"@polkadot/types-support@npm:7.13.1":
+  version: 7.13.1
+  resolution: "@polkadot/types-support@npm:7.13.1"
   dependencies:
-    "@babel/runtime": ^7.17.2
-    "@polkadot/util": ^8.5.1
-  checksum: 9c41f7a02825efa2b8311d3edd99324578499dea8de006596e41fb297c1d07b404437eb0a0ced5af3cf9a28e3bd73480d22a36f597584557e77fd3fd9ab0d9da
+    "@babel/runtime": ^7.17.8
+    "@polkadot/util": ^8.6.1
+  checksum: a639fb774f90ce3464a159e3687322dff85f43041f50f1515ef7070a20845f3eae253b7734248d751bb6038db7ef3c4a9ff465bd3a4014d41fb707dfa6480eb4
   languageName: node
   linkType: hard
 
-"@polkadot/types@npm:7.12.1":
-  version: 7.12.1
-  resolution: "@polkadot/types@npm:7.12.1"
+"@polkadot/types@npm:7.13.1":
+  version: 7.13.1
+  resolution: "@polkadot/types@npm:7.13.1"
   dependencies:
-    "@babel/runtime": ^7.17.2
-    "@polkadot/keyring": ^8.5.1
-    "@polkadot/types-augment": 7.12.1
-    "@polkadot/types-codec": 7.12.1
-    "@polkadot/types-create": 7.12.1
-    "@polkadot/util": ^8.5.1
-    "@polkadot/util-crypto": ^8.5.1
+    "@babel/runtime": ^7.17.8
+    "@polkadot/keyring": ^8.6.1
+    "@polkadot/types-augment": 7.13.1
+    "@polkadot/types-codec": 7.13.1
+    "@polkadot/types-create": 7.13.1
+    "@polkadot/util": ^8.6.1
+    "@polkadot/util-crypto": ^8.6.1
     rxjs: ^7.5.5
-  checksum: f935285cbc1fedda4af25b78871c608d22810dc55e1c8895ef574ac1cebc39bf05e78d1bc028befea9796d3c26190bd21ea2f823a57955ea2eca62b5cf1227f0
+  checksum: d5556a188cd5f00d060ac6b7a41018983482f2c774bea03ddfde4251db6495ddc859540834047c18b2123f13077b5bb0837d6e0d6b1b7c87008b3cb112620894
   languageName: node
   linkType: hard
 
-"@polkadot/util-crypto@npm:8.5.1":
-  version: 8.5.1
-  resolution: "@polkadot/util-crypto@npm:8.5.1"
+"@polkadot/util-crypto@npm:8.6.1":
+  version: 8.6.1
+  resolution: "@polkadot/util-crypto@npm:8.6.1"
   dependencies:
-    "@babel/runtime": ^7.17.2
+    "@babel/runtime": ^7.17.8
     "@noble/hashes": 1.0.0
     "@noble/secp256k1": 1.5.5
-    "@polkadot/networks": 8.5.1
-    "@polkadot/util": 8.5.1
-    "@polkadot/wasm-crypto": ^4.6.1
-    "@polkadot/x-bigint": 8.5.1
-    "@polkadot/x-randomvalues": 8.5.1
+    "@polkadot/networks": 8.6.1
+    "@polkadot/util": 8.6.1
+    "@polkadot/wasm-crypto": ^5.0.1
+    "@polkadot/x-bigint": 8.6.1
+    "@polkadot/x-randomvalues": 8.6.1
     "@scure/base": 1.0.0
     ed2curve: ^0.3.0
     tweetnacl: ^1.0.3
   peerDependencies:
-    "@polkadot/util": 8.5.1
-  checksum: 80e3fe141ebb8273701d8b3f8d36c9416b47846a7bb8843a410a96e896727b38407238a3e16a7f380aa33a413fe2f4042ed972aea1576a5205784cc9e652b75d
+    "@polkadot/util": 8.6.1
+  checksum: 46b97f98ae93fa0101e134eb2b02089888daa3d49af084af3b601ed8f491a87169d7608c7255e12910b354bacba8a5857a799c8fff7d7f06732bca49c31d3096
   languageName: node
   linkType: hard
 
-"@polkadot/util@npm:8.5.1":
-  version: 8.5.1
-  resolution: "@polkadot/util@npm:8.5.1"
+"@polkadot/util@npm:8.6.1":
+  version: 8.6.1
+  resolution: "@polkadot/util@npm:8.6.1"
   dependencies:
-    "@babel/runtime": ^7.17.2
-    "@polkadot/x-bigint": 8.5.1
-    "@polkadot/x-global": 8.5.1
-    "@polkadot/x-textdecoder": 8.5.1
-    "@polkadot/x-textencoder": 8.5.1
+    "@babel/runtime": ^7.17.8
+    "@polkadot/x-bigint": 8.6.1
+    "@polkadot/x-global": 8.6.1
+    "@polkadot/x-textdecoder": 8.6.1
+    "@polkadot/x-textencoder": 8.6.1
     "@types/bn.js": ^5.1.0
     bn.js: ^5.2.0
     ip-regex: ^4.3.0
-  checksum: 089dadfab22ebb8351da2bab8e2272ca210429ec85b66665590275db65b2ac0fc482e710247f512f6adf64b5d6c6a49a1cef7d7b964a8ff68c42984e53befcba
+  checksum: c2e0a16158a0f2569cedd863f31b95139b8cca4b55baeee2b1a1f9ce84732d6a4b980201d6356d81d8457cf8bbf0ed924c23ad44e6e238f8b1473bf66bc532fa
   languageName: node
   linkType: hard
 
-"@polkadot/wasm-crypto-asmjs@npm:^4.6.1":
-  version: 4.6.1
-  resolution: "@polkadot/wasm-crypto-asmjs@npm:4.6.1"
+"@polkadot/wasm-crypto-asmjs@npm:^5.0.1":
+  version: 5.0.1
+  resolution: "@polkadot/wasm-crypto-asmjs@npm:5.0.1"
   dependencies:
-    "@babel/runtime": ^7.17.2
+    "@babel/runtime": ^7.17.8
   peerDependencies:
     "@polkadot/util": "*"
-  checksum: b5b0cba3a71e614a0d6eafd9fd51a1432f21c2834fd91c8c42399eee3a1ec761b5234528057a66ef1a730642f8afa5067eb670f97e1174a7657818ecf4d328f5
+  checksum: c32208930de69759a14376b0c86d7944fe88cc89e34681819acaec3636e6b6725d41036de456d6becad45886e316a1be6c22c6621b7c9b791be1c3f06bc030b6
   languageName: node
   linkType: hard
 
-"@polkadot/wasm-crypto-wasm@npm:^4.6.1":
-  version: 4.6.1
-  resolution: "@polkadot/wasm-crypto-wasm@npm:4.6.1"
+"@polkadot/wasm-crypto-wasm@npm:^5.0.1":
+  version: 5.0.1
+  resolution: "@polkadot/wasm-crypto-wasm@npm:5.0.1"
   dependencies:
-    "@babel/runtime": ^7.17.2
+    "@babel/runtime": ^7.17.8
   peerDependencies:
     "@polkadot/util": "*"
-  checksum: 5b896a8c0fc025e8999689f89bea4c8437228f37ed8bb267749b1786e4b5c40c80b321d8bdc45fd3f69bfc64a74c015db023454ee574f18b4b82fcb4aea76f38
+  checksum: 167f9e7c4afc82c307a88a3f40d49458f0b8b1eeac6aec501a26ecfe8ed63f3cfc4132f3b4c8894ec1ee664cb205fa2607264b6c84846231bc705eedfc25972e
   languageName: node
   linkType: hard
 
-"@polkadot/wasm-crypto@npm:4.6.1":
-  version: 4.6.1
-  resolution: "@polkadot/wasm-crypto@npm:4.6.1"
+"@polkadot/wasm-crypto@npm:5.0.1":
+  version: 5.0.1
+  resolution: "@polkadot/wasm-crypto@npm:5.0.1"
   dependencies:
-    "@babel/runtime": ^7.17.2
-    "@polkadot/wasm-crypto-asmjs": ^4.6.1
-    "@polkadot/wasm-crypto-wasm": ^4.6.1
+    "@babel/runtime": ^7.17.8
+    "@polkadot/wasm-crypto-asmjs": ^5.0.1
+    "@polkadot/wasm-crypto-wasm": ^5.0.1
   peerDependencies:
     "@polkadot/util": "*"
     "@polkadot/x-randomvalues": "*"
-  checksum: 785b2261d8363687c67e16c8e09f9342460228bce9069870c77d4d1d6b77d4c0a14436e2d94b03c228ffc184a6a6628c15f46672be09aafa6112d2247b8c81a5
+  checksum: 4116a87c1a047de026b0feb6b68b2e46f4115f2ba7504104421ed240f111e1f5a609e954a1c1f8fd5f0b727eadabfacd1edd939197222988a889d7e40b3e30ef
   languageName: node
   linkType: hard
 
-"@polkadot/x-bigint@npm:8.5.1":
-  version: 8.5.1
-  resolution: "@polkadot/x-bigint@npm:8.5.1"
+"@polkadot/x-bigint@npm:8.6.1":
+  version: 8.6.1
+  resolution: "@polkadot/x-bigint@npm:8.6.1"
   dependencies:
-    "@babel/runtime": ^7.17.2
-    "@polkadot/x-global": 8.5.1
-  checksum: 72e4b8b4626e230f76adb6f840230bdb6b6d8a89ab9ec75be0d798accb16e1ae3a6c93b0a6358dac6ac2b3fe4c42d353a00384d07a8c3ac40b245047ce63e1f7
+    "@babel/runtime": ^7.17.8
+    "@polkadot/x-global": 8.6.1
+  checksum: 256c57fff6d55b548a831c790b680b8840734868b5a29b76ff13bdc32f4d15332da353f33af3d4e8a1bf30738759b476d8e29e2ad685051502ae2c4237fc9163
   languageName: node
   linkType: hard
 
-"@polkadot/x-fetch@npm:^8.5.1":
-  version: 8.5.1
-  resolution: "@polkadot/x-fetch@npm:8.5.1"
+"@polkadot/x-fetch@npm:^8.6.1":
+  version: 8.6.1
+  resolution: "@polkadot/x-fetch@npm:8.6.1"
   dependencies:
-    "@babel/runtime": ^7.17.2
-    "@polkadot/x-global": 8.5.1
+    "@babel/runtime": ^7.17.8
+    "@polkadot/x-global": 8.6.1
     "@types/node-fetch": ^2.6.1
     node-fetch: ^2.6.7
-  checksum: 4f598556461c8979eed6a957332d83d58512bcdc61eb86b4872021fb65f6a9259eb4d0932f69aff4df51f651b7add12ac963eba6e39494c1343f2083dce7fe14
+  checksum: f534879fcb35c5d0492e446abe796cb87b32d92a7ad5ba6ef7f88c2f51be2aa314873d2b307957bd25a80d63d069ab7209fe4a8fb9895c39c893d75c12fd7f30
   languageName: node
   linkType: hard
 
-"@polkadot/x-global@npm:8.5.1, @polkadot/x-global@npm:^8.5.1":
-  version: 8.5.1
-  resolution: "@polkadot/x-global@npm:8.5.1"
+"@polkadot/x-global@npm:8.6.1, @polkadot/x-global@npm:^8.6.1":
+  version: 8.6.1
+  resolution: "@polkadot/x-global@npm:8.6.1"
   dependencies:
-    "@babel/runtime": ^7.17.2
-  checksum: 7937f11327af5f9cd214ec34f136fd24f5ae6b375fb716fa4e8c67193f1a036afab1225169e72c84e9cb3d28f08d3043cfc3840ccd1c52f5c39177a0a70f375c
+    "@babel/runtime": ^7.17.8
+  checksum: 10c5de96b630e596634abe3468a234f1ecc2b70579d8a34601ae0306bb70c60acbe8d13e29325cf5e37a34544e09b412953fbb96e584f04f1d5f1747ac3acb54
   languageName: node
   linkType: hard
 
-"@polkadot/x-randomvalues@npm:8.5.1":
-  version: 8.5.1
-  resolution: "@polkadot/x-randomvalues@npm:8.5.1"
+"@polkadot/x-randomvalues@npm:8.6.1":
+  version: 8.6.1
+  resolution: "@polkadot/x-randomvalues@npm:8.6.1"
   dependencies:
-    "@babel/runtime": ^7.17.2
-    "@polkadot/x-global": 8.5.1
-  checksum: b90a262adedabea03d19df367a6a192dc6bc322b2374b6f14c6bd4cb06ff6b1a2e81deef414c13b6d3147306e15ed964f9ed2dff4451067541164be942a9d8f9
+    "@babel/runtime": ^7.17.8
+    "@polkadot/x-global": 8.6.1
+  checksum: 95968613313d4ab1355e527bc5785a9f88a7b55b856a6f94d9f7d89b21f63dcd0dc0c7b000ebe87487de9dc5eecbc41c113b7af95aa22fd4595f9c3d830f264d
   languageName: node
   linkType: hard
 
-"@polkadot/x-textdecoder@npm:8.5.1":
-  version: 8.5.1
-  resolution: "@polkadot/x-textdecoder@npm:8.5.1"
+"@polkadot/x-textdecoder@npm:8.6.1":
+  version: 8.6.1
+  resolution: "@polkadot/x-textdecoder@npm:8.6.1"
   dependencies:
-    "@babel/runtime": ^7.17.2
-    "@polkadot/x-global": 8.5.1
-  checksum: 00175d0d472fe2f4f26ff4e631aa9fef93a3b146e7bbef0878ed9dc09fce51b43528131ddbaa7ae0c4e7244956e5f46a00602fa72849f01c025c467808ceb487
+    "@babel/runtime": ^7.17.8
+    "@polkadot/x-global": 8.6.1
+  checksum: 35dff39b1e636569d9f9c243f43b216f5ed8ddae92fdca47a48d77a52eedbda3476855c1a1115cebc918551bae62fc09da70665f217110cf33176fd1ace09558
   languageName: node
   linkType: hard
 
-"@polkadot/x-textencoder@npm:8.5.1":
-  version: 8.5.1
-  resolution: "@polkadot/x-textencoder@npm:8.5.1"
+"@polkadot/x-textencoder@npm:8.6.1":
+  version: 8.6.1
+  resolution: "@polkadot/x-textencoder@npm:8.6.1"
   dependencies:
-    "@babel/runtime": ^7.17.2
-    "@polkadot/x-global": 8.5.1
-  checksum: 4eddf9a4e0c3a8fb1cd0150acb748cf130dc77b0f1aa96a16352ac5caff5b79cb70ff9fb9c17ef2f26fc1cb4245d51bd4f0b47b1f5193243abe632ff938c8cb5
+    "@babel/runtime": ^7.17.8
+    "@polkadot/x-global": 8.6.1
+  checksum: 88642324a3fb67919907504c237b9e26af44a8e109fcd83516c00f1014d352e9a05c6d28c0b83c807d284aad529009aa664a928e7df1accc165548c6a5332c17
   languageName: node
   linkType: hard
 
-"@polkadot/x-ws@npm:^8.5.1":
-  version: 8.5.1
-  resolution: "@polkadot/x-ws@npm:8.5.1"
+"@polkadot/x-ws@npm:^8.6.1":
+  version: 8.6.1
+  resolution: "@polkadot/x-ws@npm:8.6.1"
   dependencies:
-    "@babel/runtime": ^7.17.2
-    "@polkadot/x-global": 8.5.1
+    "@babel/runtime": ^7.17.8
+    "@polkadot/x-global": 8.6.1
     "@types/websocket": ^1.0.5
     websocket: ^1.0.34
-  checksum: 56a0bb79a852e1ac6572405e2bbba23334455789f53d1529709d024c6ced4b76fc0e331ca4810c69bd03b00a97b3c6e50d1dea138aaca4a0f69f816d331efc6d
+  checksum: 4b9237555a892b8aff80f30e506576875a9f7d866dfcfe8fc45619a63d2145253b748d7da4658bf85b4023ae21c61ce3becacca3019d6f54dd1fca34dae15ab0
   languageName: node
   linkType: hard
 
@@ -2378,12 +2387,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@sora-substrate/type-definitions@npm:1.7.49":
-  version: 1.7.49
-  resolution: "@sora-substrate/type-definitions@npm:1.7.49"
+"@sora-substrate/type-definitions@npm:1.8.1":
+  version: 1.8.1
+  resolution: "@sora-substrate/type-definitions@npm:1.8.1"
   dependencies:
     "@open-web3/orml-type-definitions": ^0.9.4-35
-  checksum: b6e77270c1b8251973f4704e5f119d1d56b7a6ca2e690631ed0bb2a52032578e7fb2bfbd45b950902da36f37fc3fc9ecbc5b3ea9e22b30d771cdec52ae64c86f
+  checksum: e228117f0f5b10a3ea98b451216529771ee224c9cd6236d8cfc7b57f80bf2c87dadd18e051dab006dd61ba68dfa31ad8ccc5158e75a287e7f480aa55aee2ec70
   languageName: node
   linkType: hard
 
@@ -2449,10 +2458,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@substrate/ss58-registry@npm:^1.16.0":
-  version: 1.16.0
-  resolution: "@substrate/ss58-registry@npm:1.16.0"
-  checksum: 3777de20eb3be3aa17b088e4786900bc7f57884c660e942596569fe886b4fc9c2381dd480db06ffddad1ab6f108ead3b162f4a8b111f6f8ffbec7982b818a5d6
+"@substrate/ss58-registry@npm:^1.17.0":
+  version: 1.17.0
+  resolution: "@substrate/ss58-registry@npm:1.17.0"
+  checksum: 48d1e28e143514ae93a0faf4406a59db9d2ccaff3f5db36d8174657fc2d12c66be786aeaa78c4f5ba52e741588dfa033faf7915882c467b78dc77eefb5ef8ee3
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2460,7 +2460,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@substrate/txwrapper-core@workspace:packages/txwrapper-core"
   dependencies:
-    "@polkadot/api": ^7.12.1
+    "@polkadot/api": ^7.13.1
     "@types/memoizee": ^0.4.3
     memoizee: 0.4.15
   languageName: unknown
@@ -2470,7 +2470,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@substrate/txwrapper-examples@workspace:packages/txwrapper-examples"
   dependencies:
-    "@polkadot/api": ^7.12.1
+    "@polkadot/api": ^7.13.1
     "@substrate/txwrapper-polkadot": ^1.5.7
     "@substrate/txwrapper-registry": ^1.5.7
   languageName: unknown
@@ -2498,8 +2498,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@substrate/txwrapper-registry@workspace:packages/txwrapper-registry"
   dependencies:
-    "@polkadot/apps-config": ^0.109.1
-    "@polkadot/networks": ^8.5.1
+    "@polkadot/apps-config": ^0.110.1
+    "@polkadot/networks": ^8.6.1
     "@substrate/txwrapper-core": ^1.5.7
   languageName: unknown
   linkType: soft
@@ -10177,7 +10177,7 @@ fsevents@^2.3.2:
   resolution: "txwrapper-core@workspace:."
   dependencies:
     "@babel/plugin-transform-modules-commonjs": ^7.15.4
-    "@polkadot/util-crypto": ^8.5.1
+    "@polkadot/util-crypto": ^8.6.1
     "@substrate/dev": ^0.5.6
     "@types/jest": ^27.0.1
     "@typescript-eslint/eslint-plugin": ^4.31.1


### PR DESCRIPTION
This updates the polkadot-js deps to the following:

    "@polkadot/api": "7.13.1",
    "@polkadot/keyring": "8.6.1",
    "@polkadot/networks": "8.6.1",
    "@polkadot/types": "7.13.1",
    "@polkadot/types-known": "7.13.1",
    "@polkadot/util": "8.6.1",
    "@polkadot/util-crypto": "8.6.1",
    "@polkadot/wasm-crypto": "5.0.1",
    "@polkadot/apps-config": "0.110.1"
    