### PR TITLE
fix(bug): handling eraPeriod when it is equal to zero

### DIFF
--- a/packages/txwrapper-core/src/core/method/defineMethod.spec.ts
+++ b/packages/txwrapper-core/src/core/method/defineMethod.spec.ts
@@ -31,6 +31,26 @@ describe('defineMethod', () => {
 		expect(unsigned.era).toBe('0xe500');
 	});
 
+	it('should handle `info.eraPeriod` correctly when 0', () => {
+		const txBaseInfo = {
+			...TEST_BASE_TX_INFO,
+			eraPeriod: 0,
+		};
+		const unsigned = defineMethod(
+			{
+				...txBaseInfo,
+				method: {
+					args: {},
+					name: 'chill',
+					pallet: 'staking',
+				},
+			},
+			POLKADOT_25_TEST_OPTIONS
+		);
+
+		expect(unsigned.era).toBe('0x2100');
+	});
+
 	it('should work', () => {
 		const txBaseInfo = {
 			...TEST_BASE_TX_INFO,

--- a/packages/txwrapper-core/src/core/method/defineMethod.ts
+++ b/packages/txwrapper-core/src/core/method/defineMethod.ts
@@ -72,11 +72,14 @@ export function defineMethod(
 		})
 	).toHex();
 
+	/**
+	 * If the `info.eraPeriod` is set use it. (This also checks for the edgecase zero).
+	 * As a last resort, it will use the default value.
+	 */
 	const eraPeriod =
-		// If `info.eraPeriod` is set, use it.
-		info.eraPeriod ||
-		// As last resort, take the default value.
-		DEFAULTS.eraPeriod;
+		info.eraPeriod === 0 || info.eraPeriod
+			? info.eraPeriod
+			: DEFAULTS.eraPeriod;
 
 	return {
 		address: info.address,


### PR DESCRIPTION
This resolves a bug where if `info.eraPeriod` is equal to zero it would use the defaults eraPeriod of 64 because it would assume it's a falsey value. 