### PR TITLE
feat: add balances::transferAll

### DIFF
--- a/packages/txwrapper-substrate/src/methods/balances/transferAll.spec.ts
+++ b/packages/txwrapper-substrate/src/methods/balances/transferAll.spec.ts
@@ -1,0 +1,24 @@
+import {
+	itHasCorrectBaseTxInfo,
+	POLKADOT_9122_TEST_OPTIONS,
+	TEST_BASE_TX_INFO,
+} from '@substrate/txwrapper-core';
+
+import { TEST_METHOD_ARGS } from '../../test-helpers';
+import { transferAll } from './transferAll';
+
+describe('balances:transferAll', () => {
+	it('should work', () => {
+		const unsigned = transferAll(
+			TEST_METHOD_ARGS.balances.transferAll,
+			TEST_BASE_TX_INFO,
+			POLKADOT_9122_TEST_OPTIONS
+		);
+
+		itHasCorrectBaseTxInfo(unsigned);
+
+		expect(unsigned.method).toBe(
+			'0x05040096074594cccf1cd185fa8a72ceaeefd86648f8d45514f3ce33c31bdd07e4655d01'
+		);
+	});
+});

--- a/packages/txwrapper-substrate/src/methods/balances/transferAll.ts
+++ b/packages/txwrapper-substrate/src/methods/balances/transferAll.ts
@@ -1,0 +1,53 @@
+import {
+	Args,
+	BaseTxInfo,
+	defineMethod,
+	OptionsWithMeta,
+	UnsignedTransaction,
+} from '@substrate/txwrapper-core';
+
+export interface BalancesTransferAllArgs extends Args {
+	/**
+	 * The recipient of the transfer.
+	 */
+	dest: string;
+
+	/**
+	 * A boolean to determine if the `transfer_all` operation should send all
+	 * of the funds the account has, causing the sender account to be killed (false), or
+	 * transfer everything except at least the existential deposit, which will guarantee to
+	 * keep the sender account alive (true).
+	 */
+	keepAlive: boolean;
+}
+
+/**
+ * Transfer the entire transferable balance from the caller account.
+ *
+ * NOTE: This function only attempts to transfer _transferable_ balances. This means that
+ * any locked, reserved, or existential deposits (when `keep_alive` is `true`), will not be
+ * transferred by this function. To ensure that this function results in a killed account,
+ * you might need to prepare the account by removing any reference counters, storage
+ * deposits, etc...
+ *
+ * @param args - Arguments specific to this method.
+ * @param info - Information required to construct the transaction.
+ * @param options - Registry and metadata used for constructing the method.
+ */
+export function transferAll(
+	args: BalancesTransferAllArgs,
+	info: BaseTxInfo,
+	options: OptionsWithMeta
+): UnsignedTransaction {
+	return defineMethod(
+		{
+			method: {
+				args,
+				name: 'transferAll',
+				pallet: 'balances',
+			},
+			...info,
+		},
+		options
+	);
+}

--- a/packages/txwrapper-substrate/src/test-helpers/TEST_METHOD_ARGS.ts
+++ b/packages/txwrapper-substrate/src/test-helpers/TEST_METHOD_ARGS.ts
@@ -34,6 +34,10 @@ export const TEST_METHOD_ARGS = {
 			dest: 'Fy2rsYCoowQBtuFXqLE65ehAY9T6KWcGiNCQAyPDCkfpm4s',
 			value: 12,
 		},
+		transferAll: {
+			dest: 'Fy2rsYCoowQBtuFXqLE65ehAY9T6KWcGiNCQAyPDCkfpm4s',
+			keepAlive: true,
+		},
 	},
 	democracy: {
 		vote: {


### PR DESCRIPTION
closes: [#197](https://github.com/paritytech/txwrapper-core/issues/197)

This adds `transferAll` method to the balances methods in `txwrapper-substrate`. 
Ideally this PR will be followed up by a PR to update the docs. 