### PR TITLE
feat!: add `isImmortalEra` option for decoding and encoding era periods

### DIFF
--- a/packages/txwrapper-core/src/core/decode/decodeUnsignedTx.spec.ts
+++ b/packages/txwrapper-core/src/core/decode/decodeUnsignedTx.spec.ts
@@ -40,4 +40,19 @@ describe('decodeUnsignedTx', () => {
 
 		itDecodesBalancesTransferCommon(decoded);
 	});
+
+	it('Should decode balances::transfer for an immortal era', () => {
+		const adjustedOptions = Object.assign({}, POLKADOT_25_TEST_OPTIONS, {
+			isImmortalEra: true,
+		});
+		const unsigned = balancesTransfer(
+			TEST_METHOD_ARGS.balances.transfer,
+			TEST_BASE_TX_INFO,
+			adjustedOptions
+		);
+
+		const decoded = decodeUnsignedTx(unsigned, adjustedOptions);
+
+		expect(decoded.eraPeriod).toBe(0);
+	});
 });

--- a/packages/txwrapper-core/src/core/decode/decodeUnsignedTx.spec.ts
+++ b/packages/txwrapper-core/src/core/decode/decodeUnsignedTx.spec.ts
@@ -42,9 +42,10 @@ describe('decodeUnsignedTx', () => {
 	});
 
 	it('Should decode balances::transfer for an immortal era', () => {
-		const adjustedOptions = Object.assign({}, POLKADOT_25_TEST_OPTIONS, {
+		const adjustedOptions = {
+			...POLKADOT_25_TEST_OPTIONS,
 			isImmortalEra: true,
-		});
+		};
 		const unsigned = balancesTransfer(
 			TEST_METHOD_ARGS.balances.transfer,
 			TEST_BASE_TX_INFO,

--- a/packages/txwrapper-core/src/core/decode/decodeUnsignedTx.ts
+++ b/packages/txwrapper-core/src/core/decode/decodeUnsignedTx.ts
@@ -1,6 +1,8 @@
 /**
  * @ignore
  */ /** */
+import { hexToNumber } from '@polkadot/util';
+
 import {
 	DecodedUnsignedTx,
 	OptionsWithMeta,
@@ -18,12 +20,16 @@ export function decodeUnsignedTx(
 	unsigned: UnsignedTransaction,
 	options: OptionsWithMeta
 ): DecodedUnsignedTx {
-	const { metadataRpc, registry, asCallsOnlyArg } = options;
+	const { metadataRpc, registry, asCallsOnlyArg, isImmortalEra } = options;
 
 	registry.setMetadata(createMetadata(registry, metadataRpc, asCallsOnlyArg));
 
 	const methodCall = registry.createType('Call', unsigned.method);
 	const method = toTxMethod(registry, methodCall);
+
+	const eraPeriod = isImmortalEra
+		? hexToNumber(registry.createType('ImmortalEra', unsigned.era).toHex())
+		: registry.createType('MortalEra', unsigned.era).period.toNumber();
 
 	return {
 		address: unsigned.address,
@@ -31,7 +37,7 @@ export function decodeUnsignedTx(
 		blockNumber: registry
 			.createType('BlockNumber', unsigned.blockNumber)
 			.toNumber(),
-		eraPeriod: registry.createType('MortalEra', unsigned.era).period.toNumber(),
+		eraPeriod,
 		genesisHash: unsigned.genesisHash,
 		metadataRpc,
 		method,

--- a/packages/txwrapper-core/src/core/method/defineMethod.spec.ts
+++ b/packages/txwrapper-core/src/core/method/defineMethod.spec.ts
@@ -11,7 +11,8 @@ import {
 import { checkEra, defineMethod, MethodErrorMessages } from './defineMethod';
 
 describe('defineMethod', () => {
-	const { InvalidEraPeriodToLow, InvalidEraPeriodToHigh } = MethodErrorMessages;
+	const { InvalidEraPeriodTooLow, InvalidEraPeriodTooHigh } =
+		MethodErrorMessages;
 
 	it('should create correct default era', () => {
 		const txBaseInfo = {
@@ -50,7 +51,7 @@ describe('defineMethod', () => {
 				},
 				POLKADOT_25_TEST_OPTIONS
 			)
-		).toThrow(InvalidEraPeriodToLow);
+		).toThrow(InvalidEraPeriodTooLow);
 	});
 
 	it('should handle `info.eraPeriod` when `isImmortalEra` is true', () => {
@@ -156,19 +157,19 @@ describe('defineMethod', () => {
 		it('Should handle values less than 4 correctly', () => {
 			expect(() => {
 				checkEra(registry, 10, 0);
-			}).toThrowError(InvalidEraPeriodToLow);
+			}).toThrowError(InvalidEraPeriodTooLow);
 			expect(() => {
 				checkEra(registry, 10, 3);
-			}).toThrowError(InvalidEraPeriodToLow);
+			}).toThrowError(InvalidEraPeriodTooLow);
 		});
 
 		it('Should handle values greater than 65536 correctly', () => {
 			expect(() => {
 				checkEra(registry, 10, 65537);
-			}).toThrowError(InvalidEraPeriodToHigh);
+			}).toThrowError(InvalidEraPeriodTooHigh);
 			expect(() => {
 				checkEra(registry, 10, 70000);
-			}).toThrowError(InvalidEraPeriodToHigh);
+			}).toThrowError(InvalidEraPeriodTooHigh);
 		});
 
 		it('Should handle immortal transactions correctly', () => {

--- a/packages/txwrapper-core/src/core/method/defineMethod.spec.ts
+++ b/packages/txwrapper-core/src/core/method/defineMethod.spec.ts
@@ -62,9 +62,10 @@ describe('defineMethod', () => {
 		/**
 		 * Adds isImmortalEra to the options.
 		 */
-		const adjustedOptions = Object.assign({}, POLKADOT_25_TEST_OPTIONS, {
+		const adjustedOptions = {
+			...POLKADOT_25_TEST_OPTIONS,
 			isImmortalEra: true,
-		});
+		};
 		const unsigned = defineMethod(
 			{
 				...txBaseInfo,

--- a/packages/txwrapper-core/src/core/method/defineMethod.spec.ts
+++ b/packages/txwrapper-core/src/core/method/defineMethod.spec.ts
@@ -31,7 +31,11 @@ describe('defineMethod', () => {
 		expect(unsigned.era).toBe('0xe500');
 	});
 
-	it('should handle `info.eraPeriod` correctly when 0', () => {
+	/**
+	 * Note: This is a mortal transaction so it will convert the info.eraPeriod
+	 * back to the value 4 as a MortalEra must be a minimum of 4.
+	 */
+	it('should handle `info.eraPeriod` correctly when 0 with a mortal tx', () => {
 		const txBaseInfo = {
 			...TEST_BASE_TX_INFO,
 			eraPeriod: 0,
@@ -49,6 +53,33 @@ describe('defineMethod', () => {
 		);
 
 		expect(unsigned.era).toBe('0x2100');
+	});
+
+	it('should handle `info.eraPeriod` when `isImmortalEra` is true', () => {
+		const txBaseInfo = {
+			...TEST_BASE_TX_INFO,
+			eraPeriod: 0,
+		};
+		/**
+		 * Adds isImmortalEra to the options.
+		 */
+		const adjustedOptions = Object.assign({},
+			POLKADOT_25_TEST_OPTIONS,
+			{ isImmortalEra: true },
+		);
+		const unsigned = defineMethod(
+			{
+				...txBaseInfo,
+				method: {
+					args: {},
+					name: 'chill',
+					pallet: 'staking',
+				},
+			},
+			adjustedOptions
+		);
+
+		expect(unsigned.era).toBe('0x00');
 	});
 
 	it('should work', () => {

--- a/packages/txwrapper-core/src/core/method/defineMethod.spec.ts
+++ b/packages/txwrapper-core/src/core/method/defineMethod.spec.ts
@@ -63,10 +63,9 @@ describe('defineMethod', () => {
 		/**
 		 * Adds isImmortalEra to the options.
 		 */
-		const adjustedOptions = Object.assign({},
-			POLKADOT_25_TEST_OPTIONS,
-			{ isImmortalEra: true },
-		);
+		const adjustedOptions = Object.assign({}, POLKADOT_25_TEST_OPTIONS, {
+			isImmortalEra: true,
+		});
 		const unsigned = defineMethod(
 			{
 				...txBaseInfo,

--- a/packages/txwrapper-core/src/core/method/defineMethod.spec.ts
+++ b/packages/txwrapper-core/src/core/method/defineMethod.spec.ts
@@ -8,7 +8,7 @@ import {
 	TEST_BASE_TX_INFO,
 	TEST_METHOD_ARGS,
 } from '../../test-helpers/';
-import { checkEra, defineMethod, MethodErrorMessages } from './defineMethod';
+import { createEra, defineMethod, MethodErrorMessages } from './defineMethod';
 
 describe('defineMethod', () => {
 	const { InvalidEraPeriodTooLow, InvalidEraPeriodTooHigh } =
@@ -151,29 +151,29 @@ describe('defineMethod', () => {
 		).not.toThrow();
 	});
 
-	describe('checkEra', () => {
+	describe('createEra', () => {
 		const { registry } = POLKADOT_9122_TEST_OPTIONS;
 
 		it('Should handle values less than 4 correctly', () => {
 			expect(() => {
-				checkEra(registry, 10, 0);
+				createEra(registry, { kind: 'mortal', blockNumber: 10, period: 0 });
 			}).toThrowError(InvalidEraPeriodTooLow);
 			expect(() => {
-				checkEra(registry, 10, 3);
+				createEra(registry, { kind: 'mortal', blockNumber: 10, period: 3 });
 			}).toThrowError(InvalidEraPeriodTooLow);
 		});
 
 		it('Should handle values greater than 65536 correctly', () => {
 			expect(() => {
-				checkEra(registry, 10, 65537);
+				createEra(registry, { kind: 'mortal', blockNumber: 10, period: 65537 });
 			}).toThrowError(InvalidEraPeriodTooHigh);
 			expect(() => {
-				checkEra(registry, 10, 70000);
+				createEra(registry, { kind: 'mortal', blockNumber: 10, period: 70000 });
 			}).toThrowError(InvalidEraPeriodTooHigh);
 		});
 
 		it('Should handle immortal transactions correctly', () => {
-			const eraImmortal = checkEra(registry, 10, undefined, true);
+			const eraImmortal = createEra(registry, { kind: 'immortal' });
 
 			expect(eraImmortal.isImmortalEra).toBe(true);
 			expect(eraImmortal.toHex()).toBe('0x00');

--- a/packages/txwrapper-core/src/core/method/defineMethod.ts
+++ b/packages/txwrapper-core/src/core/method/defineMethod.ts
@@ -19,9 +19,9 @@ import { createDecoratedTx, createMetadata } from '../metadata';
  */
 export enum MethodErrorMessages {
 	// An era period cannot be less than 4
-	InvalidEraPeriodToLow = 'lowest possible era period for a mortal tx is 4',
+	InvalidEraPeriodTooLow = 'lowest possible era period for a mortal tx is 4',
 	// An era period cannot be greater than 65536
-	InvalidEraPeriodToHigh = 'largest possible era period for a mortal tx is 65536',
+	InvalidEraPeriodTooHigh = 'largest possible era period for a mortal tx is 65536',
 	// Decorated tx doesnt have the inputted pallet or method
 	InvalidPalletOrMethod = 'pallet or method not found in metadata',
 }
@@ -56,7 +56,8 @@ export function checkEra(
 	eraPeriod: number = DEFAULTS.eraPeriod,
 	isImmortalEra?: boolean
 ): ExtrinsicEra {
-	const { InvalidEraPeriodToLow, InvalidEraPeriodToHigh } = MethodErrorMessages;
+	const { InvalidEraPeriodTooLow, InvalidEraPeriodTooHigh } =
+		MethodErrorMessages;
 	/**
 	 * Immortal transactions will be represented by the default value '0x00' for
 	 * an era.
@@ -67,15 +68,15 @@ export function checkEra(
 
 	/**
 	 * An era period cannot be less than 4 or greater than 65536.
-	 * ie. (https://github.com/paritytech/substrate/blob/master/primitives/runtime/src/generic/era.rs#L58)
+	 * ie. (https://github.com/paritytech/substrate/pull/758)
 	 *
 	 * It is encouraged to send mortal transactions, but in the use case for an immortal transaction
 	 * instead of passing in zero, you must use the `option`, `isImmortalEra`.
 	 */
 	if (eraPeriod < 4) {
-		throw Error(InvalidEraPeriodToLow);
+		throw Error(InvalidEraPeriodTooLow);
 	} else if (eraPeriod > 65536) {
-		throw Error(InvalidEraPeriodToHigh);
+		throw Error(InvalidEraPeriodTooHigh);
 	}
 
 	return registry.createType('ExtrinsicEra', {

--- a/packages/txwrapper-core/src/core/method/defineMethod.ts
+++ b/packages/txwrapper-core/src/core/method/defineMethod.ts
@@ -38,6 +38,7 @@ export function defineMethod(
 		asCallsOnlyArg,
 		signedExtensions,
 		userExtensions,
+		isImmortalEra,
 	} = options;
 	const generatedMetadata = createMetadata(
 		registry,
@@ -74,23 +75,26 @@ export function defineMethod(
 
 	/**
 	 * If the `info.eraPeriod` is set use it. (This also checks for the edgecase zero).
-	 * As a last resort, it will use the default value.
+	 * As a last resort, it will use the default value. If the eraPeriod is less than 4, 
+	 * for a mortal era, it will default to 4. 
 	 */
 	const eraPeriod =
 		info.eraPeriod === 0 || info.eraPeriod
 			? info.eraPeriod
 			: DEFAULTS.eraPeriod;
 
+	const extrinsicEra = isImmortalEra
+		? registry.createType('ExtrinsicEra')
+		: registry.createType('ExtrinsicEra', {
+				current: info.blockNumber,
+				period: eraPeriod,
+		  });
+
 	return {
 		address: info.address,
 		blockHash: info.blockHash,
 		blockNumber: registry.createType('BlockNumber', info.blockNumber).toHex(),
-		era: registry
-			.createType('ExtrinsicEra', {
-				current: info.blockNumber,
-				period: eraPeriod,
-			})
-			.toHex(),
+		era: extrinsicEra.toHex(),
 		genesisHash: info.genesisHash,
 		metadataRpc: generatedMetadata.toHex(),
 		method,

--- a/packages/txwrapper-core/src/core/method/defineMethod.ts
+++ b/packages/txwrapper-core/src/core/method/defineMethod.ts
@@ -75,8 +75,8 @@ export function defineMethod(
 
 	/**
 	 * If the `info.eraPeriod` is set use it. (This also checks for the edgecase zero).
-	 * As a last resort, it will use the default value. If the eraPeriod is less than 4, 
-	 * for a mortal era, it will default to 4. 
+	 * As a last resort, it will use the default value. If the eraPeriod is less than 4,
+	 * for a mortal era, it will default to 4.
 	 */
 	const eraPeriod =
 		info.eraPeriod === 0 || info.eraPeriod

--- a/packages/txwrapper-core/src/core/method/defineMethod.ts
+++ b/packages/txwrapper-core/src/core/method/defineMethod.ts
@@ -75,7 +75,7 @@ export function defineMethod(
 
 	/**
 	 * If the `info.eraPeriod` is set use it. (This also checks for the edgecase zero).
-	 * As a last resort, it will use the default value. If the eraPeriod is less than 4,
+	 * As a last resort, it will use the default value of 64. If the eraPeriod is less than 4,
 	 * for a mortal era, it will default to 4.
 	 */
 	const eraPeriod =

--- a/packages/txwrapper-core/src/types/method.ts
+++ b/packages/txwrapper-core/src/types/method.ts
@@ -122,4 +122,9 @@ export interface Options {
 	 * The type registry of the runtime.
 	 */
 	registry: TypeRegistry;
+	/**
+	 * Option to choose whether the constructed transaction will be immortal. By
+	 * default the number will be
+	 */
+	isImmortalEra?: boolean;
 }

--- a/packages/txwrapper-core/src/types/method.ts
+++ b/packages/txwrapper-core/src/types/method.ts
@@ -126,6 +126,8 @@ export interface Options {
 	 * Option to choose whether the constructed transaction will be immortal. If
 	 * immortal the default value will be '0x00', and when decoded it will return 0.
 	 * This option is used exclusively for unsigned transactions.
+	 *
+	 * Note: When creating an Immortal tx, the blockHash should be set as the genesis hash.
 	 */
 	isImmortalEra?: boolean;
 }

--- a/packages/txwrapper-core/src/types/method.ts
+++ b/packages/txwrapper-core/src/types/method.ts
@@ -123,8 +123,9 @@ export interface Options {
 	 */
 	registry: TypeRegistry;
 	/**
-	 * Option to choose whether the constructed transaction will be immortal. By
-	 * default the number will be
+	 * Option to choose whether the constructed transaction will be immortal. If
+	 * immortal the default value will be '0x00', and when decoded it will return 0.
+	 * This option is used exclusively for unsigned transactions.
 	 */
 	isImmortalEra?: boolean;
 }


### PR DESCRIPTION
## BREAKING CHANGE: It's a minor breaking change but breaking for some none the less. 

### Important Breaking Changes

`defineMethod` will now throw an error when the eraPeriod is less than 4 or greater than 65536. The default value will be 64 if none is passed in. The only way to bypass this is if you are creating an immortal tx.

### Feature:

`isImmortalEra` -> The interface type `options` is now given a key `isImmortalEra` which will allow the user to create an unsigned tx with an immortal era. The default value of this option will always be `undefined` ie. `false`. 

The decoded value of an immortal era will default to '0x00' or `0` via https://github.com/polkadot-js/api/blob/master/packages/types/src/extrinsic/constants.ts#L12.

This will be useful mainly in two places:

`decode` -> for unsigned transactions only.
`defineMethod` -> which residually means all methods used to create unsigned transactions. 

This PR, similar to https://github.com/paritytech/txwrapper-core/pull/200 will be followed up by a PR to update the docs before we release. 