### PR TITLE
docs: update the docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -78,6 +78,18 @@ yarn run lint
 yarn run lint --fix
 ```
 
+### Maintenence
+
+#### Yarn
+
+Txwrapper-core runs on yarn berry. It is a package manager local to the repo, and requires updating from time to time. The releases for yarn berry can be found [here](https://github.com/yarnpkg/berry/releases). Below are the steps to updating yarn. 
+
+```bash
+$ yarn set version <version>
+$ yarn
+$ yarn dedupe
+```
+
 ### Release & Publishing
 
 #### Preparation
@@ -106,14 +118,6 @@ yarn run lint --fix
     yarn run test
     yarn run lint
     ```
-
-    Note: some tests in `txwrapper-orml/src/methods/currencies/transferNativeCurrency.spec.ts` and `txwrapper-orml/src/methods/currencies/transfer.spec.ts` emit warnings that look like:
-
-    ```
-    REGISTRY: Unknown signed extensions SetEvmOrigin found, treating them as no-effect
-    ```
-
-    These are expected, and can be ignored.
 
 6. If all tests pass and all packages build successfully, commit your changes with the following format `fix(types): Update polkadot-js deps to get the latest types`. Then push your branch up to Github for review, then merge. The release tooling takes care of bumping the version so no need for a manual update (see below).
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -140,7 +140,7 @@ This libraries release process uses Lerna, and the following below is required t
     yarn run test
     ```
 
-4. Deploy the new release.
+4. Deploy the new release. It is important to note there will be a step that asks you to confirm whether or not the version bump is correct. Please confirm with the maintainers the suggested versions are correct.
 
     ```bash
     yarn run deploy

--- a/docs/interfaces/txwrapper_core_src.BaseTxInfo.md
+++ b/docs/interfaces/txwrapper_core_src.BaseTxInfo.md
@@ -37,7 +37,7 @@ The ss-58 encoded address of the sending account.
 
 #### Defined in
 
-[txwrapper-core/src/types/method.ts:71](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-core/src/types/method.ts#L71)
+[txwrapper-core/src/types/method.ts:71](https://github.com/paritytech/txwrapper-core/blob/9387f90/packages/txwrapper-core/src/types/method.ts#L71)
 
 ___
 
@@ -49,7 +49,7 @@ The checkpoint hash of the block, in hex.
 
 #### Defined in
 
-[txwrapper-core/src/types/method.ts:75](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-core/src/types/method.ts#L75)
+[txwrapper-core/src/types/method.ts:75](https://github.com/paritytech/txwrapper-core/blob/9387f90/packages/txwrapper-core/src/types/method.ts#L75)
 
 ___
 
@@ -61,7 +61,7 @@ The checkpoint block number (u32), in hex.
 
 #### Defined in
 
-[txwrapper-core/src/types/method.ts:79](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-core/src/types/method.ts#L79)
+[txwrapper-core/src/types/method.ts:79](https://github.com/paritytech/txwrapper-core/blob/9387f90/packages/txwrapper-core/src/types/method.ts#L79)
 
 ___
 
@@ -76,7 +76,7 @@ the `blockHash` field, in number of blocks. Defaults to 64 blocks.
 
 #### Defined in
 
-[txwrapper-core/src/types/method.ts:86](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-core/src/types/method.ts#L86)
+[txwrapper-core/src/types/method.ts:86](https://github.com/paritytech/txwrapper-core/blob/9387f90/packages/txwrapper-core/src/types/method.ts#L86)
 
 ___
 
@@ -88,7 +88,7 @@ The genesis hash of the chain, in hex.
 
 #### Defined in
 
-[txwrapper-core/src/types/method.ts:90](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-core/src/types/method.ts#L90)
+[txwrapper-core/src/types/method.ts:90](https://github.com/paritytech/txwrapper-core/blob/9387f90/packages/txwrapper-core/src/types/method.ts#L90)
 
 ___
 
@@ -101,7 +101,7 @@ call `state_getMetadata`.
 
 #### Defined in
 
-[txwrapper-core/src/types/method.ts:95](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-core/src/types/method.ts#L95)
+[txwrapper-core/src/types/method.ts:95](https://github.com/paritytech/txwrapper-core/blob/9387f90/packages/txwrapper-core/src/types/method.ts#L95)
 
 ___
 
@@ -113,7 +113,7 @@ The nonce for this transaction.
 
 #### Defined in
 
-[txwrapper-core/src/types/method.ts:99](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-core/src/types/method.ts#L99)
+[txwrapper-core/src/types/method.ts:99](https://github.com/paritytech/txwrapper-core/blob/9387f90/packages/txwrapper-core/src/types/method.ts#L99)
 
 ___
 
@@ -125,7 +125,7 @@ The current spec version of the runtime.
 
 #### Defined in
 
-[txwrapper-core/src/types/method.ts:103](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-core/src/types/method.ts#L103)
+[txwrapper-core/src/types/method.ts:103](https://github.com/paritytech/txwrapper-core/blob/9387f90/packages/txwrapper-core/src/types/method.ts#L103)
 
 ___
 
@@ -139,7 +139,7 @@ The tip for this transaction, in hex.
 
 #### Defined in
 
-[txwrapper-core/src/types/method.ts:109](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-core/src/types/method.ts#L109)
+[txwrapper-core/src/types/method.ts:109](https://github.com/paritytech/txwrapper-core/blob/9387f90/packages/txwrapper-core/src/types/method.ts#L109)
 
 ___
 
@@ -151,4 +151,4 @@ The current transaction version for the runtime.
 
 #### Defined in
 
-[txwrapper-core/src/types/method.ts:113](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-core/src/types/method.ts#L113)
+[txwrapper-core/src/types/method.ts:113](https://github.com/paritytech/txwrapper-core/blob/9387f90/packages/txwrapper-core/src/types/method.ts#L113)

--- a/docs/interfaces/txwrapper_core_src.BaseTxInfo.md
+++ b/docs/interfaces/txwrapper_core_src.BaseTxInfo.md
@@ -37,7 +37,7 @@ The ss-58 encoded address of the sending account.
 
 #### Defined in
 
-[txwrapper-core/src/types/method.ts:71](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-core/src/types/method.ts#L71)
+[txwrapper-core/src/types/method.ts:71](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-core/src/types/method.ts#L71)
 
 ___
 
@@ -49,7 +49,7 @@ The checkpoint hash of the block, in hex.
 
 #### Defined in
 
-[txwrapper-core/src/types/method.ts:75](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-core/src/types/method.ts#L75)
+[txwrapper-core/src/types/method.ts:75](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-core/src/types/method.ts#L75)
 
 ___
 
@@ -61,7 +61,7 @@ The checkpoint block number (u32), in hex.
 
 #### Defined in
 
-[txwrapper-core/src/types/method.ts:79](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-core/src/types/method.ts#L79)
+[txwrapper-core/src/types/method.ts:79](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-core/src/types/method.ts#L79)
 
 ___
 
@@ -76,7 +76,7 @@ the `blockHash` field, in number of blocks. Defaults to 64 blocks.
 
 #### Defined in
 
-[txwrapper-core/src/types/method.ts:86](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-core/src/types/method.ts#L86)
+[txwrapper-core/src/types/method.ts:86](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-core/src/types/method.ts#L86)
 
 ___
 
@@ -88,7 +88,7 @@ The genesis hash of the chain, in hex.
 
 #### Defined in
 
-[txwrapper-core/src/types/method.ts:90](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-core/src/types/method.ts#L90)
+[txwrapper-core/src/types/method.ts:90](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-core/src/types/method.ts#L90)
 
 ___
 
@@ -101,7 +101,7 @@ call `state_getMetadata`.
 
 #### Defined in
 
-[txwrapper-core/src/types/method.ts:95](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-core/src/types/method.ts#L95)
+[txwrapper-core/src/types/method.ts:95](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-core/src/types/method.ts#L95)
 
 ___
 
@@ -113,7 +113,7 @@ The nonce for this transaction.
 
 #### Defined in
 
-[txwrapper-core/src/types/method.ts:99](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-core/src/types/method.ts#L99)
+[txwrapper-core/src/types/method.ts:99](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-core/src/types/method.ts#L99)
 
 ___
 
@@ -125,7 +125,7 @@ The current spec version of the runtime.
 
 #### Defined in
 
-[txwrapper-core/src/types/method.ts:103](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-core/src/types/method.ts#L103)
+[txwrapper-core/src/types/method.ts:103](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-core/src/types/method.ts#L103)
 
 ___
 
@@ -139,7 +139,7 @@ The tip for this transaction, in hex.
 
 #### Defined in
 
-[txwrapper-core/src/types/method.ts:109](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-core/src/types/method.ts#L109)
+[txwrapper-core/src/types/method.ts:109](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-core/src/types/method.ts#L109)
 
 ___
 
@@ -151,4 +151,4 @@ The current transaction version for the runtime.
 
 #### Defined in
 
-[txwrapper-core/src/types/method.ts:113](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-core/src/types/method.ts#L113)
+[txwrapper-core/src/types/method.ts:113](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-core/src/types/method.ts#L113)

--- a/docs/interfaces/txwrapper_core_src.BaseTxInfo.md
+++ b/docs/interfaces/txwrapper_core_src.BaseTxInfo.md
@@ -37,7 +37,7 @@ The ss-58 encoded address of the sending account.
 
 #### Defined in
 
-[txwrapper-core/src/types/method.ts:62](https://github.com/paritytech/txwrapper-core/blob/a0283d9/packages/txwrapper-core/src/types/method.ts#L62)
+[txwrapper-core/src/types/method.ts:71](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-core/src/types/method.ts#L71)
 
 ___
 
@@ -49,7 +49,7 @@ The checkpoint hash of the block, in hex.
 
 #### Defined in
 
-[txwrapper-core/src/types/method.ts:66](https://github.com/paritytech/txwrapper-core/blob/a0283d9/packages/txwrapper-core/src/types/method.ts#L66)
+[txwrapper-core/src/types/method.ts:75](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-core/src/types/method.ts#L75)
 
 ___
 
@@ -61,7 +61,7 @@ The checkpoint block number (u32), in hex.
 
 #### Defined in
 
-[txwrapper-core/src/types/method.ts:70](https://github.com/paritytech/txwrapper-core/blob/a0283d9/packages/txwrapper-core/src/types/method.ts#L70)
+[txwrapper-core/src/types/method.ts:79](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-core/src/types/method.ts#L79)
 
 ___
 
@@ -76,7 +76,7 @@ the `blockHash` field, in number of blocks. Defaults to 64 blocks.
 
 #### Defined in
 
-[txwrapper-core/src/types/method.ts:77](https://github.com/paritytech/txwrapper-core/blob/a0283d9/packages/txwrapper-core/src/types/method.ts#L77)
+[txwrapper-core/src/types/method.ts:86](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-core/src/types/method.ts#L86)
 
 ___
 
@@ -88,7 +88,7 @@ The genesis hash of the chain, in hex.
 
 #### Defined in
 
-[txwrapper-core/src/types/method.ts:81](https://github.com/paritytech/txwrapper-core/blob/a0283d9/packages/txwrapper-core/src/types/method.ts#L81)
+[txwrapper-core/src/types/method.ts:90](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-core/src/types/method.ts#L90)
 
 ___
 
@@ -101,7 +101,7 @@ call `state_getMetadata`.
 
 #### Defined in
 
-[txwrapper-core/src/types/method.ts:86](https://github.com/paritytech/txwrapper-core/blob/a0283d9/packages/txwrapper-core/src/types/method.ts#L86)
+[txwrapper-core/src/types/method.ts:95](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-core/src/types/method.ts#L95)
 
 ___
 
@@ -113,7 +113,7 @@ The nonce for this transaction.
 
 #### Defined in
 
-[txwrapper-core/src/types/method.ts:90](https://github.com/paritytech/txwrapper-core/blob/a0283d9/packages/txwrapper-core/src/types/method.ts#L90)
+[txwrapper-core/src/types/method.ts:99](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-core/src/types/method.ts#L99)
 
 ___
 
@@ -125,7 +125,7 @@ The current spec version of the runtime.
 
 #### Defined in
 
-[txwrapper-core/src/types/method.ts:94](https://github.com/paritytech/txwrapper-core/blob/a0283d9/packages/txwrapper-core/src/types/method.ts#L94)
+[txwrapper-core/src/types/method.ts:103](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-core/src/types/method.ts#L103)
 
 ___
 
@@ -139,7 +139,7 @@ The tip for this transaction, in hex.
 
 #### Defined in
 
-[txwrapper-core/src/types/method.ts:100](https://github.com/paritytech/txwrapper-core/blob/a0283d9/packages/txwrapper-core/src/types/method.ts#L100)
+[txwrapper-core/src/types/method.ts:109](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-core/src/types/method.ts#L109)
 
 ___
 
@@ -151,4 +151,4 @@ The current transaction version for the runtime.
 
 #### Defined in
 
-[txwrapper-core/src/types/method.ts:104](https://github.com/paritytech/txwrapper-core/blob/a0283d9/packages/txwrapper-core/src/types/method.ts#L104)
+[txwrapper-core/src/types/method.ts:113](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-core/src/types/method.ts#L113)

--- a/docs/interfaces/txwrapper_core_src.ChainProperties.md
+++ b/docs/interfaces/txwrapper_core_src.ChainProperties.md
@@ -22,7 +22,7 @@ JSON object of ChainProperties codec from `@polkadot/api`.
 
 #### Defined in
 
-[txwrapper-core/src/types/codec.ts:5](https://github.com/paritytech/txwrapper-core/blob/a0283d9/packages/txwrapper-core/src/types/codec.ts#L5)
+[txwrapper-core/src/types/codec.ts:5](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-core/src/types/codec.ts#L5)
 
 ___
 
@@ -32,7 +32,7 @@ ___
 
 #### Defined in
 
-[txwrapper-core/src/types/codec.ts:6](https://github.com/paritytech/txwrapper-core/blob/a0283d9/packages/txwrapper-core/src/types/codec.ts#L6)
+[txwrapper-core/src/types/codec.ts:6](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-core/src/types/codec.ts#L6)
 
 ___
 
@@ -42,4 +42,4 @@ ___
 
 #### Defined in
 
-[txwrapper-core/src/types/codec.ts:7](https://github.com/paritytech/txwrapper-core/blob/a0283d9/packages/txwrapper-core/src/types/codec.ts#L7)
+[txwrapper-core/src/types/codec.ts:7](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-core/src/types/codec.ts#L7)

--- a/docs/interfaces/txwrapper_core_src.ChainProperties.md
+++ b/docs/interfaces/txwrapper_core_src.ChainProperties.md
@@ -22,7 +22,7 @@ JSON object of ChainProperties codec from `@polkadot/api`.
 
 #### Defined in
 
-[txwrapper-core/src/types/codec.ts:5](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-core/src/types/codec.ts#L5)
+[txwrapper-core/src/types/codec.ts:5](https://github.com/paritytech/txwrapper-core/blob/9387f90/packages/txwrapper-core/src/types/codec.ts#L5)
 
 ___
 
@@ -32,7 +32,7 @@ ___
 
 #### Defined in
 
-[txwrapper-core/src/types/codec.ts:6](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-core/src/types/codec.ts#L6)
+[txwrapper-core/src/types/codec.ts:6](https://github.com/paritytech/txwrapper-core/blob/9387f90/packages/txwrapper-core/src/types/codec.ts#L6)
 
 ___
 
@@ -42,4 +42,4 @@ ___
 
 #### Defined in
 
-[txwrapper-core/src/types/codec.ts:7](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-core/src/types/codec.ts#L7)
+[txwrapper-core/src/types/codec.ts:7](https://github.com/paritytech/txwrapper-core/blob/9387f90/packages/txwrapper-core/src/types/codec.ts#L7)

--- a/docs/interfaces/txwrapper_core_src.ChainProperties.md
+++ b/docs/interfaces/txwrapper_core_src.ChainProperties.md
@@ -22,7 +22,7 @@ JSON object of ChainProperties codec from `@polkadot/api`.
 
 #### Defined in
 
-[txwrapper-core/src/types/codec.ts:5](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-core/src/types/codec.ts#L5)
+[txwrapper-core/src/types/codec.ts:5](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-core/src/types/codec.ts#L5)
 
 ___
 
@@ -32,7 +32,7 @@ ___
 
 #### Defined in
 
-[txwrapper-core/src/types/codec.ts:6](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-core/src/types/codec.ts#L6)
+[txwrapper-core/src/types/codec.ts:6](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-core/src/types/codec.ts#L6)
 
 ___
 
@@ -42,4 +42,4 @@ ___
 
 #### Defined in
 
-[txwrapper-core/src/types/codec.ts:7](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-core/src/types/codec.ts#L7)
+[txwrapper-core/src/types/codec.ts:7](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-core/src/types/codec.ts#L7)

--- a/docs/interfaces/txwrapper_core_src.DecodedUnsignedHexTx.md
+++ b/docs/interfaces/txwrapper_core_src.DecodedUnsignedHexTx.md
@@ -23,7 +23,7 @@ which is the counterpart to `encodeUnsignedTransaction`.
 
 #### Defined in
 
-[txwrapper-core/src/types/decode.ts:23](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-core/src/types/decode.ts#L23)
+[txwrapper-core/src/types/decode.ts:23](https://github.com/paritytech/txwrapper-core/blob/9387f90/packages/txwrapper-core/src/types/decode.ts#L23)
 
 ___
 
@@ -33,4 +33,4 @@ ___
 
 #### Defined in
 
-[txwrapper-core/src/types/decode.ts:24](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-core/src/types/decode.ts#L24)
+[txwrapper-core/src/types/decode.ts:24](https://github.com/paritytech/txwrapper-core/blob/9387f90/packages/txwrapper-core/src/types/decode.ts#L24)

--- a/docs/interfaces/txwrapper_core_src.DecodedUnsignedHexTx.md
+++ b/docs/interfaces/txwrapper_core_src.DecodedUnsignedHexTx.md
@@ -1,0 +1,36 @@
+[txwrapper-core](../README.md) / [Modules](../modules.md) / [txwrapper-core/src](../modules/txwrapper_core_src.md) / DecodedUnsignedHexTx
+
+# Interface: DecodedUnsignedHexTx
+
+[txwrapper-core/src](../modules/txwrapper_core_src.md).DecodedUnsignedHexTx
+
+This Decode type is not included as a return type for the standard `txwrapper-core`
+`decode` utility function. Instead this is specific to `decodeUnsignedHexTx`,
+which is the counterpart to `encodeUnsignedTransaction`.
+
+## Table of contents
+
+### Properties
+
+- [method](txwrapper_core_src.DecodedUnsignedHexTx.md#method)
+- [version](txwrapper_core_src.DecodedUnsignedHexTx.md#version)
+
+## Properties
+
+### method
+
+• **method**: [`IMethod`](txwrapper_core_src.IMethod.md)
+
+#### Defined in
+
+[txwrapper-core/src/types/decode.ts:23](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-core/src/types/decode.ts#L23)
+
+___
+
+### version
+
+• **version**: `number`
+
+#### Defined in
+
+[txwrapper-core/src/types/decode.ts:24](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-core/src/types/decode.ts#L24)

--- a/docs/interfaces/txwrapper_core_src.DecodedUnsignedHexTx.md
+++ b/docs/interfaces/txwrapper_core_src.DecodedUnsignedHexTx.md
@@ -23,7 +23,7 @@ which is the counterpart to `encodeUnsignedTransaction`.
 
 #### Defined in
 
-[txwrapper-core/src/types/decode.ts:23](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-core/src/types/decode.ts#L23)
+[txwrapper-core/src/types/decode.ts:23](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-core/src/types/decode.ts#L23)
 
 ___
 
@@ -33,4 +33,4 @@ ___
 
 #### Defined in
 
-[txwrapper-core/src/types/decode.ts:24](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-core/src/types/decode.ts#L24)
+[txwrapper-core/src/types/decode.ts:24](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-core/src/types/decode.ts#L24)

--- a/docs/interfaces/txwrapper_core_src.GetRegistryOptsCore.md
+++ b/docs/interfaces/txwrapper_core_src.GetRegistryOptsCore.md
@@ -35,7 +35,7 @@ Used to reduce the metadata size by only having the calls
 
 #### Defined in
 
-[txwrapper-core/src/types/registry.ts:32](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-core/src/types/registry.ts#L32)
+[txwrapper-core/src/types/registry.ts:32](https://github.com/paritytech/txwrapper-core/blob/9387f90/packages/txwrapper-core/src/types/registry.ts#L32)
 
 ___
 
@@ -47,7 +47,7 @@ chainName
 
 #### Defined in
 
-[txwrapper-core/src/types/registry.ts:16](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-core/src/types/registry.ts#L16)
+[txwrapper-core/src/types/registry.ts:16](https://github.com/paritytech/txwrapper-core/blob/9387f90/packages/txwrapper-core/src/types/registry.ts#L16)
 
 ___
 
@@ -59,7 +59,7 @@ SCALE encoded runtime metadata as a hex string
 
 #### Defined in
 
-[txwrapper-core/src/types/registry.ts:24](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-core/src/types/registry.ts#L24)
+[txwrapper-core/src/types/registry.ts:24](https://github.com/paritytech/txwrapper-core/blob/9387f90/packages/txwrapper-core/src/types/registry.ts#L24)
 
 ___
 
@@ -71,7 +71,7 @@ Chain ss58format, token decimals, and token ID
 
 #### Defined in
 
-[txwrapper-core/src/types/registry.ts:28](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-core/src/types/registry.ts#L28)
+[txwrapper-core/src/types/registry.ts:28](https://github.com/paritytech/txwrapper-core/blob/9387f90/packages/txwrapper-core/src/types/registry.ts#L28)
 
 ___
 
@@ -83,7 +83,7 @@ Array of signedExtensions
 
 #### Defined in
 
-[txwrapper-core/src/types/registry.ts:36](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-core/src/types/registry.ts#L36)
+[txwrapper-core/src/types/registry.ts:36](https://github.com/paritytech/txwrapper-core/blob/9387f90/packages/txwrapper-core/src/types/registry.ts#L36)
 
 ___
 
@@ -95,7 +95,7 @@ Runtime specName
 
 #### Defined in
 
-[txwrapper-core/src/types/registry.ts:12](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-core/src/types/registry.ts#L12)
+[txwrapper-core/src/types/registry.ts:12](https://github.com/paritytech/txwrapper-core/blob/9387f90/packages/txwrapper-core/src/types/registry.ts#L12)
 
 ___
 
@@ -107,7 +107,7 @@ Runtime specVersion
 
 #### Defined in
 
-[txwrapper-core/src/types/registry.ts:20](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-core/src/types/registry.ts#L20)
+[txwrapper-core/src/types/registry.ts:20](https://github.com/paritytech/txwrapper-core/blob/9387f90/packages/txwrapper-core/src/types/registry.ts#L20)
 
 ___
 
@@ -119,4 +119,4 @@ User extensions used to inject into the type registry
 
 #### Defined in
 
-[txwrapper-core/src/types/registry.ts:40](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-core/src/types/registry.ts#L40)
+[txwrapper-core/src/types/registry.ts:40](https://github.com/paritytech/txwrapper-core/blob/9387f90/packages/txwrapper-core/src/types/registry.ts#L40)

--- a/docs/interfaces/txwrapper_core_src.GetRegistryOptsCore.md
+++ b/docs/interfaces/txwrapper_core_src.GetRegistryOptsCore.md
@@ -20,8 +20,10 @@ Options for `getRegistry*` functions.
 - [chainName](txwrapper_core_src.GetRegistryOptsCore.md#chainname)
 - [metadataRpc](txwrapper_core_src.GetRegistryOptsCore.md#metadatarpc)
 - [properties](txwrapper_core_src.GetRegistryOptsCore.md#properties)
+- [signedExtensions](txwrapper_core_src.GetRegistryOptsCore.md#signedextensions)
 - [specName](txwrapper_core_src.GetRegistryOptsCore.md#specname)
 - [specVersion](txwrapper_core_src.GetRegistryOptsCore.md#specversion)
+- [userExtensions](txwrapper_core_src.GetRegistryOptsCore.md#userextensions)
 
 ## Properties
 
@@ -33,7 +35,7 @@ Used to reduce the metadata size by only having the calls
 
 #### Defined in
 
-[txwrapper-core/src/types/registry.ts:30](https://github.com/paritytech/txwrapper-core/blob/a0283d9/packages/txwrapper-core/src/types/registry.ts#L30)
+[txwrapper-core/src/types/registry.ts:32](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-core/src/types/registry.ts#L32)
 
 ___
 
@@ -45,7 +47,7 @@ chainName
 
 #### Defined in
 
-[txwrapper-core/src/types/registry.ts:14](https://github.com/paritytech/txwrapper-core/blob/a0283d9/packages/txwrapper-core/src/types/registry.ts#L14)
+[txwrapper-core/src/types/registry.ts:16](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-core/src/types/registry.ts#L16)
 
 ___
 
@@ -57,7 +59,7 @@ SCALE encoded runtime metadata as a hex string
 
 #### Defined in
 
-[txwrapper-core/src/types/registry.ts:22](https://github.com/paritytech/txwrapper-core/blob/a0283d9/packages/txwrapper-core/src/types/registry.ts#L22)
+[txwrapper-core/src/types/registry.ts:24](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-core/src/types/registry.ts#L24)
 
 ___
 
@@ -69,7 +71,19 @@ Chain ss58format, token decimals, and token ID
 
 #### Defined in
 
-[txwrapper-core/src/types/registry.ts:26](https://github.com/paritytech/txwrapper-core/blob/a0283d9/packages/txwrapper-core/src/types/registry.ts#L26)
+[txwrapper-core/src/types/registry.ts:28](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-core/src/types/registry.ts#L28)
+
+___
+
+### signedExtensions
+
+• `Optional` **signedExtensions**: `string`[]
+
+Array of signedExtensions
+
+#### Defined in
+
+[txwrapper-core/src/types/registry.ts:36](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-core/src/types/registry.ts#L36)
 
 ___
 
@@ -81,7 +95,7 @@ Runtime specName
 
 #### Defined in
 
-[txwrapper-core/src/types/registry.ts:10](https://github.com/paritytech/txwrapper-core/blob/a0283d9/packages/txwrapper-core/src/types/registry.ts#L10)
+[txwrapper-core/src/types/registry.ts:12](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-core/src/types/registry.ts#L12)
 
 ___
 
@@ -93,4 +107,16 @@ Runtime specVersion
 
 #### Defined in
 
-[txwrapper-core/src/types/registry.ts:18](https://github.com/paritytech/txwrapper-core/blob/a0283d9/packages/txwrapper-core/src/types/registry.ts#L18)
+[txwrapper-core/src/types/registry.ts:20](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-core/src/types/registry.ts#L20)
+
+___
+
+### userExtensions
+
+• `Optional` **userExtensions**: `ExtDef`
+
+User extensions used to inject into the type registry
+
+#### Defined in
+
+[txwrapper-core/src/types/registry.ts:40](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-core/src/types/registry.ts#L40)

--- a/docs/interfaces/txwrapper_core_src.GetRegistryOptsCore.md
+++ b/docs/interfaces/txwrapper_core_src.GetRegistryOptsCore.md
@@ -35,7 +35,7 @@ Used to reduce the metadata size by only having the calls
 
 #### Defined in
 
-[txwrapper-core/src/types/registry.ts:32](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-core/src/types/registry.ts#L32)
+[txwrapper-core/src/types/registry.ts:32](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-core/src/types/registry.ts#L32)
 
 ___
 
@@ -47,7 +47,7 @@ chainName
 
 #### Defined in
 
-[txwrapper-core/src/types/registry.ts:16](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-core/src/types/registry.ts#L16)
+[txwrapper-core/src/types/registry.ts:16](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-core/src/types/registry.ts#L16)
 
 ___
 
@@ -59,7 +59,7 @@ SCALE encoded runtime metadata as a hex string
 
 #### Defined in
 
-[txwrapper-core/src/types/registry.ts:24](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-core/src/types/registry.ts#L24)
+[txwrapper-core/src/types/registry.ts:24](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-core/src/types/registry.ts#L24)
 
 ___
 
@@ -71,7 +71,7 @@ Chain ss58format, token decimals, and token ID
 
 #### Defined in
 
-[txwrapper-core/src/types/registry.ts:28](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-core/src/types/registry.ts#L28)
+[txwrapper-core/src/types/registry.ts:28](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-core/src/types/registry.ts#L28)
 
 ___
 
@@ -83,7 +83,7 @@ Array of signedExtensions
 
 #### Defined in
 
-[txwrapper-core/src/types/registry.ts:36](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-core/src/types/registry.ts#L36)
+[txwrapper-core/src/types/registry.ts:36](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-core/src/types/registry.ts#L36)
 
 ___
 
@@ -95,7 +95,7 @@ Runtime specName
 
 #### Defined in
 
-[txwrapper-core/src/types/registry.ts:12](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-core/src/types/registry.ts#L12)
+[txwrapper-core/src/types/registry.ts:12](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-core/src/types/registry.ts#L12)
 
 ___
 
@@ -107,7 +107,7 @@ Runtime specVersion
 
 #### Defined in
 
-[txwrapper-core/src/types/registry.ts:20](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-core/src/types/registry.ts#L20)
+[txwrapper-core/src/types/registry.ts:20](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-core/src/types/registry.ts#L20)
 
 ___
 
@@ -119,4 +119,4 @@ User extensions used to inject into the type registry
 
 #### Defined in
 
-[txwrapper-core/src/types/registry.ts:40](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-core/src/types/registry.ts#L40)
+[txwrapper-core/src/types/registry.ts:40](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-core/src/types/registry.ts#L40)

--- a/docs/interfaces/txwrapper_core_src.IMethod.md
+++ b/docs/interfaces/txwrapper_core_src.IMethod.md
@@ -1,0 +1,34 @@
+[txwrapper-core](../README.md) / [Modules](../modules.md) / [txwrapper-core/src](../modules/txwrapper_core_src.md) / IMethod
+
+# Interface: IMethod
+
+[txwrapper-core/src](../modules/txwrapper_core_src.md).IMethod
+
+Primitive version of `DecodeMethodInput` interface from polkadot-js.
+
+## Table of contents
+
+### Properties
+
+- [args](txwrapper_core_src.IMethod.md#args)
+- [callIndex](txwrapper_core_src.IMethod.md#callindex)
+
+## Properties
+
+### args
+
+• **args**: `unknown`
+
+#### Defined in
+
+[txwrapper-core/src/types/decode.ts:31](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-core/src/types/decode.ts#L31)
+
+___
+
+### callIndex
+
+• **callIndex**: `string`
+
+#### Defined in
+
+[txwrapper-core/src/types/decode.ts:32](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-core/src/types/decode.ts#L32)

--- a/docs/interfaces/txwrapper_core_src.IMethod.md
+++ b/docs/interfaces/txwrapper_core_src.IMethod.md
@@ -21,7 +21,7 @@ Primitive version of `DecodeMethodInput` interface from polkadot-js.
 
 #### Defined in
 
-[txwrapper-core/src/types/decode.ts:31](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-core/src/types/decode.ts#L31)
+[txwrapper-core/src/types/decode.ts:31](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-core/src/types/decode.ts#L31)
 
 ___
 
@@ -31,4 +31,4 @@ ___
 
 #### Defined in
 
-[txwrapper-core/src/types/decode.ts:32](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-core/src/types/decode.ts#L32)
+[txwrapper-core/src/types/decode.ts:32](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-core/src/types/decode.ts#L32)

--- a/docs/interfaces/txwrapper_core_src.IMethod.md
+++ b/docs/interfaces/txwrapper_core_src.IMethod.md
@@ -21,7 +21,7 @@ Primitive version of `DecodeMethodInput` interface from polkadot-js.
 
 #### Defined in
 
-[txwrapper-core/src/types/decode.ts:31](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-core/src/types/decode.ts#L31)
+[txwrapper-core/src/types/decode.ts:31](https://github.com/paritytech/txwrapper-core/blob/9387f90/packages/txwrapper-core/src/types/decode.ts#L31)
 
 ___
 
@@ -31,4 +31,4 @@ ___
 
 #### Defined in
 
-[txwrapper-core/src/types/decode.ts:32](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-core/src/types/decode.ts#L32)
+[txwrapper-core/src/types/decode.ts:32](https://github.com/paritytech/txwrapper-core/blob/9387f90/packages/txwrapper-core/src/types/decode.ts#L32)

--- a/docs/interfaces/txwrapper_core_src.Options.md
+++ b/docs/interfaces/txwrapper_core_src.Options.md
@@ -17,9 +17,26 @@ functions that only require registry.
 
 ### Properties
 
+- [isImmortalEra](txwrapper_core_src.Options.md#isimmortalera)
 - [registry](txwrapper_core_src.Options.md#registry)
 
 ## Properties
+
+### isImmortalEra
+
+• `Optional` **isImmortalEra**: `boolean`
+
+Option to choose whether the constructed transaction will be immortal. If
+immortal the default value will be '0x00', and when decoded it will return 0.
+This option is used exclusively for unsigned transactions.
+
+Note: When creating an Immortal tx, the blockHash should be set as the genesis hash.
+
+#### Defined in
+
+[txwrapper-core/src/types/method.ts:132](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-core/src/types/method.ts#L132)
+
+___
 
 ### registry
 
@@ -29,4 +46,4 @@ The type registry of the runtime.
 
 #### Defined in
 
-[txwrapper-core/src/types/method.ts:124](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-core/src/types/method.ts#L124)
+[txwrapper-core/src/types/method.ts:124](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-core/src/types/method.ts#L124)

--- a/docs/interfaces/txwrapper_core_src.Options.md
+++ b/docs/interfaces/txwrapper_core_src.Options.md
@@ -29,4 +29,4 @@ The type registry of the runtime.
 
 #### Defined in
 
-[txwrapper-core/src/types/method.ts:115](https://github.com/paritytech/txwrapper-core/blob/a0283d9/packages/txwrapper-core/src/types/method.ts#L115)
+[txwrapper-core/src/types/method.ts:124](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-core/src/types/method.ts#L124)

--- a/docs/interfaces/txwrapper_core_src.Options.md
+++ b/docs/interfaces/txwrapper_core_src.Options.md
@@ -34,7 +34,7 @@ Note: When creating an Immortal tx, the blockHash should be set as the genesis h
 
 #### Defined in
 
-[txwrapper-core/src/types/method.ts:132](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-core/src/types/method.ts#L132)
+[txwrapper-core/src/types/method.ts:132](https://github.com/paritytech/txwrapper-core/blob/9387f90/packages/txwrapper-core/src/types/method.ts#L132)
 
 ___
 
@@ -46,4 +46,4 @@ The type registry of the runtime.
 
 #### Defined in
 
-[txwrapper-core/src/types/method.ts:124](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-core/src/types/method.ts#L124)
+[txwrapper-core/src/types/method.ts:124](https://github.com/paritytech/txwrapper-core/blob/9387f90/packages/txwrapper-core/src/types/method.ts#L124)

--- a/docs/interfaces/txwrapper_core_src.OptionsWithMeta.md
+++ b/docs/interfaces/txwrapper_core_src.OptionsWithMeta.md
@@ -18,6 +18,7 @@ options to functions that require registry and metadata.
 ### Properties
 
 - [asCallsOnlyArg](txwrapper_core_src.OptionsWithMeta.md#ascallsonlyarg)
+- [isImmortalEra](txwrapper_core_src.OptionsWithMeta.md#isimmortalera)
 - [metadataRpc](txwrapper_core_src.OptionsWithMeta.md#metadatarpc)
 - [registry](txwrapper_core_src.OptionsWithMeta.md#registry)
 - [signedExtensions](txwrapper_core_src.OptionsWithMeta.md#signedextensions)
@@ -33,7 +34,27 @@ Used to reduce the metadata size by only having the calls
 
 #### Defined in
 
-[txwrapper-core/src/types/method.ts:21](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-core/src/types/method.ts#L21)
+[txwrapper-core/src/types/method.ts:21](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-core/src/types/method.ts#L21)
+
+___
+
+### isImmortalEra
+
+• `Optional` **isImmortalEra**: `boolean`
+
+Option to choose whether the constructed transaction will be immortal. If
+immortal the default value will be '0x00', and when decoded it will return 0.
+This option is used exclusively for unsigned transactions.
+
+Note: When creating an Immortal tx, the blockHash should be set as the genesis hash.
+
+#### Inherited from
+
+[Options](txwrapper_core_src.Options.md).[isImmortalEra](txwrapper_core_src.Options.md#isimmortalera)
+
+#### Defined in
+
+[txwrapper-core/src/types/method.ts:132](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-core/src/types/method.ts#L132)
 
 ___
 
@@ -45,7 +66,7 @@ The metadata of the runtime.
 
 #### Defined in
 
-[txwrapper-core/src/types/method.ts:17](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-core/src/types/method.ts#L17)
+[txwrapper-core/src/types/method.ts:17](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-core/src/types/method.ts#L17)
 
 ___
 
@@ -61,7 +82,7 @@ The type registry of the runtime.
 
 #### Defined in
 
-[txwrapper-core/src/types/method.ts:124](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-core/src/types/method.ts#L124)
+[txwrapper-core/src/types/method.ts:124](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-core/src/types/method.ts#L124)
 
 ___
 
@@ -73,7 +94,7 @@ Array of signedExtensions
 
 #### Defined in
 
-[txwrapper-core/src/types/method.ts:25](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-core/src/types/method.ts#L25)
+[txwrapper-core/src/types/method.ts:25](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-core/src/types/method.ts#L25)
 
 ___
 
@@ -85,4 +106,4 @@ User extensions used to inject into the type registry
 
 #### Defined in
 
-[txwrapper-core/src/types/method.ts:29](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-core/src/types/method.ts#L29)
+[txwrapper-core/src/types/method.ts:29](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-core/src/types/method.ts#L29)

--- a/docs/interfaces/txwrapper_core_src.OptionsWithMeta.md
+++ b/docs/interfaces/txwrapper_core_src.OptionsWithMeta.md
@@ -34,7 +34,7 @@ Used to reduce the metadata size by only having the calls
 
 #### Defined in
 
-[txwrapper-core/src/types/method.ts:21](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-core/src/types/method.ts#L21)
+[txwrapper-core/src/types/method.ts:21](https://github.com/paritytech/txwrapper-core/blob/9387f90/packages/txwrapper-core/src/types/method.ts#L21)
 
 ___
 
@@ -54,7 +54,7 @@ Note: When creating an Immortal tx, the blockHash should be set as the genesis h
 
 #### Defined in
 
-[txwrapper-core/src/types/method.ts:132](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-core/src/types/method.ts#L132)
+[txwrapper-core/src/types/method.ts:132](https://github.com/paritytech/txwrapper-core/blob/9387f90/packages/txwrapper-core/src/types/method.ts#L132)
 
 ___
 
@@ -66,7 +66,7 @@ The metadata of the runtime.
 
 #### Defined in
 
-[txwrapper-core/src/types/method.ts:17](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-core/src/types/method.ts#L17)
+[txwrapper-core/src/types/method.ts:17](https://github.com/paritytech/txwrapper-core/blob/9387f90/packages/txwrapper-core/src/types/method.ts#L17)
 
 ___
 
@@ -82,7 +82,7 @@ The type registry of the runtime.
 
 #### Defined in
 
-[txwrapper-core/src/types/method.ts:124](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-core/src/types/method.ts#L124)
+[txwrapper-core/src/types/method.ts:124](https://github.com/paritytech/txwrapper-core/blob/9387f90/packages/txwrapper-core/src/types/method.ts#L124)
 
 ___
 
@@ -94,7 +94,7 @@ Array of signedExtensions
 
 #### Defined in
 
-[txwrapper-core/src/types/method.ts:25](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-core/src/types/method.ts#L25)
+[txwrapper-core/src/types/method.ts:25](https://github.com/paritytech/txwrapper-core/blob/9387f90/packages/txwrapper-core/src/types/method.ts#L25)
 
 ___
 
@@ -106,4 +106,4 @@ User extensions used to inject into the type registry
 
 #### Defined in
 
-[txwrapper-core/src/types/method.ts:29](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-core/src/types/method.ts#L29)
+[txwrapper-core/src/types/method.ts:29](https://github.com/paritytech/txwrapper-core/blob/9387f90/packages/txwrapper-core/src/types/method.ts#L29)

--- a/docs/interfaces/txwrapper_core_src.OptionsWithMeta.md
+++ b/docs/interfaces/txwrapper_core_src.OptionsWithMeta.md
@@ -20,6 +20,8 @@ options to functions that require registry and metadata.
 - [asCallsOnlyArg](txwrapper_core_src.OptionsWithMeta.md#ascallsonlyarg)
 - [metadataRpc](txwrapper_core_src.OptionsWithMeta.md#metadatarpc)
 - [registry](txwrapper_core_src.OptionsWithMeta.md#registry)
+- [signedExtensions](txwrapper_core_src.OptionsWithMeta.md#signedextensions)
+- [userExtensions](txwrapper_core_src.OptionsWithMeta.md#userextensions)
 
 ## Properties
 
@@ -31,7 +33,7 @@ Used to reduce the metadata size by only having the calls
 
 #### Defined in
 
-[txwrapper-core/src/types/method.ts:20](https://github.com/paritytech/txwrapper-core/blob/a0283d9/packages/txwrapper-core/src/types/method.ts#L20)
+[txwrapper-core/src/types/method.ts:21](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-core/src/types/method.ts#L21)
 
 ___
 
@@ -43,7 +45,7 @@ The metadata of the runtime.
 
 #### Defined in
 
-[txwrapper-core/src/types/method.ts:16](https://github.com/paritytech/txwrapper-core/blob/a0283d9/packages/txwrapper-core/src/types/method.ts#L16)
+[txwrapper-core/src/types/method.ts:17](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-core/src/types/method.ts#L17)
 
 ___
 
@@ -59,4 +61,28 @@ The type registry of the runtime.
 
 #### Defined in
 
-[txwrapper-core/src/types/method.ts:115](https://github.com/paritytech/txwrapper-core/blob/a0283d9/packages/txwrapper-core/src/types/method.ts#L115)
+[txwrapper-core/src/types/method.ts:124](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-core/src/types/method.ts#L124)
+
+___
+
+### signedExtensions
+
+• `Optional` **signedExtensions**: `string`[]
+
+Array of signedExtensions
+
+#### Defined in
+
+[txwrapper-core/src/types/method.ts:25](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-core/src/types/method.ts#L25)
+
+___
+
+### userExtensions
+
+• `Optional` **userExtensions**: `ExtDef`
+
+User extensions used to inject into the type registry
+
+#### Defined in
+
+[txwrapper-core/src/types/method.ts:29](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-core/src/types/method.ts#L29)

--- a/docs/interfaces/txwrapper_core_src.TxInfo.md
+++ b/docs/interfaces/txwrapper_core_src.TxInfo.md
@@ -42,7 +42,7 @@ The ss-58 encoded address of the sending account.
 
 #### Defined in
 
-[txwrapper-core/src/types/method.ts:62](https://github.com/paritytech/txwrapper-core/blob/a0283d9/packages/txwrapper-core/src/types/method.ts#L62)
+[txwrapper-core/src/types/method.ts:71](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-core/src/types/method.ts#L71)
 
 ___
 
@@ -58,7 +58,7 @@ The checkpoint hash of the block, in hex.
 
 #### Defined in
 
-[txwrapper-core/src/types/method.ts:66](https://github.com/paritytech/txwrapper-core/blob/a0283d9/packages/txwrapper-core/src/types/method.ts#L66)
+[txwrapper-core/src/types/method.ts:75](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-core/src/types/method.ts#L75)
 
 ___
 
@@ -74,7 +74,7 @@ The checkpoint block number (u32), in hex.
 
 #### Defined in
 
-[txwrapper-core/src/types/method.ts:70](https://github.com/paritytech/txwrapper-core/blob/a0283d9/packages/txwrapper-core/src/types/method.ts#L70)
+[txwrapper-core/src/types/method.ts:79](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-core/src/types/method.ts#L79)
 
 ___
 
@@ -93,7 +93,7 @@ the `blockHash` field, in number of blocks. Defaults to 64 blocks.
 
 #### Defined in
 
-[txwrapper-core/src/types/method.ts:77](https://github.com/paritytech/txwrapper-core/blob/a0283d9/packages/txwrapper-core/src/types/method.ts#L77)
+[txwrapper-core/src/types/method.ts:86](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-core/src/types/method.ts#L86)
 
 ___
 
@@ -109,7 +109,7 @@ The genesis hash of the chain, in hex.
 
 #### Defined in
 
-[txwrapper-core/src/types/method.ts:81](https://github.com/paritytech/txwrapper-core/blob/a0283d9/packages/txwrapper-core/src/types/method.ts#L81)
+[txwrapper-core/src/types/method.ts:90](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-core/src/types/method.ts#L90)
 
 ___
 
@@ -126,7 +126,7 @@ call `state_getMetadata`.
 
 #### Defined in
 
-[txwrapper-core/src/types/method.ts:86](https://github.com/paritytech/txwrapper-core/blob/a0283d9/packages/txwrapper-core/src/types/method.ts#L86)
+[txwrapper-core/src/types/method.ts:95](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-core/src/types/method.ts#L95)
 
 ___
 
@@ -136,7 +136,7 @@ ___
 
 #### Defined in
 
-[txwrapper-core/src/types/method.ts:41](https://github.com/paritytech/txwrapper-core/blob/a0283d9/packages/txwrapper-core/src/types/method.ts#L41)
+[txwrapper-core/src/types/method.ts:50](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-core/src/types/method.ts#L50)
 
 ___
 
@@ -152,7 +152,7 @@ The nonce for this transaction.
 
 #### Defined in
 
-[txwrapper-core/src/types/method.ts:90](https://github.com/paritytech/txwrapper-core/blob/a0283d9/packages/txwrapper-core/src/types/method.ts#L90)
+[txwrapper-core/src/types/method.ts:99](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-core/src/types/method.ts#L99)
 
 ___
 
@@ -168,7 +168,7 @@ The current spec version of the runtime.
 
 #### Defined in
 
-[txwrapper-core/src/types/method.ts:94](https://github.com/paritytech/txwrapper-core/blob/a0283d9/packages/txwrapper-core/src/types/method.ts#L94)
+[txwrapper-core/src/types/method.ts:103](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-core/src/types/method.ts#L103)
 
 ___
 
@@ -186,7 +186,7 @@ The tip for this transaction, in hex.
 
 #### Defined in
 
-[txwrapper-core/src/types/method.ts:100](https://github.com/paritytech/txwrapper-core/blob/a0283d9/packages/txwrapper-core/src/types/method.ts#L100)
+[txwrapper-core/src/types/method.ts:109](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-core/src/types/method.ts#L109)
 
 ___
 
@@ -202,4 +202,4 @@ The current transaction version for the runtime.
 
 #### Defined in
 
-[txwrapper-core/src/types/method.ts:104](https://github.com/paritytech/txwrapper-core/blob/a0283d9/packages/txwrapper-core/src/types/method.ts#L104)
+[txwrapper-core/src/types/method.ts:113](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-core/src/types/method.ts#L113)

--- a/docs/interfaces/txwrapper_core_src.TxInfo.md
+++ b/docs/interfaces/txwrapper_core_src.TxInfo.md
@@ -42,7 +42,7 @@ The ss-58 encoded address of the sending account.
 
 #### Defined in
 
-[txwrapper-core/src/types/method.ts:71](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-core/src/types/method.ts#L71)
+[txwrapper-core/src/types/method.ts:71](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-core/src/types/method.ts#L71)
 
 ___
 
@@ -58,7 +58,7 @@ The checkpoint hash of the block, in hex.
 
 #### Defined in
 
-[txwrapper-core/src/types/method.ts:75](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-core/src/types/method.ts#L75)
+[txwrapper-core/src/types/method.ts:75](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-core/src/types/method.ts#L75)
 
 ___
 
@@ -74,7 +74,7 @@ The checkpoint block number (u32), in hex.
 
 #### Defined in
 
-[txwrapper-core/src/types/method.ts:79](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-core/src/types/method.ts#L79)
+[txwrapper-core/src/types/method.ts:79](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-core/src/types/method.ts#L79)
 
 ___
 
@@ -93,7 +93,7 @@ the `blockHash` field, in number of blocks. Defaults to 64 blocks.
 
 #### Defined in
 
-[txwrapper-core/src/types/method.ts:86](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-core/src/types/method.ts#L86)
+[txwrapper-core/src/types/method.ts:86](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-core/src/types/method.ts#L86)
 
 ___
 
@@ -109,7 +109,7 @@ The genesis hash of the chain, in hex.
 
 #### Defined in
 
-[txwrapper-core/src/types/method.ts:90](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-core/src/types/method.ts#L90)
+[txwrapper-core/src/types/method.ts:90](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-core/src/types/method.ts#L90)
 
 ___
 
@@ -126,7 +126,7 @@ call `state_getMetadata`.
 
 #### Defined in
 
-[txwrapper-core/src/types/method.ts:95](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-core/src/types/method.ts#L95)
+[txwrapper-core/src/types/method.ts:95](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-core/src/types/method.ts#L95)
 
 ___
 
@@ -136,7 +136,7 @@ ___
 
 #### Defined in
 
-[txwrapper-core/src/types/method.ts:50](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-core/src/types/method.ts#L50)
+[txwrapper-core/src/types/method.ts:50](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-core/src/types/method.ts#L50)
 
 ___
 
@@ -152,7 +152,7 @@ The nonce for this transaction.
 
 #### Defined in
 
-[txwrapper-core/src/types/method.ts:99](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-core/src/types/method.ts#L99)
+[txwrapper-core/src/types/method.ts:99](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-core/src/types/method.ts#L99)
 
 ___
 
@@ -168,7 +168,7 @@ The current spec version of the runtime.
 
 #### Defined in
 
-[txwrapper-core/src/types/method.ts:103](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-core/src/types/method.ts#L103)
+[txwrapper-core/src/types/method.ts:103](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-core/src/types/method.ts#L103)
 
 ___
 
@@ -186,7 +186,7 @@ The tip for this transaction, in hex.
 
 #### Defined in
 
-[txwrapper-core/src/types/method.ts:109](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-core/src/types/method.ts#L109)
+[txwrapper-core/src/types/method.ts:109](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-core/src/types/method.ts#L109)
 
 ___
 
@@ -202,4 +202,4 @@ The current transaction version for the runtime.
 
 #### Defined in
 
-[txwrapper-core/src/types/method.ts:113](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-core/src/types/method.ts#L113)
+[txwrapper-core/src/types/method.ts:113](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-core/src/types/method.ts#L113)

--- a/docs/interfaces/txwrapper_core_src.TxInfo.md
+++ b/docs/interfaces/txwrapper_core_src.TxInfo.md
@@ -42,7 +42,7 @@ The ss-58 encoded address of the sending account.
 
 #### Defined in
 
-[txwrapper-core/src/types/method.ts:71](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-core/src/types/method.ts#L71)
+[txwrapper-core/src/types/method.ts:71](https://github.com/paritytech/txwrapper-core/blob/9387f90/packages/txwrapper-core/src/types/method.ts#L71)
 
 ___
 
@@ -58,7 +58,7 @@ The checkpoint hash of the block, in hex.
 
 #### Defined in
 
-[txwrapper-core/src/types/method.ts:75](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-core/src/types/method.ts#L75)
+[txwrapper-core/src/types/method.ts:75](https://github.com/paritytech/txwrapper-core/blob/9387f90/packages/txwrapper-core/src/types/method.ts#L75)
 
 ___
 
@@ -74,7 +74,7 @@ The checkpoint block number (u32), in hex.
 
 #### Defined in
 
-[txwrapper-core/src/types/method.ts:79](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-core/src/types/method.ts#L79)
+[txwrapper-core/src/types/method.ts:79](https://github.com/paritytech/txwrapper-core/blob/9387f90/packages/txwrapper-core/src/types/method.ts#L79)
 
 ___
 
@@ -93,7 +93,7 @@ the `blockHash` field, in number of blocks. Defaults to 64 blocks.
 
 #### Defined in
 
-[txwrapper-core/src/types/method.ts:86](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-core/src/types/method.ts#L86)
+[txwrapper-core/src/types/method.ts:86](https://github.com/paritytech/txwrapper-core/blob/9387f90/packages/txwrapper-core/src/types/method.ts#L86)
 
 ___
 
@@ -109,7 +109,7 @@ The genesis hash of the chain, in hex.
 
 #### Defined in
 
-[txwrapper-core/src/types/method.ts:90](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-core/src/types/method.ts#L90)
+[txwrapper-core/src/types/method.ts:90](https://github.com/paritytech/txwrapper-core/blob/9387f90/packages/txwrapper-core/src/types/method.ts#L90)
 
 ___
 
@@ -126,7 +126,7 @@ call `state_getMetadata`.
 
 #### Defined in
 
-[txwrapper-core/src/types/method.ts:95](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-core/src/types/method.ts#L95)
+[txwrapper-core/src/types/method.ts:95](https://github.com/paritytech/txwrapper-core/blob/9387f90/packages/txwrapper-core/src/types/method.ts#L95)
 
 ___
 
@@ -136,7 +136,7 @@ ___
 
 #### Defined in
 
-[txwrapper-core/src/types/method.ts:50](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-core/src/types/method.ts#L50)
+[txwrapper-core/src/types/method.ts:50](https://github.com/paritytech/txwrapper-core/blob/9387f90/packages/txwrapper-core/src/types/method.ts#L50)
 
 ___
 
@@ -152,7 +152,7 @@ The nonce for this transaction.
 
 #### Defined in
 
-[txwrapper-core/src/types/method.ts:99](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-core/src/types/method.ts#L99)
+[txwrapper-core/src/types/method.ts:99](https://github.com/paritytech/txwrapper-core/blob/9387f90/packages/txwrapper-core/src/types/method.ts#L99)
 
 ___
 
@@ -168,7 +168,7 @@ The current spec version of the runtime.
 
 #### Defined in
 
-[txwrapper-core/src/types/method.ts:103](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-core/src/types/method.ts#L103)
+[txwrapper-core/src/types/method.ts:103](https://github.com/paritytech/txwrapper-core/blob/9387f90/packages/txwrapper-core/src/types/method.ts#L103)
 
 ___
 
@@ -186,7 +186,7 @@ The tip for this transaction, in hex.
 
 #### Defined in
 
-[txwrapper-core/src/types/method.ts:109](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-core/src/types/method.ts#L109)
+[txwrapper-core/src/types/method.ts:109](https://github.com/paritytech/txwrapper-core/blob/9387f90/packages/txwrapper-core/src/types/method.ts#L109)
 
 ___
 
@@ -202,4 +202,4 @@ The current transaction version for the runtime.
 
 #### Defined in
 
-[txwrapper-core/src/types/method.ts:113](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-core/src/types/method.ts#L113)
+[txwrapper-core/src/types/method.ts:113](https://github.com/paritytech/txwrapper-core/blob/9387f90/packages/txwrapper-core/src/types/method.ts#L113)

--- a/docs/interfaces/txwrapper_core_src.TxMethod.md
+++ b/docs/interfaces/txwrapper_core_src.TxMethod.md
@@ -22,7 +22,7 @@ Format used in txwrapper to represent a method.
 
 #### Defined in
 
-[txwrapper-core/src/types/method.ts:32](https://github.com/paritytech/txwrapper-core/blob/a0283d9/packages/txwrapper-core/src/types/method.ts#L32)
+[txwrapper-core/src/types/method.ts:41](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-core/src/types/method.ts#L41)
 
 ___
 
@@ -32,7 +32,7 @@ ___
 
 #### Defined in
 
-[txwrapper-core/src/types/method.ts:33](https://github.com/paritytech/txwrapper-core/blob/a0283d9/packages/txwrapper-core/src/types/method.ts#L33)
+[txwrapper-core/src/types/method.ts:42](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-core/src/types/method.ts#L42)
 
 ___
 
@@ -42,4 +42,4 @@ ___
 
 #### Defined in
 
-[txwrapper-core/src/types/method.ts:34](https://github.com/paritytech/txwrapper-core/blob/a0283d9/packages/txwrapper-core/src/types/method.ts#L34)
+[txwrapper-core/src/types/method.ts:43](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-core/src/types/method.ts#L43)

--- a/docs/interfaces/txwrapper_core_src.TxMethod.md
+++ b/docs/interfaces/txwrapper_core_src.TxMethod.md
@@ -22,7 +22,7 @@ Format used in txwrapper to represent a method.
 
 #### Defined in
 
-[txwrapper-core/src/types/method.ts:41](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-core/src/types/method.ts#L41)
+[txwrapper-core/src/types/method.ts:41](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-core/src/types/method.ts#L41)
 
 ___
 
@@ -32,7 +32,7 @@ ___
 
 #### Defined in
 
-[txwrapper-core/src/types/method.ts:42](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-core/src/types/method.ts#L42)
+[txwrapper-core/src/types/method.ts:42](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-core/src/types/method.ts#L42)
 
 ___
 
@@ -42,4 +42,4 @@ ___
 
 #### Defined in
 
-[txwrapper-core/src/types/method.ts:43](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-core/src/types/method.ts#L43)
+[txwrapper-core/src/types/method.ts:43](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-core/src/types/method.ts#L43)

--- a/docs/interfaces/txwrapper_core_src.TxMethod.md
+++ b/docs/interfaces/txwrapper_core_src.TxMethod.md
@@ -22,7 +22,7 @@ Format used in txwrapper to represent a method.
 
 #### Defined in
 
-[txwrapper-core/src/types/method.ts:41](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-core/src/types/method.ts#L41)
+[txwrapper-core/src/types/method.ts:41](https://github.com/paritytech/txwrapper-core/blob/9387f90/packages/txwrapper-core/src/types/method.ts#L41)
 
 ___
 
@@ -32,7 +32,7 @@ ___
 
 #### Defined in
 
-[txwrapper-core/src/types/method.ts:42](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-core/src/types/method.ts#L42)
+[txwrapper-core/src/types/method.ts:42](https://github.com/paritytech/txwrapper-core/blob/9387f90/packages/txwrapper-core/src/types/method.ts#L42)
 
 ___
 
@@ -42,4 +42,4 @@ ___
 
 #### Defined in
 
-[txwrapper-core/src/types/method.ts:43](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-core/src/types/method.ts#L43)
+[txwrapper-core/src/types/method.ts:43](https://github.com/paritytech/txwrapper-core/blob/9387f90/packages/txwrapper-core/src/types/method.ts#L43)

--- a/docs/interfaces/txwrapper_core_src.UnsignedTransaction.md
+++ b/docs/interfaces/txwrapper_core_src.UnsignedTransaction.md
@@ -29,4 +29,4 @@ call `state_getMetadata`.
 
 #### Defined in
 
-[txwrapper-core/src/types/method.ts:61](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-core/src/types/method.ts#L61)
+[txwrapper-core/src/types/method.ts:61](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-core/src/types/method.ts#L61)

--- a/docs/interfaces/txwrapper_core_src.UnsignedTransaction.md
+++ b/docs/interfaces/txwrapper_core_src.UnsignedTransaction.md
@@ -29,4 +29,4 @@ call `state_getMetadata`.
 
 #### Defined in
 
-[txwrapper-core/src/types/method.ts:52](https://github.com/paritytech/txwrapper-core/blob/a0283d9/packages/txwrapper-core/src/types/method.ts#L52)
+[txwrapper-core/src/types/method.ts:61](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-core/src/types/method.ts#L61)

--- a/docs/interfaces/txwrapper_core_src.UnsignedTransaction.md
+++ b/docs/interfaces/txwrapper_core_src.UnsignedTransaction.md
@@ -29,4 +29,4 @@ call `state_getMetadata`.
 
 #### Defined in
 
-[txwrapper-core/src/types/method.ts:61](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-core/src/types/method.ts#L61)
+[txwrapper-core/src/types/method.ts:61](https://github.com/paritytech/txwrapper-core/blob/9387f90/packages/txwrapper-core/src/types/method.ts#L61)

--- a/docs/interfaces/txwrapper_core_src._internal_.GetRegistryBaseArgs.md
+++ b/docs/interfaces/txwrapper_core_src._internal_.GetRegistryBaseArgs.md
@@ -1,0 +1,88 @@
+[txwrapper-core](../README.md) / [Modules](../modules.md) / [txwrapper-core/src](../modules/txwrapper_core_src.md) / [<internal\>](../modules/txwrapper_core_src._internal_.md) / GetRegistryBaseArgs
+
+# Interface: GetRegistryBaseArgs
+
+[txwrapper-core/src](../modules/txwrapper_core_src.md).[<internal>](../modules/txwrapper_core_src._internal_.md).GetRegistryBaseArgs
+
+## Table of contents
+
+### Properties
+
+- [asCallsOnlyArg](txwrapper_core_src._internal_.GetRegistryBaseArgs.md#ascallsonlyarg)
+- [chainProperties](txwrapper_core_src._internal_.GetRegistryBaseArgs.md#chainproperties)
+- [metadataRpc](txwrapper_core_src._internal_.GetRegistryBaseArgs.md#metadatarpc)
+- [signedExtensions](txwrapper_core_src._internal_.GetRegistryBaseArgs.md#signedextensions)
+- [specTypes](txwrapper_core_src._internal_.GetRegistryBaseArgs.md#spectypes)
+- [userExtensions](txwrapper_core_src._internal_.GetRegistryBaseArgs.md#userextensions)
+
+## Properties
+
+### asCallsOnlyArg
+
+• `Optional` **asCallsOnlyArg**: `boolean`
+
+Used to reduce the metadata size by only having the calls
+
+#### Defined in
+
+[txwrapper-core/src/core/metadata/getRegistryBase.ts:24](https://github.com/paritytech/txwrapper-core/blob/9387f90/packages/txwrapper-core/src/core/metadata/getRegistryBase.ts#L24)
+
+___
+
+### chainProperties
+
+• **chainProperties**: [`ChainProperties`](txwrapper_core_src.ChainProperties.md) \| `AnyJson`
+
+Chain properties, normally returned by the `system_properties` call.
+
+#### Defined in
+
+[txwrapper-core/src/core/metadata/getRegistryBase.ts:12](https://github.com/paritytech/txwrapper-core/blob/9387f90/packages/txwrapper-core/src/core/metadata/getRegistryBase.ts#L12)
+
+___
+
+### metadataRpc
+
+• **metadataRpc**: \`0x${string}\`
+
+Used to set the correct metadata for the registry
+
+#### Defined in
+
+[txwrapper-core/src/core/metadata/getRegistryBase.ts:20](https://github.com/paritytech/txwrapper-core/blob/9387f90/packages/txwrapper-core/src/core/metadata/getRegistryBase.ts#L20)
+
+___
+
+### signedExtensions
+
+• `Optional` **signedExtensions**: `string`[]
+
+Array of signedExtensions
+
+#### Defined in
+
+[txwrapper-core/src/core/metadata/getRegistryBase.ts:28](https://github.com/paritytech/txwrapper-core/blob/9387f90/packages/txwrapper-core/src/core/metadata/getRegistryBase.ts#L28)
+
+___
+
+### specTypes
+
+• **specTypes**: `RegistryTypes`
+
+Chain specific type definitions to registry.
+
+#### Defined in
+
+[txwrapper-core/src/core/metadata/getRegistryBase.ts:16](https://github.com/paritytech/txwrapper-core/blob/9387f90/packages/txwrapper-core/src/core/metadata/getRegistryBase.ts#L16)
+
+___
+
+### userExtensions
+
+• `Optional` **userExtensions**: `ExtDef`
+
+User extensions used to inject into the type registry
+
+#### Defined in
+
+[txwrapper-core/src/core/metadata/getRegistryBase.ts:32](https://github.com/paritytech/txwrapper-core/blob/9387f90/packages/txwrapper-core/src/core/metadata/getRegistryBase.ts#L32)

--- a/docs/interfaces/txwrapper_polkadot_src.GetRegistryOpts.md
+++ b/docs/interfaces/txwrapper_polkadot_src.GetRegistryOpts.md
@@ -20,8 +20,10 @@ Options for txwrapper-polkadot's `getRegistry` function.
 - [chainName](txwrapper_polkadot_src.GetRegistryOpts.md#chainname)
 - [metadataRpc](txwrapper_polkadot_src.GetRegistryOpts.md#metadatarpc)
 - [properties](txwrapper_polkadot_src.GetRegistryOpts.md#properties)
+- [signedExtensions](txwrapper_polkadot_src.GetRegistryOpts.md#signedextensions)
 - [specName](txwrapper_polkadot_src.GetRegistryOpts.md#specname)
 - [specVersion](txwrapper_polkadot_src.GetRegistryOpts.md#specversion)
+- [userExtensions](txwrapper_polkadot_src.GetRegistryOpts.md#userextensions)
 
 ## Properties
 
@@ -37,7 +39,7 @@ Used to reduce the metadata size by only having the calls
 
 #### Defined in
 
-[txwrapper-core/src/types/registry.ts:30](https://github.com/paritytech/txwrapper-core/blob/a0283d9/packages/txwrapper-core/src/types/registry.ts#L30)
+[txwrapper-core/src/types/registry.ts:32](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-core/src/types/registry.ts#L32)
 
 ___
 
@@ -53,7 +55,7 @@ chainName
 
 #### Defined in
 
-[txwrapper-core/src/types/registry.ts:14](https://github.com/paritytech/txwrapper-core/blob/a0283d9/packages/txwrapper-core/src/types/registry.ts#L14)
+[txwrapper-core/src/types/registry.ts:16](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-core/src/types/registry.ts#L16)
 
 ___
 
@@ -69,7 +71,7 @@ SCALE encoded runtime metadata as a hex string
 
 #### Defined in
 
-[txwrapper-core/src/types/registry.ts:22](https://github.com/paritytech/txwrapper-core/blob/a0283d9/packages/txwrapper-core/src/types/registry.ts#L22)
+[txwrapper-core/src/types/registry.ts:24](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-core/src/types/registry.ts#L24)
 
 ___
 
@@ -85,7 +87,23 @@ Chain ss58format, token decimals, and token ID
 
 #### Defined in
 
-[txwrapper-core/src/types/registry.ts:26](https://github.com/paritytech/txwrapper-core/blob/a0283d9/packages/txwrapper-core/src/types/registry.ts#L26)
+[txwrapper-core/src/types/registry.ts:28](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-core/src/types/registry.ts#L28)
+
+___
+
+### signedExtensions
+
+• `Optional` **signedExtensions**: `string`[]
+
+Array of signedExtensions
+
+#### Inherited from
+
+[GetRegistryOptsCore](txwrapper_core_src.GetRegistryOptsCore.md).[signedExtensions](txwrapper_core_src.GetRegistryOptsCore.md#signedextensions)
+
+#### Defined in
+
+[txwrapper-core/src/types/registry.ts:36](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-core/src/types/registry.ts#L36)
 
 ___
 
@@ -101,7 +119,7 @@ Runtime specName
 
 #### Defined in
 
-[txwrapper-polkadot/src/index.ts:73](https://github.com/paritytech/txwrapper-core/blob/a0283d9/packages/txwrapper-polkadot/src/index.ts#L73)
+[txwrapper-polkadot/src/index.ts:73](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-polkadot/src/index.ts#L73)
 
 ___
 
@@ -117,4 +135,20 @@ Runtime specVersion
 
 #### Defined in
 
-[txwrapper-core/src/types/registry.ts:18](https://github.com/paritytech/txwrapper-core/blob/a0283d9/packages/txwrapper-core/src/types/registry.ts#L18)
+[txwrapper-core/src/types/registry.ts:20](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-core/src/types/registry.ts#L20)
+
+___
+
+### userExtensions
+
+• `Optional` **userExtensions**: `ExtDef`
+
+User extensions used to inject into the type registry
+
+#### Inherited from
+
+[GetRegistryOptsCore](txwrapper_core_src.GetRegistryOptsCore.md).[userExtensions](txwrapper_core_src.GetRegistryOptsCore.md#userextensions)
+
+#### Defined in
+
+[txwrapper-core/src/types/registry.ts:40](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-core/src/types/registry.ts#L40)

--- a/docs/interfaces/txwrapper_polkadot_src.GetRegistryOpts.md
+++ b/docs/interfaces/txwrapper_polkadot_src.GetRegistryOpts.md
@@ -39,7 +39,7 @@ Used to reduce the metadata size by only having the calls
 
 #### Defined in
 
-[txwrapper-core/src/types/registry.ts:32](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-core/src/types/registry.ts#L32)
+[txwrapper-core/src/types/registry.ts:32](https://github.com/paritytech/txwrapper-core/blob/9387f90/packages/txwrapper-core/src/types/registry.ts#L32)
 
 ___
 
@@ -55,7 +55,7 @@ chainName
 
 #### Defined in
 
-[txwrapper-core/src/types/registry.ts:16](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-core/src/types/registry.ts#L16)
+[txwrapper-core/src/types/registry.ts:16](https://github.com/paritytech/txwrapper-core/blob/9387f90/packages/txwrapper-core/src/types/registry.ts#L16)
 
 ___
 
@@ -71,7 +71,7 @@ SCALE encoded runtime metadata as a hex string
 
 #### Defined in
 
-[txwrapper-core/src/types/registry.ts:24](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-core/src/types/registry.ts#L24)
+[txwrapper-core/src/types/registry.ts:24](https://github.com/paritytech/txwrapper-core/blob/9387f90/packages/txwrapper-core/src/types/registry.ts#L24)
 
 ___
 
@@ -87,7 +87,7 @@ Chain ss58format, token decimals, and token ID
 
 #### Defined in
 
-[txwrapper-core/src/types/registry.ts:28](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-core/src/types/registry.ts#L28)
+[txwrapper-core/src/types/registry.ts:28](https://github.com/paritytech/txwrapper-core/blob/9387f90/packages/txwrapper-core/src/types/registry.ts#L28)
 
 ___
 
@@ -103,7 +103,7 @@ Array of signedExtensions
 
 #### Defined in
 
-[txwrapper-core/src/types/registry.ts:36](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-core/src/types/registry.ts#L36)
+[txwrapper-core/src/types/registry.ts:36](https://github.com/paritytech/txwrapper-core/blob/9387f90/packages/txwrapper-core/src/types/registry.ts#L36)
 
 ___
 
@@ -119,7 +119,7 @@ Runtime specName
 
 #### Defined in
 
-[txwrapper-polkadot/src/index.ts:73](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-polkadot/src/index.ts#L73)
+[txwrapper-polkadot/src/index.ts:73](https://github.com/paritytech/txwrapper-core/blob/9387f90/packages/txwrapper-polkadot/src/index.ts#L73)
 
 ___
 
@@ -135,7 +135,7 @@ Runtime specVersion
 
 #### Defined in
 
-[txwrapper-core/src/types/registry.ts:20](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-core/src/types/registry.ts#L20)
+[txwrapper-core/src/types/registry.ts:20](https://github.com/paritytech/txwrapper-core/blob/9387f90/packages/txwrapper-core/src/types/registry.ts#L20)
 
 ___
 
@@ -151,4 +151,4 @@ User extensions used to inject into the type registry
 
 #### Defined in
 
-[txwrapper-core/src/types/registry.ts:40](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-core/src/types/registry.ts#L40)
+[txwrapper-core/src/types/registry.ts:40](https://github.com/paritytech/txwrapper-core/blob/9387f90/packages/txwrapper-core/src/types/registry.ts#L40)

--- a/docs/interfaces/txwrapper_polkadot_src.GetRegistryOpts.md
+++ b/docs/interfaces/txwrapper_polkadot_src.GetRegistryOpts.md
@@ -39,7 +39,7 @@ Used to reduce the metadata size by only having the calls
 
 #### Defined in
 
-[txwrapper-core/src/types/registry.ts:32](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-core/src/types/registry.ts#L32)
+[txwrapper-core/src/types/registry.ts:32](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-core/src/types/registry.ts#L32)
 
 ___
 
@@ -55,7 +55,7 @@ chainName
 
 #### Defined in
 
-[txwrapper-core/src/types/registry.ts:16](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-core/src/types/registry.ts#L16)
+[txwrapper-core/src/types/registry.ts:16](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-core/src/types/registry.ts#L16)
 
 ___
 
@@ -71,7 +71,7 @@ SCALE encoded runtime metadata as a hex string
 
 #### Defined in
 
-[txwrapper-core/src/types/registry.ts:24](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-core/src/types/registry.ts#L24)
+[txwrapper-core/src/types/registry.ts:24](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-core/src/types/registry.ts#L24)
 
 ___
 
@@ -87,7 +87,7 @@ Chain ss58format, token decimals, and token ID
 
 #### Defined in
 
-[txwrapper-core/src/types/registry.ts:28](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-core/src/types/registry.ts#L28)
+[txwrapper-core/src/types/registry.ts:28](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-core/src/types/registry.ts#L28)
 
 ___
 
@@ -103,7 +103,7 @@ Array of signedExtensions
 
 #### Defined in
 
-[txwrapper-core/src/types/registry.ts:36](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-core/src/types/registry.ts#L36)
+[txwrapper-core/src/types/registry.ts:36](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-core/src/types/registry.ts#L36)
 
 ___
 
@@ -119,7 +119,7 @@ Runtime specName
 
 #### Defined in
 
-[txwrapper-polkadot/src/index.ts:73](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-polkadot/src/index.ts#L73)
+[txwrapper-polkadot/src/index.ts:73](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-polkadot/src/index.ts#L73)
 
 ___
 
@@ -135,7 +135,7 @@ Runtime specVersion
 
 #### Defined in
 
-[txwrapper-core/src/types/registry.ts:20](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-core/src/types/registry.ts#L20)
+[txwrapper-core/src/types/registry.ts:20](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-core/src/types/registry.ts#L20)
 
 ___
 
@@ -151,4 +151,4 @@ User extensions used to inject into the type registry
 
 #### Defined in
 
-[txwrapper-core/src/types/registry.ts:40](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-core/src/types/registry.ts#L40)
+[txwrapper-core/src/types/registry.ts:40](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-core/src/types/registry.ts#L40)

--- a/docs/interfaces/txwrapper_polkadot_src._internal_.__Users_tarik_Desktop_parity_txwrapper_core_packages_txwrapper_polkadot_src_methods_crowdloan_index_.CroadloanWithdrawArgs.md
+++ b/docs/interfaces/txwrapper_polkadot_src._internal_.__Users_tarik_Desktop_parity_txwrapper_core_packages_txwrapper_polkadot_src_methods_crowdloan_index_.CroadloanWithdrawArgs.md
@@ -1,0 +1,38 @@
+[txwrapper-core](../README.md) / [Modules](../modules.md) / [txwrapper-polkadot/src](../modules/txwrapper_polkadot_src.md) / [<internal\>](../modules/txwrapper_polkadot_src._internal_.md) / ["/Users/tarik/Desktop/parity/txwrapper-core/packages/txwrapper-polkadot/src/methods/crowdloan/index"](../modules/txwrapper_polkadot_src._internal_.__Users_tarik_Desktop_parity_txwrapper_core_packages_txwrapper_polkadot_src_methods_crowdloan_index_.md) / CroadloanWithdrawArgs
+
+# Interface: CroadloanWithdrawArgs
+
+[<internal>](../modules/txwrapper_polkadot_src._internal_.md).["/Users/tarik/Desktop/parity/txwrapper-core/packages/txwrapper-polkadot/src/methods/crowdloan/index"](../modules/txwrapper_polkadot_src._internal_.__Users_tarik_Desktop_parity_txwrapper_core_packages_txwrapper_polkadot_src_methods_crowdloan_index_.md).CroadloanWithdrawArgs
+
+## Hierarchy
+
+- [`Args`](../modules/txwrapper_core_src.md#args)
+
+  ↳ **`CroadloanWithdrawArgs`**
+
+## Table of contents
+
+### Properties
+
+- [index](txwrapper_polkadot_src._internal_.__Users_tarik_Desktop_parity_txwrapper_core_packages_txwrapper_polkadot_src_methods_crowdloan_index_.CroadloanWithdrawArgs.md#index)
+- [who](txwrapper_polkadot_src._internal_.__Users_tarik_Desktop_parity_txwrapper_core_packages_txwrapper_polkadot_src_methods_crowdloan_index_.CroadloanWithdrawArgs.md#who)
+
+## Properties
+
+### index
+
+• **index**: `string` \| `number`
+
+#### Defined in
+
+[txwrapper-polkadot/src/methods/crowdloan/withdraw.ts:11](https://github.com/paritytech/txwrapper-core/blob/9387f90/packages/txwrapper-polkadot/src/methods/crowdloan/withdraw.ts#L11)
+
+___
+
+### who
+
+• **who**: `string`
+
+#### Defined in
+
+[txwrapper-polkadot/src/methods/crowdloan/withdraw.ts:10](https://github.com/paritytech/txwrapper-core/blob/9387f90/packages/txwrapper-polkadot/src/methods/crowdloan/withdraw.ts#L10)

--- a/docs/interfaces/txwrapper_polkadot_src._internal_.__Users_tarik_Desktop_parity_txwrapper_core_packages_txwrapper_polkadot_src_methods_crowdloan_index_.CrowdloanAddMemo.md
+++ b/docs/interfaces/txwrapper_polkadot_src._internal_.__Users_tarik_Desktop_parity_txwrapper_core_packages_txwrapper_polkadot_src_methods_crowdloan_index_.CrowdloanAddMemo.md
@@ -1,0 +1,38 @@
+[txwrapper-core](../README.md) / [Modules](../modules.md) / [txwrapper-polkadot/src](../modules/txwrapper_polkadot_src.md) / [<internal\>](../modules/txwrapper_polkadot_src._internal_.md) / ["/Users/tarik/Desktop/parity/txwrapper-core/packages/txwrapper-polkadot/src/methods/crowdloan/index"](../modules/txwrapper_polkadot_src._internal_.__Users_tarik_Desktop_parity_txwrapper_core_packages_txwrapper_polkadot_src_methods_crowdloan_index_.md) / CrowdloanAddMemo
+
+# Interface: CrowdloanAddMemo
+
+[<internal>](../modules/txwrapper_polkadot_src._internal_.md).["/Users/tarik/Desktop/parity/txwrapper-core/packages/txwrapper-polkadot/src/methods/crowdloan/index"](../modules/txwrapper_polkadot_src._internal_.__Users_tarik_Desktop_parity_txwrapper_core_packages_txwrapper_polkadot_src_methods_crowdloan_index_.md).CrowdloanAddMemo
+
+## Hierarchy
+
+- [`Args`](../modules/txwrapper_core_src.md#args)
+
+  ↳ **`CrowdloanAddMemo`**
+
+## Table of contents
+
+### Properties
+
+- [index](txwrapper_polkadot_src._internal_.__Users_tarik_Desktop_parity_txwrapper_core_packages_txwrapper_polkadot_src_methods_crowdloan_index_.CrowdloanAddMemo.md#index)
+- [memo](txwrapper_polkadot_src._internal_.__Users_tarik_Desktop_parity_txwrapper_core_packages_txwrapper_polkadot_src_methods_crowdloan_index_.CrowdloanAddMemo.md#memo)
+
+## Properties
+
+### index
+
+• **index**: `string` \| `number`
+
+#### Defined in
+
+[txwrapper-polkadot/src/methods/crowdloan/addMemo.ts:10](https://github.com/paritytech/txwrapper-core/blob/9387f90/packages/txwrapper-polkadot/src/methods/crowdloan/addMemo.ts#L10)
+
+___
+
+### memo
+
+• **memo**: `string`
+
+#### Defined in
+
+[txwrapper-polkadot/src/methods/crowdloan/addMemo.ts:11](https://github.com/paritytech/txwrapper-core/blob/9387f90/packages/txwrapper-polkadot/src/methods/crowdloan/addMemo.ts#L11)

--- a/docs/interfaces/txwrapper_polkadot_src._internal_.__Users_tarik_Desktop_parity_txwrapper_core_packages_txwrapper_polkadot_src_methods_crowdloan_index_.CrowdloanContributeArgs.md
+++ b/docs/interfaces/txwrapper_polkadot_src._internal_.__Users_tarik_Desktop_parity_txwrapper_core_packages_txwrapper_polkadot_src_methods_crowdloan_index_.CrowdloanContributeArgs.md
@@ -1,0 +1,49 @@
+[txwrapper-core](../README.md) / [Modules](../modules.md) / [txwrapper-polkadot/src](../modules/txwrapper_polkadot_src.md) / [<internal\>](../modules/txwrapper_polkadot_src._internal_.md) / ["/Users/tarik/Desktop/parity/txwrapper-core/packages/txwrapper-polkadot/src/methods/crowdloan/index"](../modules/txwrapper_polkadot_src._internal_.__Users_tarik_Desktop_parity_txwrapper_core_packages_txwrapper_polkadot_src_methods_crowdloan_index_.md) / CrowdloanContributeArgs
+
+# Interface: CrowdloanContributeArgs
+
+[<internal>](../modules/txwrapper_polkadot_src._internal_.md).["/Users/tarik/Desktop/parity/txwrapper-core/packages/txwrapper-polkadot/src/methods/crowdloan/index"](../modules/txwrapper_polkadot_src._internal_.__Users_tarik_Desktop_parity_txwrapper_core_packages_txwrapper_polkadot_src_methods_crowdloan_index_.md).CrowdloanContributeArgs
+
+## Hierarchy
+
+- [`Args`](../modules/txwrapper_core_src.md#args)
+
+  ↳ **`CrowdloanContributeArgs`**
+
+## Table of contents
+
+### Properties
+
+- [index](txwrapper_polkadot_src._internal_.__Users_tarik_Desktop_parity_txwrapper_core_packages_txwrapper_polkadot_src_methods_crowdloan_index_.CrowdloanContributeArgs.md#index)
+- [signature](txwrapper_polkadot_src._internal_.__Users_tarik_Desktop_parity_txwrapper_core_packages_txwrapper_polkadot_src_methods_crowdloan_index_.CrowdloanContributeArgs.md#signature)
+- [value](txwrapper_polkadot_src._internal_.__Users_tarik_Desktop_parity_txwrapper_core_packages_txwrapper_polkadot_src_methods_crowdloan_index_.CrowdloanContributeArgs.md#value)
+
+## Properties
+
+### index
+
+• **index**: `string` \| `number`
+
+#### Defined in
+
+[txwrapper-polkadot/src/methods/crowdloan/contribute.ts:12](https://github.com/paritytech/txwrapper-core/blob/9387f90/packages/txwrapper-polkadot/src/methods/crowdloan/contribute.ts#L12)
+
+___
+
+### signature
+
+• **signature**: [`MultiSignature`](../modules/txwrapper_polkadot_src._internal_.__Users_tarik_Desktop_parity_txwrapper_core_packages_txwrapper_polkadot_src_methods_crowdloan_index_.md#multisignature)
+
+#### Defined in
+
+[txwrapper-polkadot/src/methods/crowdloan/contribute.ts:14](https://github.com/paritytech/txwrapper-core/blob/9387f90/packages/txwrapper-polkadot/src/methods/crowdloan/contribute.ts#L14)
+
+___
+
+### value
+
+• **value**: `string` \| `number`
+
+#### Defined in
+
+[txwrapper-polkadot/src/methods/crowdloan/contribute.ts:13](https://github.com/paritytech/txwrapper-core/blob/9387f90/packages/txwrapper-polkadot/src/methods/crowdloan/contribute.ts#L13)

--- a/docs/interfaces/txwrapper_substrate_src._internal_.ProxyAnnounceArgs.md
+++ b/docs/interfaces/txwrapper_substrate_src._internal_.ProxyAnnounceArgs.md
@@ -1,0 +1,42 @@
+[txwrapper-core](../README.md) / [Modules](../modules.md) / [txwrapper-substrate/src](../modules/txwrapper_substrate_src.md) / [<internal\>](../modules/txwrapper_substrate_src._internal_.md) / ProxyAnnounceArgs
+
+# Interface: ProxyAnnounceArgs
+
+[txwrapper-substrate/src](../modules/txwrapper_substrate_src.md).[<internal>](../modules/txwrapper_substrate_src._internal_.md).ProxyAnnounceArgs
+
+## Hierarchy
+
+- [`Args`](../modules/txwrapper_core_src.md#args)
+
+  ↳ **`ProxyAnnounceArgs`**
+
+## Table of contents
+
+### Properties
+
+- [callHash](txwrapper_substrate_src._internal_.ProxyAnnounceArgs.md#callhash)
+- [real](txwrapper_substrate_src._internal_.ProxyAnnounceArgs.md#real)
+
+## Properties
+
+### callHash
+
+• **callHash**: `string`
+
+The hash of the call to be made by the `real` account.
+
+#### Defined in
+
+[txwrapper-substrate/src/methods/proxy/announce.ts:17](https://github.com/paritytech/txwrapper-core/blob/9387f90/packages/txwrapper-substrate/src/methods/proxy/announce.ts#L17)
+
+___
+
+### real
+
+• **real**: `string`
+
+The account that the proxy will make a call on behalf of.
+
+#### Defined in
+
+[txwrapper-substrate/src/methods/proxy/announce.ts:13](https://github.com/paritytech/txwrapper-core/blob/9387f90/packages/txwrapper-substrate/src/methods/proxy/announce.ts#L13)

--- a/docs/interfaces/txwrapper_substrate_src._internal_.ProxyAnonymousArgs.md
+++ b/docs/interfaces/txwrapper_substrate_src._internal_.ProxyAnonymousArgs.md
@@ -1,0 +1,60 @@
+[txwrapper-core](../README.md) / [Modules](../modules.md) / [txwrapper-substrate/src](../modules/txwrapper_substrate_src.md) / [<internal\>](../modules/txwrapper_substrate_src._internal_.md) / ProxyAnonymousArgs
+
+# Interface: ProxyAnonymousArgs
+
+[txwrapper-substrate/src](../modules/txwrapper_substrate_src.md).[<internal>](../modules/txwrapper_substrate_src._internal_.md).ProxyAnonymousArgs
+
+## Hierarchy
+
+- [`Args`](../modules/txwrapper_core_src.md#args)
+
+  ↳ **`ProxyAnonymousArgs`**
+
+## Table of contents
+
+### Properties
+
+- [delay](txwrapper_substrate_src._internal_.ProxyAnonymousArgs.md#delay)
+- [index](txwrapper_substrate_src._internal_.ProxyAnonymousArgs.md#index)
+- [proxyType](txwrapper_substrate_src._internal_.ProxyAnonymousArgs.md#proxytype)
+
+## Properties
+
+### delay
+
+• **delay**: `number`
+
+The announcement period (measured in number of blocks) required of the initial proxy.
+Will generally be zero.
+
+#### Defined in
+
+[txwrapper-substrate/src/methods/proxy/anonymous.ts:20](https://github.com/paritytech/txwrapper-core/blob/9387f90/packages/txwrapper-substrate/src/methods/proxy/anonymous.ts#L20)
+
+___
+
+### index
+
+• **index**: `number`
+
+A positive, non-zero disambiguation index, in case this is called multiple times in the same
+transaction (e.g. with `utility::batch`). Unless you're using `batch` you probably just
+want to use `0`.
+
+#### Defined in
+
+[txwrapper-substrate/src/methods/proxy/anonymous.ts:26](https://github.com/paritytech/txwrapper-core/blob/9387f90/packages/txwrapper-substrate/src/methods/proxy/anonymous.ts#L26)
+
+___
+
+### proxyType
+
+• **proxyType**: `string`
+
+The type of the proxy that the sender will be registered as over the
+new account. This will almost always be the most permissive `ProxyType` possible to
+allow for maximum flexibility. (`ProxyType` variants vary by runtime.)
+
+#### Defined in
+
+[txwrapper-substrate/src/methods/proxy/anonymous.ts:15](https://github.com/paritytech/txwrapper-core/blob/9387f90/packages/txwrapper-substrate/src/methods/proxy/anonymous.ts#L15)

--- a/docs/interfaces/txwrapper_substrate_src._internal_.ProxyKillAnonymousArgs.md
+++ b/docs/interfaces/txwrapper_substrate_src._internal_.ProxyKillAnonymousArgs.md
@@ -1,0 +1,81 @@
+[txwrapper-core](../README.md) / [Modules](../modules.md) / [txwrapper-substrate/src](../modules/txwrapper_substrate_src.md) / [<internal\>](../modules/txwrapper_substrate_src._internal_.md) / ProxyKillAnonymousArgs
+
+# Interface: ProxyKillAnonymousArgs
+
+[txwrapper-substrate/src](../modules/txwrapper_substrate_src.md).[<internal>](../modules/txwrapper_substrate_src._internal_.md).ProxyKillAnonymousArgs
+
+## Hierarchy
+
+- [`Args`](../modules/txwrapper_core_src.md#args)
+
+  ↳ **`ProxyKillAnonymousArgs`**
+
+## Table of contents
+
+### Properties
+
+- [extIndex](txwrapper_substrate_src._internal_.ProxyKillAnonymousArgs.md#extindex)
+- [height](txwrapper_substrate_src._internal_.ProxyKillAnonymousArgs.md#height)
+- [index](txwrapper_substrate_src._internal_.ProxyKillAnonymousArgs.md#index)
+- [proxyType](txwrapper_substrate_src._internal_.ProxyKillAnonymousArgs.md#proxytype)
+- [spawner](txwrapper_substrate_src._internal_.ProxyKillAnonymousArgs.md#spawner)
+
+## Properties
+
+### extIndex
+
+• **extIndex**: `number`
+
+The extrinsic index in which the call to `anonymous` was processed.
+
+#### Defined in
+
+[txwrapper-substrate/src/methods/proxy/killAnonymous.ts:29](https://github.com/paritytech/txwrapper-core/blob/9387f90/packages/txwrapper-substrate/src/methods/proxy/killAnonymous.ts#L29)
+
+___
+
+### height
+
+• **height**: `number`
+
+The height of the chain when the call to `anonymous` was processed.
+
+#### Defined in
+
+[txwrapper-substrate/src/methods/proxy/killAnonymous.ts:25](https://github.com/paritytech/txwrapper-core/blob/9387f90/packages/txwrapper-substrate/src/methods/proxy/killAnonymous.ts#L25)
+
+___
+
+### index
+
+• **index**: `number`
+
+The disambiguation index originally passed to `anonymous`. Probably `0`
+
+#### Defined in
+
+[txwrapper-substrate/src/methods/proxy/killAnonymous.ts:21](https://github.com/paritytech/txwrapper-core/blob/9387f90/packages/txwrapper-substrate/src/methods/proxy/killAnonymous.ts#L21)
+
+___
+
+### proxyType
+
+• **proxyType**: `string`
+
+The proxy type originally passed to `anonymous`.
+
+#### Defined in
+
+[txwrapper-substrate/src/methods/proxy/killAnonymous.ts:17](https://github.com/paritytech/txwrapper-core/blob/9387f90/packages/txwrapper-substrate/src/methods/proxy/killAnonymous.ts#L17)
+
+___
+
+### spawner
+
+• **spawner**: `string`
+
+The account that originally called `anonymous` to create this account.
+
+#### Defined in
+
+[txwrapper-substrate/src/methods/proxy/killAnonymous.ts:13](https://github.com/paritytech/txwrapper-core/blob/9387f90/packages/txwrapper-substrate/src/methods/proxy/killAnonymous.ts#L13)

--- a/docs/interfaces/txwrapper_substrate_src.methods.assets.AssetsApproveTransferArgs.md
+++ b/docs/interfaces/txwrapper_substrate_src.methods.assets.AssetsApproveTransferArgs.md
@@ -29,7 +29,7 @@ already an approval in place, then this acts additively.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/assets/approveTransfer.ts:22](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-substrate/src/methods/assets/approveTransfer.ts#L22)
+[txwrapper-substrate/src/methods/assets/approveTransfer.ts:22](https://github.com/paritytech/txwrapper-core/blob/9387f90/packages/txwrapper-substrate/src/methods/assets/approveTransfer.ts#L22)
 
 ___
 
@@ -41,7 +41,7 @@ The account to delegate permission to transfer asset.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/assets/approveTransfer.ts:17](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-substrate/src/methods/assets/approveTransfer.ts#L17)
+[txwrapper-substrate/src/methods/assets/approveTransfer.ts:17](https://github.com/paritytech/txwrapper-core/blob/9387f90/packages/txwrapper-substrate/src/methods/assets/approveTransfer.ts#L17)
 
 ___
 
@@ -53,4 +53,4 @@ The identifier of the asset.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/assets/approveTransfer.ts:13](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-substrate/src/methods/assets/approveTransfer.ts#L13)
+[txwrapper-substrate/src/methods/assets/approveTransfer.ts:13](https://github.com/paritytech/txwrapper-core/blob/9387f90/packages/txwrapper-substrate/src/methods/assets/approveTransfer.ts#L13)

--- a/docs/interfaces/txwrapper_substrate_src.methods.assets.AssetsApproveTransferArgs.md
+++ b/docs/interfaces/txwrapper_substrate_src.methods.assets.AssetsApproveTransferArgs.md
@@ -29,7 +29,7 @@ already an approval in place, then this acts additively.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/assets/approveTransfer.ts:22](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-substrate/src/methods/assets/approveTransfer.ts#L22)
+[txwrapper-substrate/src/methods/assets/approveTransfer.ts:22](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-substrate/src/methods/assets/approveTransfer.ts#L22)
 
 ___
 
@@ -41,7 +41,7 @@ The account to delegate permission to transfer asset.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/assets/approveTransfer.ts:17](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-substrate/src/methods/assets/approveTransfer.ts#L17)
+[txwrapper-substrate/src/methods/assets/approveTransfer.ts:17](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-substrate/src/methods/assets/approveTransfer.ts#L17)
 
 ___
 
@@ -53,4 +53,4 @@ The identifier of the asset.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/assets/approveTransfer.ts:13](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-substrate/src/methods/assets/approveTransfer.ts#L13)
+[txwrapper-substrate/src/methods/assets/approveTransfer.ts:13](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-substrate/src/methods/assets/approveTransfer.ts#L13)

--- a/docs/interfaces/txwrapper_substrate_src.methods.assets.AssetsApproveTransferArgs.md
+++ b/docs/interfaces/txwrapper_substrate_src.methods.assets.AssetsApproveTransferArgs.md
@@ -29,7 +29,7 @@ already an approval in place, then this acts additively.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/assets/approveTransfer.ts:22](https://github.com/paritytech/txwrapper-core/blob/a0283d9/packages/txwrapper-substrate/src/methods/assets/approveTransfer.ts#L22)
+[txwrapper-substrate/src/methods/assets/approveTransfer.ts:22](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-substrate/src/methods/assets/approveTransfer.ts#L22)
 
 ___
 
@@ -41,7 +41,7 @@ The account to delegate permission to transfer asset.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/assets/approveTransfer.ts:17](https://github.com/paritytech/txwrapper-core/blob/a0283d9/packages/txwrapper-substrate/src/methods/assets/approveTransfer.ts#L17)
+[txwrapper-substrate/src/methods/assets/approveTransfer.ts:17](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-substrate/src/methods/assets/approveTransfer.ts#L17)
 
 ___
 
@@ -53,4 +53,4 @@ The identifier of the asset.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/assets/approveTransfer.ts:13](https://github.com/paritytech/txwrapper-core/blob/a0283d9/packages/txwrapper-substrate/src/methods/assets/approveTransfer.ts#L13)
+[txwrapper-substrate/src/methods/assets/approveTransfer.ts:13](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-substrate/src/methods/assets/approveTransfer.ts#L13)

--- a/docs/interfaces/txwrapper_substrate_src.methods.assets.AssetsCancelApprovalArgs.md
+++ b/docs/interfaces/txwrapper_substrate_src.methods.assets.AssetsCancelApprovalArgs.md
@@ -27,7 +27,7 @@ The account delegated permission to transfer asset.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/assets/cancelApproval.ts:17](https://github.com/paritytech/txwrapper-core/blob/a0283d9/packages/txwrapper-substrate/src/methods/assets/cancelApproval.ts#L17)
+[txwrapper-substrate/src/methods/assets/cancelApproval.ts:17](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-substrate/src/methods/assets/cancelApproval.ts#L17)
 
 ___
 
@@ -39,4 +39,4 @@ The identifier of the asset.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/assets/cancelApproval.ts:13](https://github.com/paritytech/txwrapper-core/blob/a0283d9/packages/txwrapper-substrate/src/methods/assets/cancelApproval.ts#L13)
+[txwrapper-substrate/src/methods/assets/cancelApproval.ts:13](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-substrate/src/methods/assets/cancelApproval.ts#L13)

--- a/docs/interfaces/txwrapper_substrate_src.methods.assets.AssetsCancelApprovalArgs.md
+++ b/docs/interfaces/txwrapper_substrate_src.methods.assets.AssetsCancelApprovalArgs.md
@@ -27,7 +27,7 @@ The account delegated permission to transfer asset.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/assets/cancelApproval.ts:17](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-substrate/src/methods/assets/cancelApproval.ts#L17)
+[txwrapper-substrate/src/methods/assets/cancelApproval.ts:17](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-substrate/src/methods/assets/cancelApproval.ts#L17)
 
 ___
 
@@ -39,4 +39,4 @@ The identifier of the asset.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/assets/cancelApproval.ts:13](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-substrate/src/methods/assets/cancelApproval.ts#L13)
+[txwrapper-substrate/src/methods/assets/cancelApproval.ts:13](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-substrate/src/methods/assets/cancelApproval.ts#L13)

--- a/docs/interfaces/txwrapper_substrate_src.methods.assets.AssetsCancelApprovalArgs.md
+++ b/docs/interfaces/txwrapper_substrate_src.methods.assets.AssetsCancelApprovalArgs.md
@@ -27,7 +27,7 @@ The account delegated permission to transfer asset.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/assets/cancelApproval.ts:17](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-substrate/src/methods/assets/cancelApproval.ts#L17)
+[txwrapper-substrate/src/methods/assets/cancelApproval.ts:17](https://github.com/paritytech/txwrapper-core/blob/9387f90/packages/txwrapper-substrate/src/methods/assets/cancelApproval.ts#L17)
 
 ___
 
@@ -39,4 +39,4 @@ The identifier of the asset.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/assets/cancelApproval.ts:13](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-substrate/src/methods/assets/cancelApproval.ts#L13)
+[txwrapper-substrate/src/methods/assets/cancelApproval.ts:13](https://github.com/paritytech/txwrapper-core/blob/9387f90/packages/txwrapper-substrate/src/methods/assets/cancelApproval.ts#L13)

--- a/docs/interfaces/txwrapper_substrate_src.methods.assets.AssetsTransferApprovedArgs.md
+++ b/docs/interfaces/txwrapper_substrate_src.methods.assets.AssetsTransferApprovedArgs.md
@@ -29,7 +29,7 @@ The amount of assets to transfer.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/assets/transferApproved.ts:26](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-substrate/src/methods/assets/transferApproved.ts#L26)
+[txwrapper-substrate/src/methods/assets/transferApproved.ts:26](https://github.com/paritytech/txwrapper-core/blob/9387f90/packages/txwrapper-substrate/src/methods/assets/transferApproved.ts#L26)
 
 ___
 
@@ -41,7 +41,7 @@ The account to which the asset balance of `amount` will be transferred.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/assets/transferApproved.ts:22](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-substrate/src/methods/assets/transferApproved.ts#L22)
+[txwrapper-substrate/src/methods/assets/transferApproved.ts:22](https://github.com/paritytech/txwrapper-core/blob/9387f90/packages/txwrapper-substrate/src/methods/assets/transferApproved.ts#L22)
 
 ___
 
@@ -53,7 +53,7 @@ The identifier of the asset.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/assets/transferApproved.ts:13](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-substrate/src/methods/assets/transferApproved.ts#L13)
+[txwrapper-substrate/src/methods/assets/transferApproved.ts:13](https://github.com/paritytech/txwrapper-core/blob/9387f90/packages/txwrapper-substrate/src/methods/assets/transferApproved.ts#L13)
 
 ___
 
@@ -66,4 +66,4 @@ from which the asset balance will be withdrawn.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/assets/transferApproved.ts:18](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-substrate/src/methods/assets/transferApproved.ts#L18)
+[txwrapper-substrate/src/methods/assets/transferApproved.ts:18](https://github.com/paritytech/txwrapper-core/blob/9387f90/packages/txwrapper-substrate/src/methods/assets/transferApproved.ts#L18)

--- a/docs/interfaces/txwrapper_substrate_src.methods.assets.AssetsTransferApprovedArgs.md
+++ b/docs/interfaces/txwrapper_substrate_src.methods.assets.AssetsTransferApprovedArgs.md
@@ -29,7 +29,7 @@ The amount of assets to transfer.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/assets/transferApproved.ts:26](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-substrate/src/methods/assets/transferApproved.ts#L26)
+[txwrapper-substrate/src/methods/assets/transferApproved.ts:26](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-substrate/src/methods/assets/transferApproved.ts#L26)
 
 ___
 
@@ -41,7 +41,7 @@ The account to which the asset balance of `amount` will be transferred.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/assets/transferApproved.ts:22](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-substrate/src/methods/assets/transferApproved.ts#L22)
+[txwrapper-substrate/src/methods/assets/transferApproved.ts:22](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-substrate/src/methods/assets/transferApproved.ts#L22)
 
 ___
 
@@ -53,7 +53,7 @@ The identifier of the asset.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/assets/transferApproved.ts:13](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-substrate/src/methods/assets/transferApproved.ts#L13)
+[txwrapper-substrate/src/methods/assets/transferApproved.ts:13](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-substrate/src/methods/assets/transferApproved.ts#L13)
 
 ___
 
@@ -66,4 +66,4 @@ from which the asset balance will be withdrawn.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/assets/transferApproved.ts:18](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-substrate/src/methods/assets/transferApproved.ts#L18)
+[txwrapper-substrate/src/methods/assets/transferApproved.ts:18](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-substrate/src/methods/assets/transferApproved.ts#L18)

--- a/docs/interfaces/txwrapper_substrate_src.methods.assets.AssetsTransferApprovedArgs.md
+++ b/docs/interfaces/txwrapper_substrate_src.methods.assets.AssetsTransferApprovedArgs.md
@@ -29,7 +29,7 @@ The amount of assets to transfer.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/assets/transferApproved.ts:26](https://github.com/paritytech/txwrapper-core/blob/a0283d9/packages/txwrapper-substrate/src/methods/assets/transferApproved.ts#L26)
+[txwrapper-substrate/src/methods/assets/transferApproved.ts:26](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-substrate/src/methods/assets/transferApproved.ts#L26)
 
 ___
 
@@ -41,7 +41,7 @@ The account to which the asset balance of `amount` will be transferred.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/assets/transferApproved.ts:22](https://github.com/paritytech/txwrapper-core/blob/a0283d9/packages/txwrapper-substrate/src/methods/assets/transferApproved.ts#L22)
+[txwrapper-substrate/src/methods/assets/transferApproved.ts:22](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-substrate/src/methods/assets/transferApproved.ts#L22)
 
 ___
 
@@ -53,7 +53,7 @@ The identifier of the asset.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/assets/transferApproved.ts:13](https://github.com/paritytech/txwrapper-core/blob/a0283d9/packages/txwrapper-substrate/src/methods/assets/transferApproved.ts#L13)
+[txwrapper-substrate/src/methods/assets/transferApproved.ts:13](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-substrate/src/methods/assets/transferApproved.ts#L13)
 
 ___
 
@@ -66,4 +66,4 @@ from which the asset balance will be withdrawn.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/assets/transferApproved.ts:18](https://github.com/paritytech/txwrapper-core/blob/a0283d9/packages/txwrapper-substrate/src/methods/assets/transferApproved.ts#L18)
+[txwrapper-substrate/src/methods/assets/transferApproved.ts:18](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-substrate/src/methods/assets/transferApproved.ts#L18)

--- a/docs/interfaces/txwrapper_substrate_src.methods.assets.AssetsTransferArgs.md
+++ b/docs/interfaces/txwrapper_substrate_src.methods.assets.AssetsTransferArgs.md
@@ -31,7 +31,7 @@ the minimum balance. Must be greater than zero.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/assets/transfer.ts:24](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-substrate/src/methods/assets/transfer.ts#L24)
+[txwrapper-substrate/src/methods/assets/transfer.ts:24](https://github.com/paritytech/txwrapper-core/blob/9387f90/packages/txwrapper-substrate/src/methods/assets/transfer.ts#L24)
 
 ___
 
@@ -43,7 +43,7 @@ The identifier of the asset to have some amount transferred.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/assets/transfer.ts:13](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-substrate/src/methods/assets/transfer.ts#L13)
+[txwrapper-substrate/src/methods/assets/transfer.ts:13](https://github.com/paritytech/txwrapper-core/blob/9387f90/packages/txwrapper-substrate/src/methods/assets/transfer.ts#L13)
 
 ___
 
@@ -55,4 +55,4 @@ The account to be credited.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/assets/transfer.ts:17](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-substrate/src/methods/assets/transfer.ts#L17)
+[txwrapper-substrate/src/methods/assets/transfer.ts:17](https://github.com/paritytech/txwrapper-core/blob/9387f90/packages/txwrapper-substrate/src/methods/assets/transfer.ts#L17)

--- a/docs/interfaces/txwrapper_substrate_src.methods.assets.AssetsTransferArgs.md
+++ b/docs/interfaces/txwrapper_substrate_src.methods.assets.AssetsTransferArgs.md
@@ -31,7 +31,7 @@ the minimum balance. Must be greater than zero.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/assets/transfer.ts:24](https://github.com/paritytech/txwrapper-core/blob/a0283d9/packages/txwrapper-substrate/src/methods/assets/transfer.ts#L24)
+[txwrapper-substrate/src/methods/assets/transfer.ts:24](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-substrate/src/methods/assets/transfer.ts#L24)
 
 ___
 
@@ -43,7 +43,7 @@ The identifier of the asset to have some amount transferred.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/assets/transfer.ts:13](https://github.com/paritytech/txwrapper-core/blob/a0283d9/packages/txwrapper-substrate/src/methods/assets/transfer.ts#L13)
+[txwrapper-substrate/src/methods/assets/transfer.ts:13](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-substrate/src/methods/assets/transfer.ts#L13)
 
 ___
 
@@ -55,4 +55,4 @@ The account to be credited.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/assets/transfer.ts:17](https://github.com/paritytech/txwrapper-core/blob/a0283d9/packages/txwrapper-substrate/src/methods/assets/transfer.ts#L17)
+[txwrapper-substrate/src/methods/assets/transfer.ts:17](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-substrate/src/methods/assets/transfer.ts#L17)

--- a/docs/interfaces/txwrapper_substrate_src.methods.assets.AssetsTransferArgs.md
+++ b/docs/interfaces/txwrapper_substrate_src.methods.assets.AssetsTransferArgs.md
@@ -31,7 +31,7 @@ the minimum balance. Must be greater than zero.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/assets/transfer.ts:24](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-substrate/src/methods/assets/transfer.ts#L24)
+[txwrapper-substrate/src/methods/assets/transfer.ts:24](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-substrate/src/methods/assets/transfer.ts#L24)
 
 ___
 
@@ -43,7 +43,7 @@ The identifier of the asset to have some amount transferred.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/assets/transfer.ts:13](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-substrate/src/methods/assets/transfer.ts#L13)
+[txwrapper-substrate/src/methods/assets/transfer.ts:13](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-substrate/src/methods/assets/transfer.ts#L13)
 
 ___
 
@@ -55,4 +55,4 @@ The account to be credited.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/assets/transfer.ts:17](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-substrate/src/methods/assets/transfer.ts#L17)
+[txwrapper-substrate/src/methods/assets/transfer.ts:17](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-substrate/src/methods/assets/transfer.ts#L17)

--- a/docs/interfaces/txwrapper_substrate_src.methods.assets.AssetsTransferKeepAliveArgs.md
+++ b/docs/interfaces/txwrapper_substrate_src.methods.assets.AssetsTransferKeepAliveArgs.md
@@ -31,7 +31,7 @@ the minimum balance. Must be greater than zero.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/assets/transferKeepAlive.ts:24](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-substrate/src/methods/assets/transferKeepAlive.ts#L24)
+[txwrapper-substrate/src/methods/assets/transferKeepAlive.ts:24](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-substrate/src/methods/assets/transferKeepAlive.ts#L24)
 
 ___
 
@@ -43,7 +43,7 @@ The identifier of the asset to have some amount transferred.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/assets/transferKeepAlive.ts:13](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-substrate/src/methods/assets/transferKeepAlive.ts#L13)
+[txwrapper-substrate/src/methods/assets/transferKeepAlive.ts:13](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-substrate/src/methods/assets/transferKeepAlive.ts#L13)
 
 ___
 
@@ -55,4 +55,4 @@ The account to be credited.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/assets/transferKeepAlive.ts:17](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-substrate/src/methods/assets/transferKeepAlive.ts#L17)
+[txwrapper-substrate/src/methods/assets/transferKeepAlive.ts:17](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-substrate/src/methods/assets/transferKeepAlive.ts#L17)

--- a/docs/interfaces/txwrapper_substrate_src.methods.assets.AssetsTransferKeepAliveArgs.md
+++ b/docs/interfaces/txwrapper_substrate_src.methods.assets.AssetsTransferKeepAliveArgs.md
@@ -31,7 +31,7 @@ the minimum balance. Must be greater than zero.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/assets/transferKeepAlive.ts:24](https://github.com/paritytech/txwrapper-core/blob/a0283d9/packages/txwrapper-substrate/src/methods/assets/transferKeepAlive.ts#L24)
+[txwrapper-substrate/src/methods/assets/transferKeepAlive.ts:24](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-substrate/src/methods/assets/transferKeepAlive.ts#L24)
 
 ___
 
@@ -43,7 +43,7 @@ The identifier of the asset to have some amount transferred.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/assets/transferKeepAlive.ts:13](https://github.com/paritytech/txwrapper-core/blob/a0283d9/packages/txwrapper-substrate/src/methods/assets/transferKeepAlive.ts#L13)
+[txwrapper-substrate/src/methods/assets/transferKeepAlive.ts:13](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-substrate/src/methods/assets/transferKeepAlive.ts#L13)
 
 ___
 
@@ -55,4 +55,4 @@ The account to be credited.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/assets/transferKeepAlive.ts:17](https://github.com/paritytech/txwrapper-core/blob/a0283d9/packages/txwrapper-substrate/src/methods/assets/transferKeepAlive.ts#L17)
+[txwrapper-substrate/src/methods/assets/transferKeepAlive.ts:17](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-substrate/src/methods/assets/transferKeepAlive.ts#L17)

--- a/docs/interfaces/txwrapper_substrate_src.methods.assets.AssetsTransferKeepAliveArgs.md
+++ b/docs/interfaces/txwrapper_substrate_src.methods.assets.AssetsTransferKeepAliveArgs.md
@@ -31,7 +31,7 @@ the minimum balance. Must be greater than zero.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/assets/transferKeepAlive.ts:24](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-substrate/src/methods/assets/transferKeepAlive.ts#L24)
+[txwrapper-substrate/src/methods/assets/transferKeepAlive.ts:24](https://github.com/paritytech/txwrapper-core/blob/9387f90/packages/txwrapper-substrate/src/methods/assets/transferKeepAlive.ts#L24)
 
 ___
 
@@ -43,7 +43,7 @@ The identifier of the asset to have some amount transferred.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/assets/transferKeepAlive.ts:13](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-substrate/src/methods/assets/transferKeepAlive.ts#L13)
+[txwrapper-substrate/src/methods/assets/transferKeepAlive.ts:13](https://github.com/paritytech/txwrapper-core/blob/9387f90/packages/txwrapper-substrate/src/methods/assets/transferKeepAlive.ts#L13)
 
 ___
 
@@ -55,4 +55,4 @@ The account to be credited.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/assets/transferKeepAlive.ts:17](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-substrate/src/methods/assets/transferKeepAlive.ts#L17)
+[txwrapper-substrate/src/methods/assets/transferKeepAlive.ts:17](https://github.com/paritytech/txwrapper-core/blob/9387f90/packages/txwrapper-substrate/src/methods/assets/transferKeepAlive.ts#L17)

--- a/docs/interfaces/txwrapper_substrate_src.methods.balances.BalancesTransferAllArgs.md
+++ b/docs/interfaces/txwrapper_substrate_src.methods.balances.BalancesTransferAllArgs.md
@@ -27,7 +27,7 @@ The recipient of the transfer.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/balances/transferAll.ts:13](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-substrate/src/methods/balances/transferAll.ts#L13)
+[txwrapper-substrate/src/methods/balances/transferAll.ts:13](https://github.com/paritytech/txwrapper-core/blob/9387f90/packages/txwrapper-substrate/src/methods/balances/transferAll.ts#L13)
 
 ___
 
@@ -42,4 +42,4 @@ keep the sender account alive (true).
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/balances/transferAll.ts:21](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-substrate/src/methods/balances/transferAll.ts#L21)
+[txwrapper-substrate/src/methods/balances/transferAll.ts:21](https://github.com/paritytech/txwrapper-core/blob/9387f90/packages/txwrapper-substrate/src/methods/balances/transferAll.ts#L21)

--- a/docs/interfaces/txwrapper_substrate_src.methods.balances.BalancesTransferAllArgs.md
+++ b/docs/interfaces/txwrapper_substrate_src.methods.balances.BalancesTransferAllArgs.md
@@ -1,0 +1,45 @@
+[txwrapper-core](../README.md) / [Modules](../modules.md) / [txwrapper-substrate/src](../modules/txwrapper_substrate_src.md) / [methods](../modules/txwrapper_substrate_src.methods.md) / [balances](../modules/txwrapper_substrate_src.methods.balances.md) / BalancesTransferAllArgs
+
+# Interface: BalancesTransferAllArgs
+
+[methods](../modules/txwrapper_substrate_src.methods.md).[balances](../modules/txwrapper_substrate_src.methods.balances.md).BalancesTransferAllArgs
+
+## Hierarchy
+
+- [`Args`](../modules/txwrapper_core_src.md#args)
+
+  ↳ **`BalancesTransferAllArgs`**
+
+## Table of contents
+
+### Properties
+
+- [dest](txwrapper_substrate_src.methods.balances.BalancesTransferAllArgs.md#dest)
+- [keepAlive](txwrapper_substrate_src.methods.balances.BalancesTransferAllArgs.md#keepalive)
+
+## Properties
+
+### dest
+
+• **dest**: `string`
+
+The recipient of the transfer.
+
+#### Defined in
+
+[txwrapper-substrate/src/methods/balances/transferAll.ts:13](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-substrate/src/methods/balances/transferAll.ts#L13)
+
+___
+
+### keepAlive
+
+• **keepAlive**: `boolean`
+
+A boolean to determine if the `transfer_all` operation should send all
+of the funds the account has, causing the sender account to be killed (false), or
+transfer everything except at least the existential deposit, which will guarantee to
+keep the sender account alive (true).
+
+#### Defined in
+
+[txwrapper-substrate/src/methods/balances/transferAll.ts:21](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-substrate/src/methods/balances/transferAll.ts#L21)

--- a/docs/interfaces/txwrapper_substrate_src.methods.balances.BalancesTransferArgs.md
+++ b/docs/interfaces/txwrapper_substrate_src.methods.balances.BalancesTransferArgs.md
@@ -27,7 +27,7 @@ The recipient address, SS-58 encoded.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/balances/transfer.ts:13](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-substrate/src/methods/balances/transfer.ts#L13)
+[txwrapper-substrate/src/methods/balances/transfer.ts:13](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-substrate/src/methods/balances/transfer.ts#L13)
 
 ___
 
@@ -39,4 +39,4 @@ The amount to send.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/balances/transfer.ts:17](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-substrate/src/methods/balances/transfer.ts#L17)
+[txwrapper-substrate/src/methods/balances/transfer.ts:17](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-substrate/src/methods/balances/transfer.ts#L17)

--- a/docs/interfaces/txwrapper_substrate_src.methods.balances.BalancesTransferArgs.md
+++ b/docs/interfaces/txwrapper_substrate_src.methods.balances.BalancesTransferArgs.md
@@ -27,7 +27,7 @@ The recipient address, SS-58 encoded.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/balances/transfer.ts:13](https://github.com/paritytech/txwrapper-core/blob/a0283d9/packages/txwrapper-substrate/src/methods/balances/transfer.ts#L13)
+[txwrapper-substrate/src/methods/balances/transfer.ts:13](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-substrate/src/methods/balances/transfer.ts#L13)
 
 ___
 
@@ -39,4 +39,4 @@ The amount to send.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/balances/transfer.ts:17](https://github.com/paritytech/txwrapper-core/blob/a0283d9/packages/txwrapper-substrate/src/methods/balances/transfer.ts#L17)
+[txwrapper-substrate/src/methods/balances/transfer.ts:17](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-substrate/src/methods/balances/transfer.ts#L17)

--- a/docs/interfaces/txwrapper_substrate_src.methods.balances.BalancesTransferArgs.md
+++ b/docs/interfaces/txwrapper_substrate_src.methods.balances.BalancesTransferArgs.md
@@ -27,7 +27,7 @@ The recipient address, SS-58 encoded.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/balances/transfer.ts:13](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-substrate/src/methods/balances/transfer.ts#L13)
+[txwrapper-substrate/src/methods/balances/transfer.ts:13](https://github.com/paritytech/txwrapper-core/blob/9387f90/packages/txwrapper-substrate/src/methods/balances/transfer.ts#L13)
 
 ___
 
@@ -39,4 +39,4 @@ The amount to send.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/balances/transfer.ts:17](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-substrate/src/methods/balances/transfer.ts#L17)
+[txwrapper-substrate/src/methods/balances/transfer.ts:17](https://github.com/paritytech/txwrapper-core/blob/9387f90/packages/txwrapper-substrate/src/methods/balances/transfer.ts#L17)

--- a/docs/interfaces/txwrapper_substrate_src.methods.democracy.DemocracyVoteArgs.md
+++ b/docs/interfaces/txwrapper_substrate_src.methods.democracy.DemocracyVoteArgs.md
@@ -25,7 +25,7 @@
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/democracy/vote.ts:15](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-substrate/src/methods/democracy/vote.ts#L15)
+[txwrapper-substrate/src/methods/democracy/vote.ts:15](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-substrate/src/methods/democracy/vote.ts#L15)
 
 ___
 
@@ -37,4 +37,4 @@ Vote.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/democracy/vote.ts:19](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-substrate/src/methods/democracy/vote.ts#L19)
+[txwrapper-substrate/src/methods/democracy/vote.ts:19](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-substrate/src/methods/democracy/vote.ts#L19)

--- a/docs/interfaces/txwrapper_substrate_src.methods.democracy.DemocracyVoteArgs.md
+++ b/docs/interfaces/txwrapper_substrate_src.methods.democracy.DemocracyVoteArgs.md
@@ -25,7 +25,7 @@
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/democracy/vote.ts:15](https://github.com/paritytech/txwrapper-core/blob/a0283d9/packages/txwrapper-substrate/src/methods/democracy/vote.ts#L15)
+[txwrapper-substrate/src/methods/democracy/vote.ts:15](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-substrate/src/methods/democracy/vote.ts#L15)
 
 ___
 
@@ -37,4 +37,4 @@ Vote.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/democracy/vote.ts:19](https://github.com/paritytech/txwrapper-core/blob/a0283d9/packages/txwrapper-substrate/src/methods/democracy/vote.ts#L19)
+[txwrapper-substrate/src/methods/democracy/vote.ts:19](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-substrate/src/methods/democracy/vote.ts#L19)

--- a/docs/interfaces/txwrapper_substrate_src.methods.democracy.DemocracyVoteArgs.md
+++ b/docs/interfaces/txwrapper_substrate_src.methods.democracy.DemocracyVoteArgs.md
@@ -25,16 +25,16 @@
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/democracy/vote.ts:15](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-substrate/src/methods/democracy/vote.ts#L15)
+[txwrapper-substrate/src/methods/democracy/vote.ts:15](https://github.com/paritytech/txwrapper-core/blob/9387f90/packages/txwrapper-substrate/src/methods/democracy/vote.ts#L15)
 
 ___
 
 ### vote
 
-• **vote**: `AccountVote`
+• **vote**: [`AccountVote`](../modules/txwrapper_substrate_src._internal_.md#accountvote)
 
 Vote.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/democracy/vote.ts:19](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-substrate/src/methods/democracy/vote.ts#L19)
+[txwrapper-substrate/src/methods/democracy/vote.ts:19](https://github.com/paritytech/txwrapper-core/blob/9387f90/packages/txwrapper-substrate/src/methods/democracy/vote.ts#L19)

--- a/docs/interfaces/txwrapper_substrate_src.methods.multisig.MultiSigApproveAsMulti.md
+++ b/docs/interfaces/txwrapper_substrate_src.methods.multisig.MultiSigApproveAsMulti.md
@@ -30,7 +30,7 @@ The hash of the call to be executed.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/multisig/approveAsMulti.ts:30](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-substrate/src/methods/multisig/approveAsMulti.ts#L30)
+[txwrapper-substrate/src/methods/multisig/approveAsMulti.ts:30](https://github.com/paritytech/txwrapper-core/blob/9387f90/packages/txwrapper-substrate/src/methods/multisig/approveAsMulti.ts#L30)
 
 ___
 
@@ -42,13 +42,13 @@ Maximium weight the call being approved may consume.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/multisig/approveAsMulti.ts:34](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-substrate/src/methods/multisig/approveAsMulti.ts#L34)
+[txwrapper-substrate/src/methods/multisig/approveAsMulti.ts:34](https://github.com/paritytech/txwrapper-core/blob/9387f90/packages/txwrapper-substrate/src/methods/multisig/approveAsMulti.ts#L34)
 
 ___
 
 ### maybeTimepoint
 
-• **maybeTimepoint**: ``null`` \| `Timepoint`
+• **maybeTimepoint**: ``null`` \| [`Timepoint`](../modules/txwrapper_substrate_src._internal_.md#timepoint)
 
 If this is the first approval, then this must be `null`. If it is not the first
 approval, then it must be the timepoint (block number and transaction index) of the first
@@ -56,7 +56,7 @@ approving transaction.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/multisig/approveAsMulti.ts:26](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-substrate/src/methods/multisig/approveAsMulti.ts#L26)
+[txwrapper-substrate/src/methods/multisig/approveAsMulti.ts:26](https://github.com/paritytech/txwrapper-core/blob/9387f90/packages/txwrapper-substrate/src/methods/multisig/approveAsMulti.ts#L26)
 
 ___
 
@@ -69,7 +69,7 @@ May not be empty.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/multisig/approveAsMulti.ts:20](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-substrate/src/methods/multisig/approveAsMulti.ts#L20)
+[txwrapper-substrate/src/methods/multisig/approveAsMulti.ts:20](https://github.com/paritytech/txwrapper-core/blob/9387f90/packages/txwrapper-substrate/src/methods/multisig/approveAsMulti.ts#L20)
 
 ___
 
@@ -81,4 +81,4 @@ The total number of approvals required for this dispatch before it is executed.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/multisig/approveAsMulti.ts:15](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-substrate/src/methods/multisig/approveAsMulti.ts#L15)
+[txwrapper-substrate/src/methods/multisig/approveAsMulti.ts:15](https://github.com/paritytech/txwrapper-core/blob/9387f90/packages/txwrapper-substrate/src/methods/multisig/approveAsMulti.ts#L15)

--- a/docs/interfaces/txwrapper_substrate_src.methods.multisig.MultiSigApproveAsMulti.md
+++ b/docs/interfaces/txwrapper_substrate_src.methods.multisig.MultiSigApproveAsMulti.md
@@ -30,7 +30,7 @@ The hash of the call to be executed.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/multisig/approveAsMulti.ts:30](https://github.com/paritytech/txwrapper-core/blob/a0283d9/packages/txwrapper-substrate/src/methods/multisig/approveAsMulti.ts#L30)
+[txwrapper-substrate/src/methods/multisig/approveAsMulti.ts:30](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-substrate/src/methods/multisig/approveAsMulti.ts#L30)
 
 ___
 
@@ -42,7 +42,7 @@ Maximium weight the call being approved may consume.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/multisig/approveAsMulti.ts:34](https://github.com/paritytech/txwrapper-core/blob/a0283d9/packages/txwrapper-substrate/src/methods/multisig/approveAsMulti.ts#L34)
+[txwrapper-substrate/src/methods/multisig/approveAsMulti.ts:34](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-substrate/src/methods/multisig/approveAsMulti.ts#L34)
 
 ___
 
@@ -56,7 +56,7 @@ approving transaction.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/multisig/approveAsMulti.ts:26](https://github.com/paritytech/txwrapper-core/blob/a0283d9/packages/txwrapper-substrate/src/methods/multisig/approveAsMulti.ts#L26)
+[txwrapper-substrate/src/methods/multisig/approveAsMulti.ts:26](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-substrate/src/methods/multisig/approveAsMulti.ts#L26)
 
 ___
 
@@ -69,7 +69,7 @@ May not be empty.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/multisig/approveAsMulti.ts:20](https://github.com/paritytech/txwrapper-core/blob/a0283d9/packages/txwrapper-substrate/src/methods/multisig/approveAsMulti.ts#L20)
+[txwrapper-substrate/src/methods/multisig/approveAsMulti.ts:20](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-substrate/src/methods/multisig/approveAsMulti.ts#L20)
 
 ___
 
@@ -81,4 +81,4 @@ The total number of approvals required for this dispatch before it is executed.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/multisig/approveAsMulti.ts:15](https://github.com/paritytech/txwrapper-core/blob/a0283d9/packages/txwrapper-substrate/src/methods/multisig/approveAsMulti.ts#L15)
+[txwrapper-substrate/src/methods/multisig/approveAsMulti.ts:15](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-substrate/src/methods/multisig/approveAsMulti.ts#L15)

--- a/docs/interfaces/txwrapper_substrate_src.methods.multisig.MultiSigApproveAsMulti.md
+++ b/docs/interfaces/txwrapper_substrate_src.methods.multisig.MultiSigApproveAsMulti.md
@@ -30,7 +30,7 @@ The hash of the call to be executed.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/multisig/approveAsMulti.ts:30](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-substrate/src/methods/multisig/approveAsMulti.ts#L30)
+[txwrapper-substrate/src/methods/multisig/approveAsMulti.ts:30](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-substrate/src/methods/multisig/approveAsMulti.ts#L30)
 
 ___
 
@@ -42,7 +42,7 @@ Maximium weight the call being approved may consume.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/multisig/approveAsMulti.ts:34](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-substrate/src/methods/multisig/approveAsMulti.ts#L34)
+[txwrapper-substrate/src/methods/multisig/approveAsMulti.ts:34](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-substrate/src/methods/multisig/approveAsMulti.ts#L34)
 
 ___
 
@@ -56,7 +56,7 @@ approving transaction.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/multisig/approveAsMulti.ts:26](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-substrate/src/methods/multisig/approveAsMulti.ts#L26)
+[txwrapper-substrate/src/methods/multisig/approveAsMulti.ts:26](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-substrate/src/methods/multisig/approveAsMulti.ts#L26)
 
 ___
 
@@ -69,7 +69,7 @@ May not be empty.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/multisig/approveAsMulti.ts:20](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-substrate/src/methods/multisig/approveAsMulti.ts#L20)
+[txwrapper-substrate/src/methods/multisig/approveAsMulti.ts:20](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-substrate/src/methods/multisig/approveAsMulti.ts#L20)
 
 ___
 
@@ -81,4 +81,4 @@ The total number of approvals required for this dispatch before it is executed.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/multisig/approveAsMulti.ts:15](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-substrate/src/methods/multisig/approveAsMulti.ts#L15)
+[txwrapper-substrate/src/methods/multisig/approveAsMulti.ts:15](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-substrate/src/methods/multisig/approveAsMulti.ts#L15)

--- a/docs/interfaces/txwrapper_substrate_src.methods.multisig.MultisigAsMulti.md
+++ b/docs/interfaces/txwrapper_substrate_src.methods.multisig.MultisigAsMulti.md
@@ -27,7 +27,7 @@ The call to be executed as a SCALE encoded hex string.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/multisig/asMulti.ts:15](https://github.com/paritytech/txwrapper-core/blob/a0283d9/packages/txwrapper-substrate/src/methods/multisig/asMulti.ts#L15)
+[txwrapper-substrate/src/methods/multisig/asMulti.ts:15](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-substrate/src/methods/multisig/asMulti.ts#L15)
 
 ___
 
@@ -42,4 +42,4 @@ removed from storage once the call is executed.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/multisig/asMulti.ts:22](https://github.com/paritytech/txwrapper-core/blob/a0283d9/packages/txwrapper-substrate/src/methods/multisig/asMulti.ts#L22)
+[txwrapper-substrate/src/methods/multisig/asMulti.ts:22](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-substrate/src/methods/multisig/asMulti.ts#L22)

--- a/docs/interfaces/txwrapper_substrate_src.methods.multisig.MultisigAsMulti.md
+++ b/docs/interfaces/txwrapper_substrate_src.methods.multisig.MultisigAsMulti.md
@@ -27,7 +27,7 @@ The call to be executed as a SCALE encoded hex string.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/multisig/asMulti.ts:15](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-substrate/src/methods/multisig/asMulti.ts#L15)
+[txwrapper-substrate/src/methods/multisig/asMulti.ts:15](https://github.com/paritytech/txwrapper-core/blob/9387f90/packages/txwrapper-substrate/src/methods/multisig/asMulti.ts#L15)
 
 ___
 
@@ -42,4 +42,4 @@ removed from storage once the call is executed.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/multisig/asMulti.ts:22](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-substrate/src/methods/multisig/asMulti.ts#L22)
+[txwrapper-substrate/src/methods/multisig/asMulti.ts:22](https://github.com/paritytech/txwrapper-core/blob/9387f90/packages/txwrapper-substrate/src/methods/multisig/asMulti.ts#L22)

--- a/docs/interfaces/txwrapper_substrate_src.methods.multisig.MultisigAsMulti.md
+++ b/docs/interfaces/txwrapper_substrate_src.methods.multisig.MultisigAsMulti.md
@@ -27,7 +27,7 @@ The call to be executed as a SCALE encoded hex string.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/multisig/asMulti.ts:15](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-substrate/src/methods/multisig/asMulti.ts#L15)
+[txwrapper-substrate/src/methods/multisig/asMulti.ts:15](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-substrate/src/methods/multisig/asMulti.ts#L15)
 
 ___
 
@@ -42,4 +42,4 @@ removed from storage once the call is executed.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/multisig/asMulti.ts:22](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-substrate/src/methods/multisig/asMulti.ts#L22)
+[txwrapper-substrate/src/methods/multisig/asMulti.ts:22](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-substrate/src/methods/multisig/asMulti.ts#L22)

--- a/docs/interfaces/txwrapper_substrate_src.methods.multisig.MultisigCancelAsMulti.md
+++ b/docs/interfaces/txwrapper_substrate_src.methods.multisig.MultisigCancelAsMulti.md
@@ -27,7 +27,7 @@ The hash of the call to be executed.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/multisig/cancelAsMulti.ts:21](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-substrate/src/methods/multisig/cancelAsMulti.ts#L21)
+[txwrapper-substrate/src/methods/multisig/cancelAsMulti.ts:21](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-substrate/src/methods/multisig/cancelAsMulti.ts#L21)
 
 ___
 
@@ -40,4 +40,4 @@ transaction for this dispatch.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/multisig/cancelAsMulti.ts:17](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-substrate/src/methods/multisig/cancelAsMulti.ts#L17)
+[txwrapper-substrate/src/methods/multisig/cancelAsMulti.ts:17](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-substrate/src/methods/multisig/cancelAsMulti.ts#L17)

--- a/docs/interfaces/txwrapper_substrate_src.methods.multisig.MultisigCancelAsMulti.md
+++ b/docs/interfaces/txwrapper_substrate_src.methods.multisig.MultisigCancelAsMulti.md
@@ -27,7 +27,7 @@ The hash of the call to be executed.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/multisig/cancelAsMulti.ts:21](https://github.com/paritytech/txwrapper-core/blob/a0283d9/packages/txwrapper-substrate/src/methods/multisig/cancelAsMulti.ts#L21)
+[txwrapper-substrate/src/methods/multisig/cancelAsMulti.ts:21](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-substrate/src/methods/multisig/cancelAsMulti.ts#L21)
 
 ___
 
@@ -40,4 +40,4 @@ transaction for this dispatch.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/multisig/cancelAsMulti.ts:17](https://github.com/paritytech/txwrapper-core/blob/a0283d9/packages/txwrapper-substrate/src/methods/multisig/cancelAsMulti.ts#L17)
+[txwrapper-substrate/src/methods/multisig/cancelAsMulti.ts:17](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-substrate/src/methods/multisig/cancelAsMulti.ts#L17)

--- a/docs/interfaces/txwrapper_substrate_src.methods.multisig.MultisigCancelAsMulti.md
+++ b/docs/interfaces/txwrapper_substrate_src.methods.multisig.MultisigCancelAsMulti.md
@@ -27,17 +27,17 @@ The hash of the call to be executed.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/multisig/cancelAsMulti.ts:21](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-substrate/src/methods/multisig/cancelAsMulti.ts#L21)
+[txwrapper-substrate/src/methods/multisig/cancelAsMulti.ts:21](https://github.com/paritytech/txwrapper-core/blob/9387f90/packages/txwrapper-substrate/src/methods/multisig/cancelAsMulti.ts#L21)
 
 ___
 
 ### timepoint
 
-• **timepoint**: `Timepoint`
+• **timepoint**: [`Timepoint`](../modules/txwrapper_substrate_src._internal_.md#timepoint)
 
 The timepoint (block number and transaction index) of the first approval
 transaction for this dispatch.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/multisig/cancelAsMulti.ts:17](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-substrate/src/methods/multisig/cancelAsMulti.ts#L17)
+[txwrapper-substrate/src/methods/multisig/cancelAsMulti.ts:17](https://github.com/paritytech/txwrapper-core/blob/9387f90/packages/txwrapper-substrate/src/methods/multisig/cancelAsMulti.ts#L17)

--- a/docs/interfaces/txwrapper_substrate_src.methods.proxy.ProxyAddProxy.md
+++ b/docs/interfaces/txwrapper_substrate_src.methods.proxy.ProxyAddProxy.md
@@ -29,7 +29,7 @@ may be dispatched. If zero, then no announcement is needed.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/proxy/addProxy.ts:22](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-substrate/src/methods/proxy/addProxy.ts#L22)
+[txwrapper-substrate/src/methods/proxy/addProxy.ts:22](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-substrate/src/methods/proxy/addProxy.ts#L22)
 
 ___
 
@@ -41,7 +41,7 @@ The account that the `caller` would like to make a proxy.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/proxy/addProxy.ts:13](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-substrate/src/methods/proxy/addProxy.ts#L13)
+[txwrapper-substrate/src/methods/proxy/addProxy.ts:13](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-substrate/src/methods/proxy/addProxy.ts#L13)
 
 ___
 
@@ -53,4 +53,4 @@ The permissions for this proxy account. See the chain's runtime for the `call` f
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/proxy/addProxy.ts:17](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-substrate/src/methods/proxy/addProxy.ts#L17)
+[txwrapper-substrate/src/methods/proxy/addProxy.ts:17](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-substrate/src/methods/proxy/addProxy.ts#L17)

--- a/docs/interfaces/txwrapper_substrate_src.methods.proxy.ProxyAddProxy.md
+++ b/docs/interfaces/txwrapper_substrate_src.methods.proxy.ProxyAddProxy.md
@@ -29,7 +29,7 @@ may be dispatched. If zero, then no announcement is needed.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/proxy/addProxy.ts:22](https://github.com/paritytech/txwrapper-core/blob/a0283d9/packages/txwrapper-substrate/src/methods/proxy/addProxy.ts#L22)
+[txwrapper-substrate/src/methods/proxy/addProxy.ts:22](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-substrate/src/methods/proxy/addProxy.ts#L22)
 
 ___
 
@@ -41,7 +41,7 @@ The account that the `caller` would like to make a proxy.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/proxy/addProxy.ts:13](https://github.com/paritytech/txwrapper-core/blob/a0283d9/packages/txwrapper-substrate/src/methods/proxy/addProxy.ts#L13)
+[txwrapper-substrate/src/methods/proxy/addProxy.ts:13](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-substrate/src/methods/proxy/addProxy.ts#L13)
 
 ___
 
@@ -53,4 +53,4 @@ The permissions for this proxy account. See the chain's runtime for the `call` f
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/proxy/addProxy.ts:17](https://github.com/paritytech/txwrapper-core/blob/a0283d9/packages/txwrapper-substrate/src/methods/proxy/addProxy.ts#L17)
+[txwrapper-substrate/src/methods/proxy/addProxy.ts:17](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-substrate/src/methods/proxy/addProxy.ts#L17)

--- a/docs/interfaces/txwrapper_substrate_src.methods.proxy.ProxyAddProxy.md
+++ b/docs/interfaces/txwrapper_substrate_src.methods.proxy.ProxyAddProxy.md
@@ -29,7 +29,7 @@ may be dispatched. If zero, then no announcement is needed.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/proxy/addProxy.ts:22](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-substrate/src/methods/proxy/addProxy.ts#L22)
+[txwrapper-substrate/src/methods/proxy/addProxy.ts:22](https://github.com/paritytech/txwrapper-core/blob/9387f90/packages/txwrapper-substrate/src/methods/proxy/addProxy.ts#L22)
 
 ___
 
@@ -41,7 +41,7 @@ The account that the `caller` would like to make a proxy.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/proxy/addProxy.ts:13](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-substrate/src/methods/proxy/addProxy.ts#L13)
+[txwrapper-substrate/src/methods/proxy/addProxy.ts:13](https://github.com/paritytech/txwrapper-core/blob/9387f90/packages/txwrapper-substrate/src/methods/proxy/addProxy.ts#L13)
 
 ___
 
@@ -53,4 +53,4 @@ The permissions for this proxy account. See the chain's runtime for the `call` f
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/proxy/addProxy.ts:17](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-substrate/src/methods/proxy/addProxy.ts#L17)
+[txwrapper-substrate/src/methods/proxy/addProxy.ts:17](https://github.com/paritytech/txwrapper-core/blob/9387f90/packages/txwrapper-substrate/src/methods/proxy/addProxy.ts#L17)

--- a/docs/interfaces/txwrapper_substrate_src.methods.proxy.ProxyProxy.md
+++ b/docs/interfaces/txwrapper_substrate_src.methods.proxy.ProxyProxy.md
@@ -29,7 +29,7 @@ To take advantage of txwrapper methods, this could be UnsignedTransaction.method
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/proxy/proxy.ts:23](https://github.com/paritytech/txwrapper-core/blob/a0283d9/packages/txwrapper-substrate/src/methods/proxy/proxy.ts#L23)
+[txwrapper-substrate/src/methods/proxy/proxy.ts:23](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-substrate/src/methods/proxy/proxy.ts#L23)
 
 ___
 
@@ -41,7 +41,7 @@ Specify the exact proxy type to be used and checked for this call.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/proxy/proxy.ts:18](https://github.com/paritytech/txwrapper-core/blob/a0283d9/packages/txwrapper-substrate/src/methods/proxy/proxy.ts#L18)
+[txwrapper-substrate/src/methods/proxy/proxy.ts:18](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-substrate/src/methods/proxy/proxy.ts#L18)
 
 ___
 
@@ -54,4 +54,4 @@ through, `add_proxy`.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/proxy/proxy.ts:14](https://github.com/paritytech/txwrapper-core/blob/a0283d9/packages/txwrapper-substrate/src/methods/proxy/proxy.ts#L14)
+[txwrapper-substrate/src/methods/proxy/proxy.ts:14](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-substrate/src/methods/proxy/proxy.ts#L14)

--- a/docs/interfaces/txwrapper_substrate_src.methods.proxy.ProxyProxy.md
+++ b/docs/interfaces/txwrapper_substrate_src.methods.proxy.ProxyProxy.md
@@ -29,7 +29,7 @@ To take advantage of txwrapper methods, this could be UnsignedTransaction.method
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/proxy/proxy.ts:23](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-substrate/src/methods/proxy/proxy.ts#L23)
+[txwrapper-substrate/src/methods/proxy/proxy.ts:23](https://github.com/paritytech/txwrapper-core/blob/9387f90/packages/txwrapper-substrate/src/methods/proxy/proxy.ts#L23)
 
 ___
 
@@ -41,7 +41,7 @@ Specify the exact proxy type to be used and checked for this call.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/proxy/proxy.ts:18](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-substrate/src/methods/proxy/proxy.ts#L18)
+[txwrapper-substrate/src/methods/proxy/proxy.ts:18](https://github.com/paritytech/txwrapper-core/blob/9387f90/packages/txwrapper-substrate/src/methods/proxy/proxy.ts#L18)
 
 ___
 
@@ -54,4 +54,4 @@ through, `add_proxy`.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/proxy/proxy.ts:14](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-substrate/src/methods/proxy/proxy.ts#L14)
+[txwrapper-substrate/src/methods/proxy/proxy.ts:14](https://github.com/paritytech/txwrapper-core/blob/9387f90/packages/txwrapper-substrate/src/methods/proxy/proxy.ts#L14)

--- a/docs/interfaces/txwrapper_substrate_src.methods.proxy.ProxyProxy.md
+++ b/docs/interfaces/txwrapper_substrate_src.methods.proxy.ProxyProxy.md
@@ -29,7 +29,7 @@ To take advantage of txwrapper methods, this could be UnsignedTransaction.method
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/proxy/proxy.ts:23](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-substrate/src/methods/proxy/proxy.ts#L23)
+[txwrapper-substrate/src/methods/proxy/proxy.ts:23](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-substrate/src/methods/proxy/proxy.ts#L23)
 
 ___
 
@@ -41,7 +41,7 @@ Specify the exact proxy type to be used and checked for this call.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/proxy/proxy.ts:18](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-substrate/src/methods/proxy/proxy.ts#L18)
+[txwrapper-substrate/src/methods/proxy/proxy.ts:18](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-substrate/src/methods/proxy/proxy.ts#L18)
 
 ___
 
@@ -54,4 +54,4 @@ through, `add_proxy`.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/proxy/proxy.ts:14](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-substrate/src/methods/proxy/proxy.ts#L14)
+[txwrapper-substrate/src/methods/proxy/proxy.ts:14](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-substrate/src/methods/proxy/proxy.ts#L14)

--- a/docs/interfaces/txwrapper_substrate_src.methods.proxy.ProxyProxyAnnouncedArgs.md
+++ b/docs/interfaces/txwrapper_substrate_src.methods.proxy.ProxyProxyAnnouncedArgs.md
@@ -30,7 +30,7 @@ To take advantage of txwrapper methods, this could be UnsignedTransaction.method
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/proxy/proxyAnnounced.ts:26](https://github.com/paritytech/txwrapper-core/blob/a0283d9/packages/txwrapper-substrate/src/methods/proxy/proxyAnnounced.ts#L26)
+[txwrapper-substrate/src/methods/proxy/proxyAnnounced.ts:26](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-substrate/src/methods/proxy/proxyAnnounced.ts#L26)
 
 ___
 
@@ -42,7 +42,7 @@ The account that previously announced the call.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/proxy/proxyAnnounced.ts:13](https://github.com/paritytech/txwrapper-core/blob/a0283d9/packages/txwrapper-substrate/src/methods/proxy/proxyAnnounced.ts#L13)
+[txwrapper-substrate/src/methods/proxy/proxyAnnounced.ts:13](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-substrate/src/methods/proxy/proxyAnnounced.ts#L13)
 
 ___
 
@@ -54,7 +54,7 @@ Specify the exact proxy type to be used and checked for this call.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/proxy/proxyAnnounced.ts:21](https://github.com/paritytech/txwrapper-core/blob/a0283d9/packages/txwrapper-substrate/src/methods/proxy/proxyAnnounced.ts#L21)
+[txwrapper-substrate/src/methods/proxy/proxyAnnounced.ts:21](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-substrate/src/methods/proxy/proxyAnnounced.ts#L21)
 
 ___
 
@@ -66,4 +66,4 @@ The account that the proxy will make a call on behalf of.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/proxy/proxyAnnounced.ts:17](https://github.com/paritytech/txwrapper-core/blob/a0283d9/packages/txwrapper-substrate/src/methods/proxy/proxyAnnounced.ts#L17)
+[txwrapper-substrate/src/methods/proxy/proxyAnnounced.ts:17](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-substrate/src/methods/proxy/proxyAnnounced.ts#L17)

--- a/docs/interfaces/txwrapper_substrate_src.methods.proxy.ProxyProxyAnnouncedArgs.md
+++ b/docs/interfaces/txwrapper_substrate_src.methods.proxy.ProxyProxyAnnouncedArgs.md
@@ -30,7 +30,7 @@ To take advantage of txwrapper methods, this could be UnsignedTransaction.method
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/proxy/proxyAnnounced.ts:26](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-substrate/src/methods/proxy/proxyAnnounced.ts#L26)
+[txwrapper-substrate/src/methods/proxy/proxyAnnounced.ts:26](https://github.com/paritytech/txwrapper-core/blob/9387f90/packages/txwrapper-substrate/src/methods/proxy/proxyAnnounced.ts#L26)
 
 ___
 
@@ -42,7 +42,7 @@ The account that previously announced the call.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/proxy/proxyAnnounced.ts:13](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-substrate/src/methods/proxy/proxyAnnounced.ts#L13)
+[txwrapper-substrate/src/methods/proxy/proxyAnnounced.ts:13](https://github.com/paritytech/txwrapper-core/blob/9387f90/packages/txwrapper-substrate/src/methods/proxy/proxyAnnounced.ts#L13)
 
 ___
 
@@ -54,7 +54,7 @@ Specify the exact proxy type to be used and checked for this call.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/proxy/proxyAnnounced.ts:21](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-substrate/src/methods/proxy/proxyAnnounced.ts#L21)
+[txwrapper-substrate/src/methods/proxy/proxyAnnounced.ts:21](https://github.com/paritytech/txwrapper-core/blob/9387f90/packages/txwrapper-substrate/src/methods/proxy/proxyAnnounced.ts#L21)
 
 ___
 
@@ -66,4 +66,4 @@ The account that the proxy will make a call on behalf of.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/proxy/proxyAnnounced.ts:17](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-substrate/src/methods/proxy/proxyAnnounced.ts#L17)
+[txwrapper-substrate/src/methods/proxy/proxyAnnounced.ts:17](https://github.com/paritytech/txwrapper-core/blob/9387f90/packages/txwrapper-substrate/src/methods/proxy/proxyAnnounced.ts#L17)

--- a/docs/interfaces/txwrapper_substrate_src.methods.proxy.ProxyProxyAnnouncedArgs.md
+++ b/docs/interfaces/txwrapper_substrate_src.methods.proxy.ProxyProxyAnnouncedArgs.md
@@ -30,7 +30,7 @@ To take advantage of txwrapper methods, this could be UnsignedTransaction.method
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/proxy/proxyAnnounced.ts:26](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-substrate/src/methods/proxy/proxyAnnounced.ts#L26)
+[txwrapper-substrate/src/methods/proxy/proxyAnnounced.ts:26](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-substrate/src/methods/proxy/proxyAnnounced.ts#L26)
 
 ___
 
@@ -42,7 +42,7 @@ The account that previously announced the call.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/proxy/proxyAnnounced.ts:13](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-substrate/src/methods/proxy/proxyAnnounced.ts#L13)
+[txwrapper-substrate/src/methods/proxy/proxyAnnounced.ts:13](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-substrate/src/methods/proxy/proxyAnnounced.ts#L13)
 
 ___
 
@@ -54,7 +54,7 @@ Specify the exact proxy type to be used and checked for this call.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/proxy/proxyAnnounced.ts:21](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-substrate/src/methods/proxy/proxyAnnounced.ts#L21)
+[txwrapper-substrate/src/methods/proxy/proxyAnnounced.ts:21](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-substrate/src/methods/proxy/proxyAnnounced.ts#L21)
 
 ___
 
@@ -66,4 +66,4 @@ The account that the proxy will make a call on behalf of.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/proxy/proxyAnnounced.ts:17](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-substrate/src/methods/proxy/proxyAnnounced.ts#L17)
+[txwrapper-substrate/src/methods/proxy/proxyAnnounced.ts:17](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-substrate/src/methods/proxy/proxyAnnounced.ts#L17)

--- a/docs/interfaces/txwrapper_substrate_src.methods.proxy.ProxyRejectAnnouncementArgs.md
+++ b/docs/interfaces/txwrapper_substrate_src.methods.proxy.ProxyRejectAnnouncementArgs.md
@@ -27,7 +27,7 @@ The hash of the call that the proxy wants to execute.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/proxy/rejectAnnouncement.ts:17](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-substrate/src/methods/proxy/rejectAnnouncement.ts#L17)
+[txwrapper-substrate/src/methods/proxy/rejectAnnouncement.ts:17](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-substrate/src/methods/proxy/rejectAnnouncement.ts#L17)
 
 ___
 
@@ -39,4 +39,4 @@ The account that previously announced the call.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/proxy/rejectAnnouncement.ts:13](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-substrate/src/methods/proxy/rejectAnnouncement.ts#L13)
+[txwrapper-substrate/src/methods/proxy/rejectAnnouncement.ts:13](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-substrate/src/methods/proxy/rejectAnnouncement.ts#L13)

--- a/docs/interfaces/txwrapper_substrate_src.methods.proxy.ProxyRejectAnnouncementArgs.md
+++ b/docs/interfaces/txwrapper_substrate_src.methods.proxy.ProxyRejectAnnouncementArgs.md
@@ -27,7 +27,7 @@ The hash of the call that the proxy wants to execute.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/proxy/rejectAnnouncement.ts:17](https://github.com/paritytech/txwrapper-core/blob/a0283d9/packages/txwrapper-substrate/src/methods/proxy/rejectAnnouncement.ts#L17)
+[txwrapper-substrate/src/methods/proxy/rejectAnnouncement.ts:17](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-substrate/src/methods/proxy/rejectAnnouncement.ts#L17)
 
 ___
 
@@ -39,4 +39,4 @@ The account that previously announced the call.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/proxy/rejectAnnouncement.ts:13](https://github.com/paritytech/txwrapper-core/blob/a0283d9/packages/txwrapper-substrate/src/methods/proxy/rejectAnnouncement.ts#L13)
+[txwrapper-substrate/src/methods/proxy/rejectAnnouncement.ts:13](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-substrate/src/methods/proxy/rejectAnnouncement.ts#L13)

--- a/docs/interfaces/txwrapper_substrate_src.methods.proxy.ProxyRejectAnnouncementArgs.md
+++ b/docs/interfaces/txwrapper_substrate_src.methods.proxy.ProxyRejectAnnouncementArgs.md
@@ -27,7 +27,7 @@ The hash of the call that the proxy wants to execute.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/proxy/rejectAnnouncement.ts:17](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-substrate/src/methods/proxy/rejectAnnouncement.ts#L17)
+[txwrapper-substrate/src/methods/proxy/rejectAnnouncement.ts:17](https://github.com/paritytech/txwrapper-core/blob/9387f90/packages/txwrapper-substrate/src/methods/proxy/rejectAnnouncement.ts#L17)
 
 ___
 
@@ -39,4 +39,4 @@ The account that previously announced the call.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/proxy/rejectAnnouncement.ts:13](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-substrate/src/methods/proxy/rejectAnnouncement.ts#L13)
+[txwrapper-substrate/src/methods/proxy/rejectAnnouncement.ts:13](https://github.com/paritytech/txwrapper-core/blob/9387f90/packages/txwrapper-substrate/src/methods/proxy/rejectAnnouncement.ts#L13)

--- a/docs/interfaces/txwrapper_substrate_src.methods.session.SessionSetKeysArgs.md
+++ b/docs/interfaces/txwrapper_substrate_src.methods.session.SessionSetKeysArgs.md
@@ -27,7 +27,7 @@ The 5 keys to set.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/session/setKeys.ts:13](https://github.com/paritytech/txwrapper-core/blob/a0283d9/packages/txwrapper-substrate/src/methods/session/setKeys.ts#L13)
+[txwrapper-substrate/src/methods/session/setKeys.ts:13](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-substrate/src/methods/session/setKeys.ts#L13)
 
 ___
 
@@ -39,4 +39,4 @@ Proof of key ownership (currently unused).
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/session/setKeys.ts:17](https://github.com/paritytech/txwrapper-core/blob/a0283d9/packages/txwrapper-substrate/src/methods/session/setKeys.ts#L17)
+[txwrapper-substrate/src/methods/session/setKeys.ts:17](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-substrate/src/methods/session/setKeys.ts#L17)

--- a/docs/interfaces/txwrapper_substrate_src.methods.session.SessionSetKeysArgs.md
+++ b/docs/interfaces/txwrapper_substrate_src.methods.session.SessionSetKeysArgs.md
@@ -27,7 +27,7 @@ The 5 keys to set.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/session/setKeys.ts:13](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-substrate/src/methods/session/setKeys.ts#L13)
+[txwrapper-substrate/src/methods/session/setKeys.ts:13](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-substrate/src/methods/session/setKeys.ts#L13)
 
 ___
 
@@ -39,4 +39,4 @@ Proof of key ownership (currently unused).
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/session/setKeys.ts:17](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-substrate/src/methods/session/setKeys.ts#L17)
+[txwrapper-substrate/src/methods/session/setKeys.ts:17](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-substrate/src/methods/session/setKeys.ts#L17)

--- a/docs/interfaces/txwrapper_substrate_src.methods.session.SessionSetKeysArgs.md
+++ b/docs/interfaces/txwrapper_substrate_src.methods.session.SessionSetKeysArgs.md
@@ -27,7 +27,7 @@ The 5 keys to set.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/session/setKeys.ts:13](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-substrate/src/methods/session/setKeys.ts#L13)
+[txwrapper-substrate/src/methods/session/setKeys.ts:13](https://github.com/paritytech/txwrapper-core/blob/9387f90/packages/txwrapper-substrate/src/methods/session/setKeys.ts#L13)
 
 ___
 
@@ -39,4 +39,4 @@ Proof of key ownership (currently unused).
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/session/setKeys.ts:17](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-substrate/src/methods/session/setKeys.ts#L17)
+[txwrapper-substrate/src/methods/session/setKeys.ts:17](https://github.com/paritytech/txwrapper-core/blob/9387f90/packages/txwrapper-substrate/src/methods/session/setKeys.ts#L17)

--- a/docs/interfaces/txwrapper_substrate_src.methods.staking.StakingBondArgs.md
+++ b/docs/interfaces/txwrapper_substrate_src.methods.staking.StakingBondArgs.md
@@ -28,7 +28,7 @@ The SS-58 encoded address of the Controller account.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/staking/bond.ts:14](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-substrate/src/methods/staking/bond.ts#L14)
+[txwrapper-substrate/src/methods/staking/bond.ts:14](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-substrate/src/methods/staking/bond.ts#L14)
 
 ___
 
@@ -44,7 +44,7 @@ The rewards destination. Can be "Stash", "Staked", "Controller" or "{ Account: a
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/staking/setPayee.ts:13](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-substrate/src/methods/staking/setPayee.ts#L13)
+[txwrapper-substrate/src/methods/staking/setPayee.ts:13](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-substrate/src/methods/staking/setPayee.ts#L13)
 
 ___
 
@@ -56,4 +56,4 @@ The number of tokens to bond.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/staking/bond.ts:18](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-substrate/src/methods/staking/bond.ts#L18)
+[txwrapper-substrate/src/methods/staking/bond.ts:18](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-substrate/src/methods/staking/bond.ts#L18)

--- a/docs/interfaces/txwrapper_substrate_src.methods.staking.StakingBondArgs.md
+++ b/docs/interfaces/txwrapper_substrate_src.methods.staking.StakingBondArgs.md
@@ -28,7 +28,7 @@ The SS-58 encoded address of the Controller account.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/staking/bond.ts:14](https://github.com/paritytech/txwrapper-core/blob/a0283d9/packages/txwrapper-substrate/src/methods/staking/bond.ts#L14)
+[txwrapper-substrate/src/methods/staking/bond.ts:14](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-substrate/src/methods/staking/bond.ts#L14)
 
 ___
 
@@ -44,7 +44,7 @@ The rewards destination. Can be "Stash", "Staked", "Controller" or "{ Account: a
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/staking/setPayee.ts:13](https://github.com/paritytech/txwrapper-core/blob/a0283d9/packages/txwrapper-substrate/src/methods/staking/setPayee.ts#L13)
+[txwrapper-substrate/src/methods/staking/setPayee.ts:13](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-substrate/src/methods/staking/setPayee.ts#L13)
 
 ___
 
@@ -56,4 +56,4 @@ The number of tokens to bond.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/staking/bond.ts:18](https://github.com/paritytech/txwrapper-core/blob/a0283d9/packages/txwrapper-substrate/src/methods/staking/bond.ts#L18)
+[txwrapper-substrate/src/methods/staking/bond.ts:18](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-substrate/src/methods/staking/bond.ts#L18)

--- a/docs/interfaces/txwrapper_substrate_src.methods.staking.StakingBondArgs.md
+++ b/docs/interfaces/txwrapper_substrate_src.methods.staking.StakingBondArgs.md
@@ -28,7 +28,7 @@ The SS-58 encoded address of the Controller account.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/staking/bond.ts:14](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-substrate/src/methods/staking/bond.ts#L14)
+[txwrapper-substrate/src/methods/staking/bond.ts:14](https://github.com/paritytech/txwrapper-core/blob/9387f90/packages/txwrapper-substrate/src/methods/staking/bond.ts#L14)
 
 ___
 
@@ -44,7 +44,7 @@ The rewards destination. Can be "Stash", "Staked", "Controller" or "{ Account: a
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/staking/setPayee.ts:13](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-substrate/src/methods/staking/setPayee.ts#L13)
+[txwrapper-substrate/src/methods/staking/setPayee.ts:13](https://github.com/paritytech/txwrapper-core/blob/9387f90/packages/txwrapper-substrate/src/methods/staking/setPayee.ts#L13)
 
 ___
 
@@ -56,4 +56,4 @@ The number of tokens to bond.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/staking/bond.ts:18](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-substrate/src/methods/staking/bond.ts#L18)
+[txwrapper-substrate/src/methods/staking/bond.ts:18](https://github.com/paritytech/txwrapper-core/blob/9387f90/packages/txwrapper-substrate/src/methods/staking/bond.ts#L18)

--- a/docs/interfaces/txwrapper_substrate_src.methods.staking.StakingBondExtraArgs.md
+++ b/docs/interfaces/txwrapper_substrate_src.methods.staking.StakingBondExtraArgs.md
@@ -26,4 +26,4 @@ The maximum amount to bond.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/staking/bondExtra.ts:13](https://github.com/paritytech/txwrapper-core/blob/a0283d9/packages/txwrapper-substrate/src/methods/staking/bondExtra.ts#L13)
+[txwrapper-substrate/src/methods/staking/bondExtra.ts:13](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-substrate/src/methods/staking/bondExtra.ts#L13)

--- a/docs/interfaces/txwrapper_substrate_src.methods.staking.StakingBondExtraArgs.md
+++ b/docs/interfaces/txwrapper_substrate_src.methods.staking.StakingBondExtraArgs.md
@@ -26,4 +26,4 @@ The maximum amount to bond.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/staking/bondExtra.ts:13](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-substrate/src/methods/staking/bondExtra.ts#L13)
+[txwrapper-substrate/src/methods/staking/bondExtra.ts:13](https://github.com/paritytech/txwrapper-core/blob/9387f90/packages/txwrapper-substrate/src/methods/staking/bondExtra.ts#L13)

--- a/docs/interfaces/txwrapper_substrate_src.methods.staking.StakingBondExtraArgs.md
+++ b/docs/interfaces/txwrapper_substrate_src.methods.staking.StakingBondExtraArgs.md
@@ -26,4 +26,4 @@ The maximum amount to bond.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/staking/bondExtra.ts:13](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-substrate/src/methods/staking/bondExtra.ts#L13)
+[txwrapper-substrate/src/methods/staking/bondExtra.ts:13](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-substrate/src/methods/staking/bondExtra.ts#L13)

--- a/docs/interfaces/txwrapper_substrate_src.methods.staking.StakingNominateArgs.md
+++ b/docs/interfaces/txwrapper_substrate_src.methods.staking.StakingNominateArgs.md
@@ -29,4 +29,4 @@ Warning: This provides no checks as to whether these targets are actual validato
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/staking/nominate.ts:16](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-substrate/src/methods/staking/nominate.ts#L16)
+[txwrapper-substrate/src/methods/staking/nominate.ts:16](https://github.com/paritytech/txwrapper-core/blob/9387f90/packages/txwrapper-substrate/src/methods/staking/nominate.ts#L16)

--- a/docs/interfaces/txwrapper_substrate_src.methods.staking.StakingNominateArgs.md
+++ b/docs/interfaces/txwrapper_substrate_src.methods.staking.StakingNominateArgs.md
@@ -29,4 +29,4 @@ Warning: This provides no checks as to whether these targets are actual validato
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/staking/nominate.ts:16](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-substrate/src/methods/staking/nominate.ts#L16)
+[txwrapper-substrate/src/methods/staking/nominate.ts:16](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-substrate/src/methods/staking/nominate.ts#L16)

--- a/docs/interfaces/txwrapper_substrate_src.methods.staking.StakingNominateArgs.md
+++ b/docs/interfaces/txwrapper_substrate_src.methods.staking.StakingNominateArgs.md
@@ -29,4 +29,4 @@ Warning: This provides no checks as to whether these targets are actual validato
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/staking/nominate.ts:16](https://github.com/paritytech/txwrapper-core/blob/a0283d9/packages/txwrapper-substrate/src/methods/staking/nominate.ts#L16)
+[txwrapper-substrate/src/methods/staking/nominate.ts:16](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-substrate/src/methods/staking/nominate.ts#L16)

--- a/docs/interfaces/txwrapper_substrate_src.methods.staking.StakingPayoutStakersArgs.md
+++ b/docs/interfaces/txwrapper_substrate_src.methods.staking.StakingPayoutStakersArgs.md
@@ -28,7 +28,7 @@ retains up to `history_depth` eras of reward information.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/staking/payoutStakers.ts:19](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-substrate/src/methods/staking/payoutStakers.ts#L19)
+[txwrapper-substrate/src/methods/staking/payoutStakers.ts:19](https://github.com/paritytech/txwrapper-core/blob/9387f90/packages/txwrapper-substrate/src/methods/staking/payoutStakers.ts#L19)
 
 ___
 
@@ -41,4 +41,4 @@ The Stash account of a _validator._ Their nominators, up to, the maximum
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/staking/payoutStakers.ts:14](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-substrate/src/methods/staking/payoutStakers.ts#L14)
+[txwrapper-substrate/src/methods/staking/payoutStakers.ts:14](https://github.com/paritytech/txwrapper-core/blob/9387f90/packages/txwrapper-substrate/src/methods/staking/payoutStakers.ts#L14)

--- a/docs/interfaces/txwrapper_substrate_src.methods.staking.StakingPayoutStakersArgs.md
+++ b/docs/interfaces/txwrapper_substrate_src.methods.staking.StakingPayoutStakersArgs.md
@@ -28,7 +28,7 @@ retains up to `history_depth` eras of reward information.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/staking/payoutStakers.ts:19](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-substrate/src/methods/staking/payoutStakers.ts#L19)
+[txwrapper-substrate/src/methods/staking/payoutStakers.ts:19](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-substrate/src/methods/staking/payoutStakers.ts#L19)
 
 ___
 
@@ -41,4 +41,4 @@ The Stash account of a _validator._ Their nominators, up to, the maximum
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/staking/payoutStakers.ts:14](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-substrate/src/methods/staking/payoutStakers.ts#L14)
+[txwrapper-substrate/src/methods/staking/payoutStakers.ts:14](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-substrate/src/methods/staking/payoutStakers.ts#L14)

--- a/docs/interfaces/txwrapper_substrate_src.methods.staking.StakingPayoutStakersArgs.md
+++ b/docs/interfaces/txwrapper_substrate_src.methods.staking.StakingPayoutStakersArgs.md
@@ -28,7 +28,7 @@ retains up to `history_depth` eras of reward information.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/staking/payoutStakers.ts:19](https://github.com/paritytech/txwrapper-core/blob/a0283d9/packages/txwrapper-substrate/src/methods/staking/payoutStakers.ts#L19)
+[txwrapper-substrate/src/methods/staking/payoutStakers.ts:19](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-substrate/src/methods/staking/payoutStakers.ts#L19)
 
 ___
 
@@ -41,4 +41,4 @@ The Stash account of a _validator._ Their nominators, up to, the maximum
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/staking/payoutStakers.ts:14](https://github.com/paritytech/txwrapper-core/blob/a0283d9/packages/txwrapper-substrate/src/methods/staking/payoutStakers.ts#L14)
+[txwrapper-substrate/src/methods/staking/payoutStakers.ts:14](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-substrate/src/methods/staking/payoutStakers.ts#L14)

--- a/docs/interfaces/txwrapper_substrate_src.methods.staking.StakingRebondArgs.md
+++ b/docs/interfaces/txwrapper_substrate_src.methods.staking.StakingRebondArgs.md
@@ -26,4 +26,4 @@ The number of tokens to rebond.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/staking/rebond.ts:13](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-substrate/src/methods/staking/rebond.ts#L13)
+[txwrapper-substrate/src/methods/staking/rebond.ts:13](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-substrate/src/methods/staking/rebond.ts#L13)

--- a/docs/interfaces/txwrapper_substrate_src.methods.staking.StakingRebondArgs.md
+++ b/docs/interfaces/txwrapper_substrate_src.methods.staking.StakingRebondArgs.md
@@ -26,4 +26,4 @@ The number of tokens to rebond.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/staking/rebond.ts:13](https://github.com/paritytech/txwrapper-core/blob/a0283d9/packages/txwrapper-substrate/src/methods/staking/rebond.ts#L13)
+[txwrapper-substrate/src/methods/staking/rebond.ts:13](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-substrate/src/methods/staking/rebond.ts#L13)

--- a/docs/interfaces/txwrapper_substrate_src.methods.staking.StakingRebondArgs.md
+++ b/docs/interfaces/txwrapper_substrate_src.methods.staking.StakingRebondArgs.md
@@ -26,4 +26,4 @@ The number of tokens to rebond.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/staking/rebond.ts:13](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-substrate/src/methods/staking/rebond.ts#L13)
+[txwrapper-substrate/src/methods/staking/rebond.ts:13](https://github.com/paritytech/txwrapper-core/blob/9387f90/packages/txwrapper-substrate/src/methods/staking/rebond.ts#L13)

--- a/docs/interfaces/txwrapper_substrate_src.methods.staking.StakingSetControllerArgs.md
+++ b/docs/interfaces/txwrapper_substrate_src.methods.staking.StakingSetControllerArgs.md
@@ -26,4 +26,4 @@ The SS-58 encoded controller address.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/staking/setController.ts:13](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-substrate/src/methods/staking/setController.ts#L13)
+[txwrapper-substrate/src/methods/staking/setController.ts:13](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-substrate/src/methods/staking/setController.ts#L13)

--- a/docs/interfaces/txwrapper_substrate_src.methods.staking.StakingSetControllerArgs.md
+++ b/docs/interfaces/txwrapper_substrate_src.methods.staking.StakingSetControllerArgs.md
@@ -26,4 +26,4 @@ The SS-58 encoded controller address.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/staking/setController.ts:13](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-substrate/src/methods/staking/setController.ts#L13)
+[txwrapper-substrate/src/methods/staking/setController.ts:13](https://github.com/paritytech/txwrapper-core/blob/9387f90/packages/txwrapper-substrate/src/methods/staking/setController.ts#L13)

--- a/docs/interfaces/txwrapper_substrate_src.methods.staking.StakingSetControllerArgs.md
+++ b/docs/interfaces/txwrapper_substrate_src.methods.staking.StakingSetControllerArgs.md
@@ -26,4 +26,4 @@ The SS-58 encoded controller address.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/staking/setController.ts:13](https://github.com/paritytech/txwrapper-core/blob/a0283d9/packages/txwrapper-substrate/src/methods/staking/setController.ts#L13)
+[txwrapper-substrate/src/methods/staking/setController.ts:13](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-substrate/src/methods/staking/setController.ts#L13)

--- a/docs/interfaces/txwrapper_substrate_src.methods.staking.StakingSetPayeeArgs.md
+++ b/docs/interfaces/txwrapper_substrate_src.methods.staking.StakingSetPayeeArgs.md
@@ -28,4 +28,4 @@ The rewards destination. Can be "Stash", "Staked", "Controller" or "{ Account: a
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/staking/setPayee.ts:13](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-substrate/src/methods/staking/setPayee.ts#L13)
+[txwrapper-substrate/src/methods/staking/setPayee.ts:13](https://github.com/paritytech/txwrapper-core/blob/9387f90/packages/txwrapper-substrate/src/methods/staking/setPayee.ts#L13)

--- a/docs/interfaces/txwrapper_substrate_src.methods.staking.StakingSetPayeeArgs.md
+++ b/docs/interfaces/txwrapper_substrate_src.methods.staking.StakingSetPayeeArgs.md
@@ -28,4 +28,4 @@ The rewards destination. Can be "Stash", "Staked", "Controller" or "{ Account: a
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/staking/setPayee.ts:13](https://github.com/paritytech/txwrapper-core/blob/a0283d9/packages/txwrapper-substrate/src/methods/staking/setPayee.ts#L13)
+[txwrapper-substrate/src/methods/staking/setPayee.ts:13](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-substrate/src/methods/staking/setPayee.ts#L13)

--- a/docs/interfaces/txwrapper_substrate_src.methods.staking.StakingSetPayeeArgs.md
+++ b/docs/interfaces/txwrapper_substrate_src.methods.staking.StakingSetPayeeArgs.md
@@ -28,4 +28,4 @@ The rewards destination. Can be "Stash", "Staked", "Controller" or "{ Account: a
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/staking/setPayee.ts:13](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-substrate/src/methods/staking/setPayee.ts#L13)
+[txwrapper-substrate/src/methods/staking/setPayee.ts:13](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-substrate/src/methods/staking/setPayee.ts#L13)

--- a/docs/interfaces/txwrapper_substrate_src.methods.staking.StakingUnbondArgs.md
+++ b/docs/interfaces/txwrapper_substrate_src.methods.staking.StakingUnbondArgs.md
@@ -26,4 +26,4 @@ The number of tokens to unbond.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/staking/unbond.ts:13](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-substrate/src/methods/staking/unbond.ts#L13)
+[txwrapper-substrate/src/methods/staking/unbond.ts:13](https://github.com/paritytech/txwrapper-core/blob/9387f90/packages/txwrapper-substrate/src/methods/staking/unbond.ts#L13)

--- a/docs/interfaces/txwrapper_substrate_src.methods.staking.StakingUnbondArgs.md
+++ b/docs/interfaces/txwrapper_substrate_src.methods.staking.StakingUnbondArgs.md
@@ -26,4 +26,4 @@ The number of tokens to unbond.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/staking/unbond.ts:13](https://github.com/paritytech/txwrapper-core/blob/a0283d9/packages/txwrapper-substrate/src/methods/staking/unbond.ts#L13)
+[txwrapper-substrate/src/methods/staking/unbond.ts:13](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-substrate/src/methods/staking/unbond.ts#L13)

--- a/docs/interfaces/txwrapper_substrate_src.methods.staking.StakingUnbondArgs.md
+++ b/docs/interfaces/txwrapper_substrate_src.methods.staking.StakingUnbondArgs.md
@@ -26,4 +26,4 @@ The number of tokens to unbond.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/staking/unbond.ts:13](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-substrate/src/methods/staking/unbond.ts#L13)
+[txwrapper-substrate/src/methods/staking/unbond.ts:13](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-substrate/src/methods/staking/unbond.ts#L13)

--- a/docs/interfaces/txwrapper_substrate_src.methods.staking.StakingValidateArgs.md
+++ b/docs/interfaces/txwrapper_substrate_src.methods.staking.StakingValidateArgs.md
@@ -32,4 +32,4 @@ Set the desired commission for the validator. Value is Perbill.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/staking/validate.ts:13](https://github.com/paritytech/txwrapper-core/blob/a0283d9/packages/txwrapper-substrate/src/methods/staking/validate.ts#L13)
+[txwrapper-substrate/src/methods/staking/validate.ts:13](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-substrate/src/methods/staking/validate.ts#L13)

--- a/docs/interfaces/txwrapper_substrate_src.methods.staking.StakingValidateArgs.md
+++ b/docs/interfaces/txwrapper_substrate_src.methods.staking.StakingValidateArgs.md
@@ -32,4 +32,4 @@ Set the desired commission for the validator. Value is Perbill.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/staking/validate.ts:13](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-substrate/src/methods/staking/validate.ts#L13)
+[txwrapper-substrate/src/methods/staking/validate.ts:13](https://github.com/paritytech/txwrapper-core/blob/9387f90/packages/txwrapper-substrate/src/methods/staking/validate.ts#L13)

--- a/docs/interfaces/txwrapper_substrate_src.methods.staking.StakingValidateArgs.md
+++ b/docs/interfaces/txwrapper_substrate_src.methods.staking.StakingValidateArgs.md
@@ -32,4 +32,4 @@ Set the desired commission for the validator. Value is Perbill.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/staking/validate.ts:13](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-substrate/src/methods/staking/validate.ts#L13)
+[txwrapper-substrate/src/methods/staking/validate.ts:13](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-substrate/src/methods/staking/validate.ts#L13)

--- a/docs/interfaces/txwrapper_substrate_src.methods.staking.StakingWithdrawUnbondedArgs.md
+++ b/docs/interfaces/txwrapper_substrate_src.methods.staking.StakingWithdrawUnbondedArgs.md
@@ -24,4 +24,4 @@
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/staking/withdrawUnbonded.ts:10](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-substrate/src/methods/staking/withdrawUnbonded.ts#L10)
+[txwrapper-substrate/src/methods/staking/withdrawUnbonded.ts:10](https://github.com/paritytech/txwrapper-core/blob/9387f90/packages/txwrapper-substrate/src/methods/staking/withdrawUnbonded.ts#L10)

--- a/docs/interfaces/txwrapper_substrate_src.methods.staking.StakingWithdrawUnbondedArgs.md
+++ b/docs/interfaces/txwrapper_substrate_src.methods.staking.StakingWithdrawUnbondedArgs.md
@@ -24,4 +24,4 @@
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/staking/withdrawUnbonded.ts:10](https://github.com/paritytech/txwrapper-core/blob/a0283d9/packages/txwrapper-substrate/src/methods/staking/withdrawUnbonded.ts#L10)
+[txwrapper-substrate/src/methods/staking/withdrawUnbonded.ts:10](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-substrate/src/methods/staking/withdrawUnbonded.ts#L10)

--- a/docs/interfaces/txwrapper_substrate_src.methods.staking.StakingWithdrawUnbondedArgs.md
+++ b/docs/interfaces/txwrapper_substrate_src.methods.staking.StakingWithdrawUnbondedArgs.md
@@ -24,4 +24,4 @@
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/staking/withdrawUnbonded.ts:10](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-substrate/src/methods/staking/withdrawUnbonded.ts#L10)
+[txwrapper-substrate/src/methods/staking/withdrawUnbonded.ts:10](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-substrate/src/methods/staking/withdrawUnbonded.ts#L10)

--- a/docs/interfaces/txwrapper_substrate_src.methods.system.SystemRemarkArgs.md
+++ b/docs/interfaces/txwrapper_substrate_src.methods.system.SystemRemarkArgs.md
@@ -26,4 +26,4 @@ The remark to set on chain, in hex or bytes.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/system/remark.ts:13](https://github.com/paritytech/txwrapper-core/blob/a0283d9/packages/txwrapper-substrate/src/methods/system/remark.ts#L13)
+[txwrapper-substrate/src/methods/system/remark.ts:13](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-substrate/src/methods/system/remark.ts#L13)

--- a/docs/interfaces/txwrapper_substrate_src.methods.system.SystemRemarkArgs.md
+++ b/docs/interfaces/txwrapper_substrate_src.methods.system.SystemRemarkArgs.md
@@ -26,4 +26,4 @@ The remark to set on chain, in hex or bytes.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/system/remark.ts:13](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-substrate/src/methods/system/remark.ts#L13)
+[txwrapper-substrate/src/methods/system/remark.ts:13](https://github.com/paritytech/txwrapper-core/blob/9387f90/packages/txwrapper-substrate/src/methods/system/remark.ts#L13)

--- a/docs/interfaces/txwrapper_substrate_src.methods.system.SystemRemarkArgs.md
+++ b/docs/interfaces/txwrapper_substrate_src.methods.system.SystemRemarkArgs.md
@@ -26,4 +26,4 @@ The remark to set on chain, in hex or bytes.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/system/remark.ts:13](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-substrate/src/methods/system/remark.ts#L13)
+[txwrapper-substrate/src/methods/system/remark.ts:13](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-substrate/src/methods/system/remark.ts#L13)

--- a/docs/interfaces/txwrapper_substrate_src.methods.utility.UtilityAsDerivativeArgs.md
+++ b/docs/interfaces/txwrapper_substrate_src.methods.utility.UtilityAsDerivativeArgs.md
@@ -29,7 +29,7 @@ UnsignedTransaction.method.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/utility/asDerivative.ts:19](https://github.com/paritytech/txwrapper-core/blob/a0283d9/packages/txwrapper-substrate/src/methods/utility/asDerivative.ts#L19)
+[txwrapper-substrate/src/methods/utility/asDerivative.ts:19](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-substrate/src/methods/utility/asDerivative.ts#L19)
 
 ___
 
@@ -41,4 +41,4 @@ The sub-account index of the origin.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/utility/asDerivative.ts:13](https://github.com/paritytech/txwrapper-core/blob/a0283d9/packages/txwrapper-substrate/src/methods/utility/asDerivative.ts#L13)
+[txwrapper-substrate/src/methods/utility/asDerivative.ts:13](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-substrate/src/methods/utility/asDerivative.ts#L13)

--- a/docs/interfaces/txwrapper_substrate_src.methods.utility.UtilityAsDerivativeArgs.md
+++ b/docs/interfaces/txwrapper_substrate_src.methods.utility.UtilityAsDerivativeArgs.md
@@ -29,7 +29,7 @@ UnsignedTransaction.method.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/utility/asDerivative.ts:19](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-substrate/src/methods/utility/asDerivative.ts#L19)
+[txwrapper-substrate/src/methods/utility/asDerivative.ts:19](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-substrate/src/methods/utility/asDerivative.ts#L19)
 
 ___
 
@@ -41,4 +41,4 @@ The sub-account index of the origin.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/utility/asDerivative.ts:13](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-substrate/src/methods/utility/asDerivative.ts#L13)
+[txwrapper-substrate/src/methods/utility/asDerivative.ts:13](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-substrate/src/methods/utility/asDerivative.ts#L13)

--- a/docs/interfaces/txwrapper_substrate_src.methods.utility.UtilityAsDerivativeArgs.md
+++ b/docs/interfaces/txwrapper_substrate_src.methods.utility.UtilityAsDerivativeArgs.md
@@ -29,7 +29,7 @@ UnsignedTransaction.method.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/utility/asDerivative.ts:19](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-substrate/src/methods/utility/asDerivative.ts#L19)
+[txwrapper-substrate/src/methods/utility/asDerivative.ts:19](https://github.com/paritytech/txwrapper-core/blob/9387f90/packages/txwrapper-substrate/src/methods/utility/asDerivative.ts#L19)
 
 ___
 
@@ -41,4 +41,4 @@ The sub-account index of the origin.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/utility/asDerivative.ts:13](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-substrate/src/methods/utility/asDerivative.ts#L13)
+[txwrapper-substrate/src/methods/utility/asDerivative.ts:13](https://github.com/paritytech/txwrapper-core/blob/9387f90/packages/txwrapper-substrate/src/methods/utility/asDerivative.ts#L13)

--- a/docs/interfaces/txwrapper_substrate_src.methods.utility.UtilityBatch.md
+++ b/docs/interfaces/txwrapper_substrate_src.methods.utility.UtilityBatch.md
@@ -28,4 +28,4 @@ UnsignedTransaction.method.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/utility/batch.ts:15](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-substrate/src/methods/utility/batch.ts#L15)
+[txwrapper-substrate/src/methods/utility/batch.ts:15](https://github.com/paritytech/txwrapper-core/blob/9387f90/packages/txwrapper-substrate/src/methods/utility/batch.ts#L15)

--- a/docs/interfaces/txwrapper_substrate_src.methods.utility.UtilityBatch.md
+++ b/docs/interfaces/txwrapper_substrate_src.methods.utility.UtilityBatch.md
@@ -28,4 +28,4 @@ UnsignedTransaction.method.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/utility/batch.ts:15](https://github.com/paritytech/txwrapper-core/blob/a0283d9/packages/txwrapper-substrate/src/methods/utility/batch.ts#L15)
+[txwrapper-substrate/src/methods/utility/batch.ts:15](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-substrate/src/methods/utility/batch.ts#L15)

--- a/docs/interfaces/txwrapper_substrate_src.methods.utility.UtilityBatch.md
+++ b/docs/interfaces/txwrapper_substrate_src.methods.utility.UtilityBatch.md
@@ -28,4 +28,4 @@ UnsignedTransaction.method.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/utility/batch.ts:15](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-substrate/src/methods/utility/batch.ts#L15)
+[txwrapper-substrate/src/methods/utility/batch.ts:15](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-substrate/src/methods/utility/batch.ts#L15)

--- a/docs/interfaces/txwrapper_substrate_src.methods.vesting.VestingVestOtherArgs.md
+++ b/docs/interfaces/txwrapper_substrate_src.methods.vesting.VestingVestOtherArgs.md
@@ -27,4 +27,4 @@ locked under this module.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/vesting/vestOther.ts:14](https://github.com/paritytech/txwrapper-core/blob/a0283d9/packages/txwrapper-substrate/src/methods/vesting/vestOther.ts#L14)
+[txwrapper-substrate/src/methods/vesting/vestOther.ts:14](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-substrate/src/methods/vesting/vestOther.ts#L14)

--- a/docs/interfaces/txwrapper_substrate_src.methods.vesting.VestingVestOtherArgs.md
+++ b/docs/interfaces/txwrapper_substrate_src.methods.vesting.VestingVestOtherArgs.md
@@ -27,4 +27,4 @@ locked under this module.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/vesting/vestOther.ts:14](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-substrate/src/methods/vesting/vestOther.ts#L14)
+[txwrapper-substrate/src/methods/vesting/vestOther.ts:14](https://github.com/paritytech/txwrapper-core/blob/9387f90/packages/txwrapper-substrate/src/methods/vesting/vestOther.ts#L14)

--- a/docs/interfaces/txwrapper_substrate_src.methods.vesting.VestingVestOtherArgs.md
+++ b/docs/interfaces/txwrapper_substrate_src.methods.vesting.VestingVestOtherArgs.md
@@ -27,4 +27,4 @@ locked under this module.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/vesting/vestOther.ts:14](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-substrate/src/methods/vesting/vestOther.ts#L14)
+[txwrapper-substrate/src/methods/vesting/vestOther.ts:14](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-substrate/src/methods/vesting/vestOther.ts#L14)

--- a/docs/modules/txwrapper_core_src._internal_.md
+++ b/docs/modules/txwrapper_core_src._internal_.md
@@ -1,0 +1,11 @@
+[txwrapper-core](../README.md) / [Modules](../modules.md) / [txwrapper-core/src](txwrapper_core_src.md) / <internal\>
+
+# Namespace: <internal\>
+
+[txwrapper-core/src](txwrapper_core_src.md).<internal>
+
+## Table of contents
+
+### Interfaces
+
+- [GetRegistryBaseArgs](../interfaces/txwrapper_core_src._internal_.GetRegistryBaseArgs.md)

--- a/docs/modules/txwrapper_core_src.md
+++ b/docs/modules/txwrapper_core_src.md
@@ -8,7 +8,9 @@
 
 - [BaseTxInfo](../interfaces/txwrapper_core_src.BaseTxInfo.md)
 - [ChainProperties](../interfaces/txwrapper_core_src.ChainProperties.md)
+- [DecodedUnsignedHexTx](../interfaces/txwrapper_core_src.DecodedUnsignedHexTx.md)
 - [GetRegistryOptsCore](../interfaces/txwrapper_core_src.GetRegistryOptsCore.md)
+- [IMethod](../interfaces/txwrapper_core_src.IMethod.md)
 - [Options](../interfaces/txwrapper_core_src.Options.md)
 - [OptionsWithMeta](../interfaces/txwrapper_core_src.OptionsWithMeta.md)
 - [TxInfo](../interfaces/txwrapper_core_src.TxInfo.md)
@@ -46,7 +48,7 @@ Base Argument object for methods.
 
 #### Defined in
 
-[txwrapper-core/src/types/method.ts:26](https://github.com/paritytech/txwrapper-core/blob/a0283d9/packages/txwrapper-core/src/types/method.ts#L26)
+[txwrapper-core/src/types/method.ts:35](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-core/src/types/method.ts#L35)
 
 ___
 
@@ -56,7 +58,7 @@ ___
 
 #### Defined in
 
-[txwrapper-core/src/types/decode.ts:7](https://github.com/paritytech/txwrapper-core/blob/a0283d9/packages/txwrapper-core/src/types/decode.ts#L7)
+[txwrapper-core/src/types/decode.ts:7](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-core/src/types/decode.ts#L7)
 
 ___
 
@@ -66,7 +68,7 @@ ___
 
 #### Defined in
 
-[txwrapper-core/src/types/decode.ts:5](https://github.com/paritytech/txwrapper-core/blob/a0283d9/packages/txwrapper-core/src/types/decode.ts#L5)
+[txwrapper-core/src/types/decode.ts:5](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-core/src/types/decode.ts#L5)
 
 ___
 
@@ -76,7 +78,7 @@ ___
 
 #### Defined in
 
-[txwrapper-core/src/types/decode.ts:3](https://github.com/paritytech/txwrapper-core/blob/a0283d9/packages/txwrapper-core/src/types/decode.ts#L3)
+[txwrapper-core/src/types/decode.ts:3](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-core/src/types/decode.ts#L3)
 
 ___
 
@@ -88,7 +90,7 @@ A keyring pair
 
 #### Defined in
 
-[txwrapper-core/src/core/util/importPrivateKey.ts:8](https://github.com/paritytech/txwrapper-core/blob/a0283d9/packages/txwrapper-core/src/core/util/importPrivateKey.ts#L8)
+[txwrapper-core/src/core/util/importPrivateKey.ts:8](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-core/src/core/util/importPrivateKey.ts#L8)
 
 ## Variables
 
@@ -105,11 +107,12 @@ Functions for each step of the transaction construction process.
 | `encodeUnsignedTransaction` | (`unsigned`: [`UnsignedTransaction`](../interfaces/txwrapper_core_src.UnsignedTransaction.md), `options`: [`Options`](../interfaces/txwrapper_core_src.Options.md)) => `string` |
 | `signedTx` | (`unsigned`: [`UnsignedTransaction`](../interfaces/txwrapper_core_src.UnsignedTransaction.md), `signature`: \`0x${string}\`, `options`: [`OptionsWithMeta`](../interfaces/txwrapper_core_src.OptionsWithMeta.md)) => `string` |
 | `signingPayload` | (`unsigned`: [`UnsignedTransaction`](../interfaces/txwrapper_core_src.UnsignedTransaction.md), `options`: [`Options`](../interfaces/txwrapper_core_src.Options.md)) => `string` |
+| `signingPayloadToU8a` | (`unsigned`: [`UnsignedTransaction`](../interfaces/txwrapper_core_src.UnsignedTransaction.md), `options`: [`Options`](../interfaces/txwrapper_core_src.Options.md)) => `Uint8Array` |
 | `txHash` | (`signedTx`: `string`) => `string` |
 
 #### Defined in
 
-[txwrapper-core/src/core/index.ts:17](https://github.com/paritytech/txwrapper-core/blob/a0283d9/packages/txwrapper-core/src/core/index.ts#L17)
+[txwrapper-core/src/core/index.ts:18](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-core/src/core/index.ts#L18)
 
 ## Functions
 
@@ -133,7 +136,7 @@ All integers are serialized to a base-10 string.
 
 #### Defined in
 
-[txwrapper-core/src/core/decode/decode.ts:19](https://github.com/paritytech/txwrapper-core/blob/a0283d9/packages/txwrapper-core/src/core/decode/decode.ts#L19)
+[txwrapper-core/src/core/decode/decode.ts:19](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-core/src/core/decode/decode.ts#L19)
 
 ▸ **decode**(`signedTx`, `options`): [`DecodedSignedTx`](txwrapper_core_src.md#decodedsignedtx)
 
@@ -153,7 +156,7 @@ All integers are serialized to a base-10 string.
 
 #### Defined in
 
-[txwrapper-core/src/core/decode/decode.ts:31](https://github.com/paritytech/txwrapper-core/blob/a0283d9/packages/txwrapper-core/src/core/decode/decode.ts#L31)
+[txwrapper-core/src/core/decode/decode.ts:31](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-core/src/core/decode/decode.ts#L31)
 
 ▸ **decode**(`signingPayload`, `options`): [`DecodedSigningPayload`](txwrapper_core_src.md#decodedsigningpayload)
 
@@ -173,7 +176,7 @@ All integers are serialized to a base-10 string.
 
 #### Defined in
 
-[txwrapper-core/src/core/decode/decode.ts:43](https://github.com/paritytech/txwrapper-core/blob/a0283d9/packages/txwrapper-core/src/core/decode/decode.ts#L43)
+[txwrapper-core/src/core/decode/decode.ts:43](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-core/src/core/decode/decode.ts#L43)
 
 ___
 
@@ -196,7 +199,7 @@ Helper function to construct an offline method.
 
 #### Defined in
 
-[txwrapper-core/src/core/method/defineMethod.ts:31](https://github.com/paritytech/txwrapper-core/blob/a0283d9/packages/txwrapper-core/src/core/method/defineMethod.ts#L31)
+[txwrapper-core/src/core/method/defineMethod.ts:31](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-core/src/core/method/defineMethod.ts#L31)
 
 ___
 
@@ -219,7 +222,7 @@ Derive an address from a cryptographic public key offline.
 
 #### Defined in
 
-[txwrapper-core/src/core/util/deriveAddress.ts:9](https://github.com/paritytech/txwrapper-core/blob/a0283d9/packages/txwrapper-core/src/core/util/deriveAddress.ts#L9)
+[txwrapper-core/src/core/util/deriveAddress.ts:9](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-core/src/core/util/deriveAddress.ts#L9)
 
 ___
 
@@ -241,7 +244,7 @@ Create a type registry given chainProperties, specTypes, and metadataRpc.
 
 #### Defined in
 
-[txwrapper-core/src/core/metadata/getRegistryBase.ts:29](https://github.com/paritytech/txwrapper-core/blob/a0283d9/packages/txwrapper-core/src/core/metadata/getRegistryBase.ts#L29)
+[txwrapper-core/src/core/metadata/getRegistryBase.ts:38](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-core/src/core/metadata/getRegistryBase.ts#L38)
 
 ___
 
@@ -264,7 +267,7 @@ Import a private key and create a KeyringPair.
 
 #### Defined in
 
-[txwrapper-core/src/core/util/importPrivateKey.ts:16](https://github.com/paritytech/txwrapper-core/blob/a0283d9/packages/txwrapper-core/src/core/util/importPrivateKey.ts#L16)
+[txwrapper-core/src/core/util/importPrivateKey.ts:16](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-core/src/core/util/importPrivateKey.ts#L16)
 
 ___
 
@@ -288,4 +291,4 @@ call. All integers are serialized to base 10 strings in order to be safe.
 
 #### Defined in
 
-[txwrapper-core/src/core/method/toTxMethod.ts:21](https://github.com/paritytech/txwrapper-core/blob/a0283d9/packages/txwrapper-core/src/core/method/toTxMethod.ts#L21)
+[txwrapper-core/src/core/method/toTxMethod.ts:21](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-core/src/core/method/toTxMethod.ts#L21)

--- a/docs/modules/txwrapper_core_src.md
+++ b/docs/modules/txwrapper_core_src.md
@@ -48,7 +48,7 @@ Base Argument object for methods.
 
 #### Defined in
 
-[txwrapper-core/src/types/method.ts:35](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-core/src/types/method.ts#L35)
+[txwrapper-core/src/types/method.ts:35](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-core/src/types/method.ts#L35)
 
 ___
 
@@ -58,7 +58,7 @@ ___
 
 #### Defined in
 
-[txwrapper-core/src/types/decode.ts:7](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-core/src/types/decode.ts#L7)
+[txwrapper-core/src/types/decode.ts:7](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-core/src/types/decode.ts#L7)
 
 ___
 
@@ -68,7 +68,7 @@ ___
 
 #### Defined in
 
-[txwrapper-core/src/types/decode.ts:5](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-core/src/types/decode.ts#L5)
+[txwrapper-core/src/types/decode.ts:5](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-core/src/types/decode.ts#L5)
 
 ___
 
@@ -78,7 +78,7 @@ ___
 
 #### Defined in
 
-[txwrapper-core/src/types/decode.ts:3](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-core/src/types/decode.ts#L3)
+[txwrapper-core/src/types/decode.ts:3](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-core/src/types/decode.ts#L3)
 
 ___
 
@@ -90,7 +90,7 @@ A keyring pair
 
 #### Defined in
 
-[txwrapper-core/src/core/util/importPrivateKey.ts:8](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-core/src/core/util/importPrivateKey.ts#L8)
+[txwrapper-core/src/core/util/importPrivateKey.ts:8](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-core/src/core/util/importPrivateKey.ts#L8)
 
 ## Variables
 
@@ -112,7 +112,7 @@ Functions for each step of the transaction construction process.
 
 #### Defined in
 
-[txwrapper-core/src/core/index.ts:18](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-core/src/core/index.ts#L18)
+[txwrapper-core/src/core/index.ts:18](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-core/src/core/index.ts#L18)
 
 ## Functions
 
@@ -136,7 +136,7 @@ All integers are serialized to a base-10 string.
 
 #### Defined in
 
-[txwrapper-core/src/core/decode/decode.ts:19](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-core/src/core/decode/decode.ts#L19)
+[txwrapper-core/src/core/decode/decode.ts:19](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-core/src/core/decode/decode.ts#L19)
 
 ▸ **decode**(`signedTx`, `options`): [`DecodedSignedTx`](txwrapper_core_src.md#decodedsignedtx)
 
@@ -156,7 +156,7 @@ All integers are serialized to a base-10 string.
 
 #### Defined in
 
-[txwrapper-core/src/core/decode/decode.ts:31](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-core/src/core/decode/decode.ts#L31)
+[txwrapper-core/src/core/decode/decode.ts:31](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-core/src/core/decode/decode.ts#L31)
 
 ▸ **decode**(`signingPayload`, `options`): [`DecodedSigningPayload`](txwrapper_core_src.md#decodedsigningpayload)
 
@@ -176,7 +176,7 @@ All integers are serialized to a base-10 string.
 
 #### Defined in
 
-[txwrapper-core/src/core/decode/decode.ts:43](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-core/src/core/decode/decode.ts#L43)
+[txwrapper-core/src/core/decode/decode.ts:43](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-core/src/core/decode/decode.ts#L43)
 
 ___
 
@@ -199,7 +199,7 @@ Helper function to construct an offline method.
 
 #### Defined in
 
-[txwrapper-core/src/core/method/defineMethod.ts:31](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-core/src/core/method/defineMethod.ts#L31)
+[txwrapper-core/src/core/method/defineMethod.ts:100](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-core/src/core/method/defineMethod.ts#L100)
 
 ___
 
@@ -222,7 +222,7 @@ Derive an address from a cryptographic public key offline.
 
 #### Defined in
 
-[txwrapper-core/src/core/util/deriveAddress.ts:9](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-core/src/core/util/deriveAddress.ts#L9)
+[txwrapper-core/src/core/util/deriveAddress.ts:9](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-core/src/core/util/deriveAddress.ts#L9)
 
 ___
 
@@ -244,7 +244,7 @@ Create a type registry given chainProperties, specTypes, and metadataRpc.
 
 #### Defined in
 
-[txwrapper-core/src/core/metadata/getRegistryBase.ts:38](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-core/src/core/metadata/getRegistryBase.ts#L38)
+[txwrapper-core/src/core/metadata/getRegistryBase.ts:38](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-core/src/core/metadata/getRegistryBase.ts#L38)
 
 ___
 
@@ -267,7 +267,7 @@ Import a private key and create a KeyringPair.
 
 #### Defined in
 
-[txwrapper-core/src/core/util/importPrivateKey.ts:16](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-core/src/core/util/importPrivateKey.ts#L16)
+[txwrapper-core/src/core/util/importPrivateKey.ts:16](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-core/src/core/util/importPrivateKey.ts#L16)
 
 ___
 
@@ -291,4 +291,4 @@ call. All integers are serialized to base 10 strings in order to be safe.
 
 #### Defined in
 
-[txwrapper-core/src/core/method/toTxMethod.ts:21](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-core/src/core/method/toTxMethod.ts#L21)
+[txwrapper-core/src/core/method/toTxMethod.ts:21](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-core/src/core/method/toTxMethod.ts#L21)

--- a/docs/modules/txwrapper_core_src.md
+++ b/docs/modules/txwrapper_core_src.md
@@ -4,6 +4,10 @@
 
 ## Table of contents
 
+### Namespaces
+
+- [&lt;internal\&gt;](txwrapper_core_src._internal_.md)
+
 ### Interfaces
 
 - [BaseTxInfo](../interfaces/txwrapper_core_src.BaseTxInfo.md)
@@ -48,7 +52,7 @@ Base Argument object for methods.
 
 #### Defined in
 
-[txwrapper-core/src/types/method.ts:35](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-core/src/types/method.ts#L35)
+[txwrapper-core/src/types/method.ts:35](https://github.com/paritytech/txwrapper-core/blob/9387f90/packages/txwrapper-core/src/types/method.ts#L35)
 
 ___
 
@@ -58,7 +62,7 @@ ___
 
 #### Defined in
 
-[txwrapper-core/src/types/decode.ts:7](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-core/src/types/decode.ts#L7)
+[txwrapper-core/src/types/decode.ts:7](https://github.com/paritytech/txwrapper-core/blob/9387f90/packages/txwrapper-core/src/types/decode.ts#L7)
 
 ___
 
@@ -68,7 +72,7 @@ ___
 
 #### Defined in
 
-[txwrapper-core/src/types/decode.ts:5](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-core/src/types/decode.ts#L5)
+[txwrapper-core/src/types/decode.ts:5](https://github.com/paritytech/txwrapper-core/blob/9387f90/packages/txwrapper-core/src/types/decode.ts#L5)
 
 ___
 
@@ -78,7 +82,7 @@ ___
 
 #### Defined in
 
-[txwrapper-core/src/types/decode.ts:3](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-core/src/types/decode.ts#L3)
+[txwrapper-core/src/types/decode.ts:3](https://github.com/paritytech/txwrapper-core/blob/9387f90/packages/txwrapper-core/src/types/decode.ts#L3)
 
 ___
 
@@ -90,7 +94,7 @@ A keyring pair
 
 #### Defined in
 
-[txwrapper-core/src/core/util/importPrivateKey.ts:8](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-core/src/core/util/importPrivateKey.ts#L8)
+[txwrapper-core/src/core/util/importPrivateKey.ts:8](https://github.com/paritytech/txwrapper-core/blob/9387f90/packages/txwrapper-core/src/core/util/importPrivateKey.ts#L8)
 
 ## Variables
 
@@ -112,7 +116,7 @@ Functions for each step of the transaction construction process.
 
 #### Defined in
 
-[txwrapper-core/src/core/index.ts:18](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-core/src/core/index.ts#L18)
+[txwrapper-core/src/core/index.ts:18](https://github.com/paritytech/txwrapper-core/blob/9387f90/packages/txwrapper-core/src/core/index.ts#L18)
 
 ## Functions
 
@@ -136,7 +140,7 @@ All integers are serialized to a base-10 string.
 
 #### Defined in
 
-[txwrapper-core/src/core/decode/decode.ts:19](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-core/src/core/decode/decode.ts#L19)
+[txwrapper-core/src/core/decode/decode.ts:19](https://github.com/paritytech/txwrapper-core/blob/9387f90/packages/txwrapper-core/src/core/decode/decode.ts#L19)
 
 ▸ **decode**(`signedTx`, `options`): [`DecodedSignedTx`](txwrapper_core_src.md#decodedsignedtx)
 
@@ -156,7 +160,7 @@ All integers are serialized to a base-10 string.
 
 #### Defined in
 
-[txwrapper-core/src/core/decode/decode.ts:31](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-core/src/core/decode/decode.ts#L31)
+[txwrapper-core/src/core/decode/decode.ts:31](https://github.com/paritytech/txwrapper-core/blob/9387f90/packages/txwrapper-core/src/core/decode/decode.ts#L31)
 
 ▸ **decode**(`signingPayload`, `options`): [`DecodedSigningPayload`](txwrapper_core_src.md#decodedsigningpayload)
 
@@ -176,7 +180,7 @@ All integers are serialized to a base-10 string.
 
 #### Defined in
 
-[txwrapper-core/src/core/decode/decode.ts:43](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-core/src/core/decode/decode.ts#L43)
+[txwrapper-core/src/core/decode/decode.ts:43](https://github.com/paritytech/txwrapper-core/blob/9387f90/packages/txwrapper-core/src/core/decode/decode.ts#L43)
 
 ___
 
@@ -199,7 +203,7 @@ Helper function to construct an offline method.
 
 #### Defined in
 
-[txwrapper-core/src/core/method/defineMethod.ts:100](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-core/src/core/method/defineMethod.ts#L100)
+[txwrapper-core/src/core/method/defineMethod.ts:100](https://github.com/paritytech/txwrapper-core/blob/9387f90/packages/txwrapper-core/src/core/method/defineMethod.ts#L100)
 
 ___
 
@@ -222,7 +226,7 @@ Derive an address from a cryptographic public key offline.
 
 #### Defined in
 
-[txwrapper-core/src/core/util/deriveAddress.ts:9](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-core/src/core/util/deriveAddress.ts#L9)
+[txwrapper-core/src/core/util/deriveAddress.ts:9](https://github.com/paritytech/txwrapper-core/blob/9387f90/packages/txwrapper-core/src/core/util/deriveAddress.ts#L9)
 
 ___
 
@@ -236,7 +240,7 @@ Create a type registry given chainProperties, specTypes, and metadataRpc.
 
 | Name | Type |
 | :------ | :------ |
-| `__namedParameters` | `GetRegistryBaseArgs` |
+| `__namedParameters` | [`GetRegistryBaseArgs`](../interfaces/txwrapper_core_src._internal_.GetRegistryBaseArgs.md) |
 
 #### Returns
 
@@ -244,7 +248,7 @@ Create a type registry given chainProperties, specTypes, and metadataRpc.
 
 #### Defined in
 
-[txwrapper-core/src/core/metadata/getRegistryBase.ts:38](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-core/src/core/metadata/getRegistryBase.ts#L38)
+[txwrapper-core/src/core/metadata/getRegistryBase.ts:38](https://github.com/paritytech/txwrapper-core/blob/9387f90/packages/txwrapper-core/src/core/metadata/getRegistryBase.ts#L38)
 
 ___
 
@@ -267,7 +271,7 @@ Import a private key and create a KeyringPair.
 
 #### Defined in
 
-[txwrapper-core/src/core/util/importPrivateKey.ts:16](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-core/src/core/util/importPrivateKey.ts#L16)
+[txwrapper-core/src/core/util/importPrivateKey.ts:16](https://github.com/paritytech/txwrapper-core/blob/9387f90/packages/txwrapper-core/src/core/util/importPrivateKey.ts#L16)
 
 ___
 
@@ -291,4 +295,4 @@ call. All integers are serialized to base 10 strings in order to be safe.
 
 #### Defined in
 
-[txwrapper-core/src/core/method/toTxMethod.ts:21](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-core/src/core/method/toTxMethod.ts#L21)
+[txwrapper-core/src/core/method/toTxMethod.ts:21](https://github.com/paritytech/txwrapper-core/blob/9387f90/packages/txwrapper-core/src/core/method/toTxMethod.ts#L21)

--- a/docs/modules/txwrapper_polkadot_src._internal_.__Users_tarik_Desktop_parity_txwrapper_core_packages_txwrapper_polkadot_src_methods_crowdloan_index_.md
+++ b/docs/modules/txwrapper_polkadot_src._internal_.__Users_tarik_Desktop_parity_txwrapper_core_packages_txwrapper_polkadot_src_methods_crowdloan_index_.md
@@ -1,0 +1,107 @@
+[txwrapper-core](../README.md) / [Modules](../modules.md) / [txwrapper-polkadot/src](txwrapper_polkadot_src.md) / [<internal\>](txwrapper_polkadot_src._internal_.md) / "/Users/tarik/Desktop/parity/txwrapper-core/packages/txwrapper-polkadot/src/methods/crowdloan/index"
+
+# Namespace: "/Users/tarik/Desktop/parity/txwrapper-core/packages/txwrapper-polkadot/src/methods/crowdloan/index"
+
+[txwrapper-polkadot/src](txwrapper_polkadot_src.md).[<internal>](txwrapper_polkadot_src._internal_.md)."/Users/tarik/Desktop/parity/txwrapper-core/packages/txwrapper-polkadot/src/methods/crowdloan/index"
+
+## Table of contents
+
+### Interfaces
+
+- [CroadloanWithdrawArgs](../interfaces/txwrapper_polkadot_src._internal_.__Users_tarik_Desktop_parity_txwrapper_core_packages_txwrapper_polkadot_src_methods_crowdloan_index_.CroadloanWithdrawArgs.md)
+- [CrowdloanAddMemo](../interfaces/txwrapper_polkadot_src._internal_.__Users_tarik_Desktop_parity_txwrapper_core_packages_txwrapper_polkadot_src_methods_crowdloan_index_.CrowdloanAddMemo.md)
+- [CrowdloanContributeArgs](../interfaces/txwrapper_polkadot_src._internal_.__Users_tarik_Desktop_parity_txwrapper_core_packages_txwrapper_polkadot_src_methods_crowdloan_index_.CrowdloanContributeArgs.md)
+
+### Type aliases
+
+- [MultiSignature](txwrapper_polkadot_src._internal_.__Users_tarik_Desktop_parity_txwrapper_core_packages_txwrapper_polkadot_src_methods_crowdloan_index_.md#multisignature)
+
+### Functions
+
+- [addMemo](txwrapper_polkadot_src._internal_.__Users_tarik_Desktop_parity_txwrapper_core_packages_txwrapper_polkadot_src_methods_crowdloan_index_.md#addmemo)
+- [contribute](txwrapper_polkadot_src._internal_.__Users_tarik_Desktop_parity_txwrapper_core_packages_txwrapper_polkadot_src_methods_crowdloan_index_.md#contribute)
+- [withdraw](txwrapper_polkadot_src._internal_.__Users_tarik_Desktop_parity_txwrapper_core_packages_txwrapper_polkadot_src_methods_crowdloan_index_.md#withdraw)
+
+## Type aliases
+
+### MultiSignature
+
+Ƭ **MultiSignature**: `Object`
+
+#### Type declaration
+
+| Name | Type |
+| :------ | :------ |
+| `Ecdsa?` | `string` |
+| `Ed25519?` | `string` |
+| `Sr25519?` | `string` |
+
+#### Defined in
+
+[txwrapper-polkadot/src/methods/crowdloan/types.ts:1](https://github.com/paritytech/txwrapper-core/blob/9387f90/packages/txwrapper-polkadot/src/methods/crowdloan/types.ts#L1)
+
+## Functions
+
+### addMemo
+
+▸ **addMemo**(`args`, `info`, `options`): [`UnsignedTransaction`](../interfaces/txwrapper_core_src.UnsignedTransaction.md)
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `args` | [`CrowdloanAddMemo`](../interfaces/txwrapper_polkadot_src._internal_.__Users_tarik_Desktop_parity_txwrapper_core_packages_txwrapper_polkadot_src_methods_crowdloan_index_.CrowdloanAddMemo.md) |
+| `info` | [`BaseTxInfo`](../interfaces/txwrapper_core_src.BaseTxInfo.md) |
+| `options` | [`OptionsWithMeta`](../interfaces/txwrapper_core_src.OptionsWithMeta.md) |
+
+#### Returns
+
+[`UnsignedTransaction`](../interfaces/txwrapper_core_src.UnsignedTransaction.md)
+
+#### Defined in
+
+[txwrapper-polkadot/src/methods/crowdloan/addMemo.ts:14](https://github.com/paritytech/txwrapper-core/blob/9387f90/packages/txwrapper-polkadot/src/methods/crowdloan/addMemo.ts#L14)
+
+___
+
+### contribute
+
+▸ **contribute**(`args`, `info`, `options`): [`UnsignedTransaction`](../interfaces/txwrapper_core_src.UnsignedTransaction.md)
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `args` | [`CrowdloanContributeArgs`](../interfaces/txwrapper_polkadot_src._internal_.__Users_tarik_Desktop_parity_txwrapper_core_packages_txwrapper_polkadot_src_methods_crowdloan_index_.CrowdloanContributeArgs.md) |
+| `info` | [`BaseTxInfo`](../interfaces/txwrapper_core_src.BaseTxInfo.md) |
+| `options` | [`OptionsWithMeta`](../interfaces/txwrapper_core_src.OptionsWithMeta.md) |
+
+#### Returns
+
+[`UnsignedTransaction`](../interfaces/txwrapper_core_src.UnsignedTransaction.md)
+
+#### Defined in
+
+[txwrapper-polkadot/src/methods/crowdloan/contribute.ts:17](https://github.com/paritytech/txwrapper-core/blob/9387f90/packages/txwrapper-polkadot/src/methods/crowdloan/contribute.ts#L17)
+
+___
+
+### withdraw
+
+▸ **withdraw**(`args`, `info`, `options`): [`UnsignedTransaction`](../interfaces/txwrapper_core_src.UnsignedTransaction.md)
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `args` | [`CroadloanWithdrawArgs`](../interfaces/txwrapper_polkadot_src._internal_.__Users_tarik_Desktop_parity_txwrapper_core_packages_txwrapper_polkadot_src_methods_crowdloan_index_.CroadloanWithdrawArgs.md) |
+| `info` | [`BaseTxInfo`](../interfaces/txwrapper_core_src.BaseTxInfo.md) |
+| `options` | [`OptionsWithMeta`](../interfaces/txwrapper_core_src.OptionsWithMeta.md) |
+
+#### Returns
+
+[`UnsignedTransaction`](../interfaces/txwrapper_core_src.UnsignedTransaction.md)
+
+#### Defined in
+
+[txwrapper-polkadot/src/methods/crowdloan/withdraw.ts:14](https://github.com/paritytech/txwrapper-core/blob/9387f90/packages/txwrapper-polkadot/src/methods/crowdloan/withdraw.ts#L14)

--- a/docs/modules/txwrapper_polkadot_src._internal_.md
+++ b/docs/modules/txwrapper_polkadot_src._internal_.md
@@ -1,0 +1,11 @@
+[txwrapper-core](../README.md) / [Modules](../modules.md) / [txwrapper-polkadot/src](txwrapper_polkadot_src.md) / <internal\>
+
+# Namespace: <internal\>
+
+[txwrapper-polkadot/src](txwrapper_polkadot_src.md).<internal>
+
+## Table of contents
+
+### Namespaces
+
+- [&quot;/Users/tarik/Desktop/parity/txwrapper-core/packages/txwrapper-polkadot/src/methods/crowdloan/index&quot;](txwrapper_polkadot_src._internal_.__Users_tarik_Desktop_parity_txwrapper_core_packages_txwrapper_polkadot_src_methods_crowdloan_index_.md)

--- a/docs/modules/txwrapper_polkadot_src.md
+++ b/docs/modules/txwrapper_polkadot_src.md
@@ -29,6 +29,10 @@
 - [importPrivateKey](txwrapper_polkadot_src.md#importprivatekey)
 - [toTxMethod](txwrapper_polkadot_src.md#totxmethod)
 
+### Namespaces
+
+- [&lt;internal\&gt;](txwrapper_polkadot_src._internal_.md)
+
 ### Interfaces
 
 - [GetRegistryOpts](../interfaces/txwrapper_polkadot_src.GetRegistryOpts.md)
@@ -185,7 +189,7 @@ Re-exports [toTxMethod](txwrapper_core_src.md#totxmethod)
 | :------ | :------ |
 | `assets` | [`assets`](txwrapper_substrate_src.methods.assets.md) |
 | `balances` | [`balances`](txwrapper_substrate_src.methods.balances.md) |
-| `crowdloan` | `__module` |
+| `crowdloan` | [`"/Users/tarik/Desktop/parity/txwrapper-core/packages/txwrapper-polkadot/src/methods/crowdloan/index"`](txwrapper_polkadot_src._internal_.__Users_tarik_Desktop_parity_txwrapper_core_packages_txwrapper_polkadot_src_methods_crowdloan_index_.md) |
 | `democracy` | [`democracy`](txwrapper_substrate_src.methods.democracy.md) |
 | `multisig` | [`multisig`](txwrapper_substrate_src.methods.multisig.md) |
 | `proxy` | [`proxy`](txwrapper_substrate_src.methods.proxy.md) |
@@ -197,7 +201,7 @@ Re-exports [toTxMethod](txwrapper_core_src.md#totxmethod)
 
 #### Defined in
 
-[txwrapper-polkadot/src/index.ts:16](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-polkadot/src/index.ts#L16)
+[txwrapper-polkadot/src/index.ts:16](https://github.com/paritytech/txwrapper-core/blob/9387f90/packages/txwrapper-polkadot/src/index.ts#L16)
 
 ## Functions
 
@@ -219,4 +223,4 @@ Get a type registry for networks that txwrapper-polkadot supports.
 
 #### Defined in
 
-[txwrapper-polkadot/src/index.ts:81](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-polkadot/src/index.ts#L81)
+[txwrapper-polkadot/src/index.ts:81](https://github.com/paritytech/txwrapper-core/blob/9387f90/packages/txwrapper-polkadot/src/index.ts#L81)

--- a/docs/modules/txwrapper_polkadot_src.md
+++ b/docs/modules/txwrapper_polkadot_src.md
@@ -197,7 +197,7 @@ Re-exports [toTxMethod](txwrapper_core_src.md#totxmethod)
 
 #### Defined in
 
-[txwrapper-polkadot/src/index.ts:16](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-polkadot/src/index.ts#L16)
+[txwrapper-polkadot/src/index.ts:16](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-polkadot/src/index.ts#L16)
 
 ## Functions
 
@@ -219,4 +219,4 @@ Get a type registry for networks that txwrapper-polkadot supports.
 
 #### Defined in
 
-[txwrapper-polkadot/src/index.ts:81](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-polkadot/src/index.ts#L81)
+[txwrapper-polkadot/src/index.ts:81](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-polkadot/src/index.ts#L81)

--- a/docs/modules/txwrapper_polkadot_src.md
+++ b/docs/modules/txwrapper_polkadot_src.md
@@ -11,8 +11,10 @@
 - [ChainProperties](txwrapper_polkadot_src.md#chainproperties)
 - [DecodedSignedTx](txwrapper_polkadot_src.md#decodedsignedtx)
 - [DecodedSigningPayload](txwrapper_polkadot_src.md#decodedsigningpayload)
+- [DecodedUnsignedHexTx](txwrapper_polkadot_src.md#decodedunsignedhextx)
 - [DecodedUnsignedTx](txwrapper_polkadot_src.md#decodedunsignedtx)
 - [GetRegistryOptsCore](txwrapper_polkadot_src.md#getregistryoptscore)
+- [IMethod](txwrapper_polkadot_src.md#imethod)
 - [KeyringPair](txwrapper_polkadot_src.md#keyringpair)
 - [Options](txwrapper_polkadot_src.md#options)
 - [OptionsWithMeta](txwrapper_polkadot_src.md#optionswithmeta)
@@ -71,6 +73,12 @@ Re-exports [DecodedSigningPayload](txwrapper_core_src.md#decodedsigningpayload)
 
 ___
 
+### DecodedUnsignedHexTx
+
+Re-exports [DecodedUnsignedHexTx](../interfaces/txwrapper_core_src.DecodedUnsignedHexTx.md)
+
+___
+
 ### DecodedUnsignedTx
 
 Re-exports [DecodedUnsignedTx](txwrapper_core_src.md#decodedunsignedtx)
@@ -80,6 +88,12 @@ ___
 ### GetRegistryOptsCore
 
 Re-exports [GetRegistryOptsCore](../interfaces/txwrapper_core_src.GetRegistryOptsCore.md)
+
+___
+
+### IMethod
+
+Re-exports [IMethod](../interfaces/txwrapper_core_src.IMethod.md)
 
 ___
 
@@ -183,7 +197,7 @@ Re-exports [toTxMethod](txwrapper_core_src.md#totxmethod)
 
 #### Defined in
 
-[txwrapper-polkadot/src/index.ts:16](https://github.com/paritytech/txwrapper-core/blob/a0283d9/packages/txwrapper-polkadot/src/index.ts#L16)
+[txwrapper-polkadot/src/index.ts:16](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-polkadot/src/index.ts#L16)
 
 ## Functions
 
@@ -205,4 +219,4 @@ Get a type registry for networks that txwrapper-polkadot supports.
 
 #### Defined in
 
-[txwrapper-polkadot/src/index.ts:81](https://github.com/paritytech/txwrapper-core/blob/a0283d9/packages/txwrapper-polkadot/src/index.ts#L81)
+[txwrapper-polkadot/src/index.ts:81](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-polkadot/src/index.ts#L81)

--- a/docs/modules/txwrapper_substrate_src._internal_.md
+++ b/docs/modules/txwrapper_substrate_src._internal_.md
@@ -1,0 +1,78 @@
+[txwrapper-core](../README.md) / [Modules](../modules.md) / [txwrapper-substrate/src](txwrapper_substrate_src.md) / <internal\>
+
+# Namespace: <internal\>
+
+[txwrapper-substrate/src](txwrapper_substrate_src.md).<internal>
+
+## Table of contents
+
+### Interfaces
+
+- [ProxyAnnounceArgs](../interfaces/txwrapper_substrate_src._internal_.ProxyAnnounceArgs.md)
+- [ProxyAnonymousArgs](../interfaces/txwrapper_substrate_src._internal_.ProxyAnonymousArgs.md)
+- [ProxyKillAnonymousArgs](../interfaces/txwrapper_substrate_src._internal_.ProxyKillAnonymousArgs.md)
+
+### Type aliases
+
+- [AccountVote](txwrapper_substrate_src._internal_.md#accountvote)
+- [Timepoint](txwrapper_substrate_src._internal_.md#timepoint)
+- [Vote](txwrapper_substrate_src._internal_.md#vote)
+
+## Type aliases
+
+### AccountVote
+
+Ƭ **AccountVote**: { `Standard`: { `balance`: `number` ; `vote`: [`Vote`](txwrapper_substrate_src._internal_.md#vote)  }  } \| { `Split`: { `aye`: `number` ; `nay`: `number`  }  }
+
+A vote in a referendum. Can be one of:
+- Standard: A standard vote, one-way (approve or reject) with a given amount
+of conviction.
+- Split: A split vote with balances given for both ways, and with no
+conviction. This is useful for parachains, which vote on behalf of their
+participants and are free to choose their own way of splitting up the total
+balance. The stake behind a parachain can e.g. be split e.g. 2/3 aye and
+1/3 nay.
+
+#### Defined in
+
+[txwrapper-substrate/src/methods/democracy/types.ts:30](https://github.com/paritytech/txwrapper-core/blob/9387f90/packages/txwrapper-substrate/src/methods/democracy/types.ts#L30)
+
+___
+
+### Timepoint
+
+Ƭ **Timepoint**: `Object`
+
+A global extrinsic index, formed as the extrinsic index within a block, together with that
+block's height. This allows a transaction in which a multisig operation of a particular
+multisig account was created to be uniquely identified.
+
+#### Type declaration
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `height` | `number` \| `string` | The height of the chain at the point in time. |
+| `index` | `number` \| `string` | The index of the extrinsic in the block it was executed in. |
+
+#### Defined in
+
+[txwrapper-substrate/src/methods/multisig/types.ts:6](https://github.com/paritytech/txwrapper-core/blob/9387f90/packages/txwrapper-substrate/src/methods/multisig/types.ts#L6)
+
+___
+
+### Vote
+
+Ƭ **Vote**: `Object`
+
+A vote in a referendum
+
+#### Type declaration
+
+| Name | Type |
+| :------ | :------ |
+| `aye` | `boolean` |
+| `conviction` | `ArrayElementType`<typeof `AllConvictions`\> |
+
+#### Defined in
+
+[txwrapper-substrate/src/methods/democracy/types.ts:7](https://github.com/paritytech/txwrapper-core/blob/9387f90/packages/txwrapper-substrate/src/methods/democracy/types.ts#L7)

--- a/docs/modules/txwrapper_substrate_src.md
+++ b/docs/modules/txwrapper_substrate_src.md
@@ -6,4 +6,5 @@
 
 ### Namespaces
 
+- [&lt;internal\&gt;](txwrapper_substrate_src._internal_.md)
 - [methods](txwrapper_substrate_src.methods.md)

--- a/docs/modules/txwrapper_substrate_src.methods.assets.md
+++ b/docs/modules/txwrapper_substrate_src.methods.assets.md
@@ -47,7 +47,7 @@ making this call.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/assets/approveTransfer.ts:35](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-substrate/src/methods/assets/approveTransfer.ts#L35)
+[txwrapper-substrate/src/methods/assets/approveTransfer.ts:35](https://github.com/paritytech/txwrapper-core/blob/9387f90/packages/txwrapper-substrate/src/methods/assets/approveTransfer.ts#L35)
 
 ___
 
@@ -71,7 +71,7 @@ Cancel all of some asset approved for delegated transfer by a third-party accoun
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/assets/cancelApproval.ts:27](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-substrate/src/methods/assets/cancelApproval.ts#L27)
+[txwrapper-substrate/src/methods/assets/cancelApproval.ts:27](https://github.com/paritytech/txwrapper-core/blob/9387f90/packages/txwrapper-substrate/src/methods/assets/cancelApproval.ts#L27)
 
 ___
 
@@ -95,7 +95,7 @@ Move some assets from the sender account to another.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/assets/transfer.ts:34](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-substrate/src/methods/assets/transfer.ts#L34)
+[txwrapper-substrate/src/methods/assets/transfer.ts:34](https://github.com/paritytech/txwrapper-core/blob/9387f90/packages/txwrapper-substrate/src/methods/assets/transfer.ts#L34)
 
 ___
 
@@ -120,7 +120,7 @@ account.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/assets/transferApproved.ts:37](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-substrate/src/methods/assets/transferApproved.ts#L37)
+[txwrapper-substrate/src/methods/assets/transferApproved.ts:37](https://github.com/paritytech/txwrapper-core/blob/9387f90/packages/txwrapper-substrate/src/methods/assets/transferApproved.ts#L37)
 
 ___
 
@@ -144,4 +144,4 @@ Move some assets from the sender account to another, keeping the sender account 
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/assets/transferKeepAlive.ts:34](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-substrate/src/methods/assets/transferKeepAlive.ts#L34)
+[txwrapper-substrate/src/methods/assets/transferKeepAlive.ts:34](https://github.com/paritytech/txwrapper-core/blob/9387f90/packages/txwrapper-substrate/src/methods/assets/transferKeepAlive.ts#L34)

--- a/docs/modules/txwrapper_substrate_src.methods.assets.md
+++ b/docs/modules/txwrapper_substrate_src.methods.assets.md
@@ -47,7 +47,7 @@ making this call.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/assets/approveTransfer.ts:35](https://github.com/paritytech/txwrapper-core/blob/a0283d9/packages/txwrapper-substrate/src/methods/assets/approveTransfer.ts#L35)
+[txwrapper-substrate/src/methods/assets/approveTransfer.ts:35](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-substrate/src/methods/assets/approveTransfer.ts#L35)
 
 ___
 
@@ -71,7 +71,7 @@ Cancel all of some asset approved for delegated transfer by a third-party accoun
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/assets/cancelApproval.ts:27](https://github.com/paritytech/txwrapper-core/blob/a0283d9/packages/txwrapper-substrate/src/methods/assets/cancelApproval.ts#L27)
+[txwrapper-substrate/src/methods/assets/cancelApproval.ts:27](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-substrate/src/methods/assets/cancelApproval.ts#L27)
 
 ___
 
@@ -95,7 +95,7 @@ Move some assets from the sender account to another.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/assets/transfer.ts:34](https://github.com/paritytech/txwrapper-core/blob/a0283d9/packages/txwrapper-substrate/src/methods/assets/transfer.ts#L34)
+[txwrapper-substrate/src/methods/assets/transfer.ts:34](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-substrate/src/methods/assets/transfer.ts#L34)
 
 ___
 
@@ -120,7 +120,7 @@ account.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/assets/transferApproved.ts:37](https://github.com/paritytech/txwrapper-core/blob/a0283d9/packages/txwrapper-substrate/src/methods/assets/transferApproved.ts#L37)
+[txwrapper-substrate/src/methods/assets/transferApproved.ts:37](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-substrate/src/methods/assets/transferApproved.ts#L37)
 
 ___
 
@@ -144,4 +144,4 @@ Move some assets from the sender account to another, keeping the sender account 
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/assets/transferKeepAlive.ts:34](https://github.com/paritytech/txwrapper-core/blob/a0283d9/packages/txwrapper-substrate/src/methods/assets/transferKeepAlive.ts#L34)
+[txwrapper-substrate/src/methods/assets/transferKeepAlive.ts:34](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-substrate/src/methods/assets/transferKeepAlive.ts#L34)

--- a/docs/modules/txwrapper_substrate_src.methods.assets.md
+++ b/docs/modules/txwrapper_substrate_src.methods.assets.md
@@ -47,7 +47,7 @@ making this call.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/assets/approveTransfer.ts:35](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-substrate/src/methods/assets/approveTransfer.ts#L35)
+[txwrapper-substrate/src/methods/assets/approveTransfer.ts:35](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-substrate/src/methods/assets/approveTransfer.ts#L35)
 
 ___
 
@@ -71,7 +71,7 @@ Cancel all of some asset approved for delegated transfer by a third-party accoun
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/assets/cancelApproval.ts:27](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-substrate/src/methods/assets/cancelApproval.ts#L27)
+[txwrapper-substrate/src/methods/assets/cancelApproval.ts:27](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-substrate/src/methods/assets/cancelApproval.ts#L27)
 
 ___
 
@@ -95,7 +95,7 @@ Move some assets from the sender account to another.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/assets/transfer.ts:34](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-substrate/src/methods/assets/transfer.ts#L34)
+[txwrapper-substrate/src/methods/assets/transfer.ts:34](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-substrate/src/methods/assets/transfer.ts#L34)
 
 ___
 
@@ -120,7 +120,7 @@ account.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/assets/transferApproved.ts:37](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-substrate/src/methods/assets/transferApproved.ts#L37)
+[txwrapper-substrate/src/methods/assets/transferApproved.ts:37](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-substrate/src/methods/assets/transferApproved.ts#L37)
 
 ___
 
@@ -144,4 +144,4 @@ Move some assets from the sender account to another, keeping the sender account 
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/assets/transferKeepAlive.ts:34](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-substrate/src/methods/assets/transferKeepAlive.ts#L34)
+[txwrapper-substrate/src/methods/assets/transferKeepAlive.ts:34](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-substrate/src/methods/assets/transferKeepAlive.ts#L34)

--- a/docs/modules/txwrapper_substrate_src.methods.balances.md
+++ b/docs/modules/txwrapper_substrate_src.methods.balances.md
@@ -8,6 +8,7 @@
 
 ### Interfaces
 
+- [BalancesTransferAllArgs](../interfaces/txwrapper_substrate_src.methods.balances.BalancesTransferAllArgs.md)
 - [BalancesTransferArgs](../interfaces/txwrapper_substrate_src.methods.balances.BalancesTransferArgs.md)
 
 ### Type aliases
@@ -17,6 +18,7 @@
 ### Functions
 
 - [transfer](txwrapper_substrate_src.methods.balances.md#transfer)
+- [transferAll](txwrapper_substrate_src.methods.balances.md#transferall)
 - [transferKeepAlive](txwrapper_substrate_src.methods.balances.md#transferkeepalive)
 
 ## Type aliases
@@ -27,7 +29,7 @@
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/balances/transferKeepAlive.ts:10](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-substrate/src/methods/balances/transferKeepAlive.ts#L10)
+[txwrapper-substrate/src/methods/balances/transferKeepAlive.ts:10](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-substrate/src/methods/balances/transferKeepAlive.ts#L10)
 
 ## Functions
 
@@ -51,7 +53,37 @@ Construct a balance transfer transaction offline.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/balances/transfer.ts:27](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-substrate/src/methods/balances/transfer.ts#L27)
+[txwrapper-substrate/src/methods/balances/transfer.ts:27](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-substrate/src/methods/balances/transfer.ts#L27)
+
+___
+
+### transferAll
+
+▸ **transferAll**(`args`, `info`, `options`): [`UnsignedTransaction`](../interfaces/txwrapper_core_src.UnsignedTransaction.md)
+
+Transfer the entire transferable balance from the caller account.
+
+NOTE: This function only attempts to transfer _transferable_ balances. This means that
+any locked, reserved, or existential deposits (when `keep_alive` is `true`), will not be
+transferred by this function. To ensure that this function results in a killed account,
+you might need to prepare the account by removing any reference counters, storage
+deposits, etc...
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `args` | [`BalancesTransferAllArgs`](../interfaces/txwrapper_substrate_src.methods.balances.BalancesTransferAllArgs.md) | Arguments specific to this method. |
+| `info` | [`BaseTxInfo`](../interfaces/txwrapper_core_src.BaseTxInfo.md) | Information required to construct the transaction. |
+| `options` | [`OptionsWithMeta`](../interfaces/txwrapper_core_src.OptionsWithMeta.md) | Registry and metadata used for constructing the method. |
+
+#### Returns
+
+[`UnsignedTransaction`](../interfaces/txwrapper_core_src.UnsignedTransaction.md)
+
+#### Defined in
+
+[txwrapper-substrate/src/methods/balances/transferAll.ts:37](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-substrate/src/methods/balances/transferAll.ts#L37)
 
 ___
 
@@ -75,4 +107,4 @@ Construct a balance transfer transaction offline.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/balances/transferKeepAlive.ts:19](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-substrate/src/methods/balances/transferKeepAlive.ts#L19)
+[txwrapper-substrate/src/methods/balances/transferKeepAlive.ts:19](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-substrate/src/methods/balances/transferKeepAlive.ts#L19)

--- a/docs/modules/txwrapper_substrate_src.methods.balances.md
+++ b/docs/modules/txwrapper_substrate_src.methods.balances.md
@@ -29,7 +29,7 @@
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/balances/transferKeepAlive.ts:10](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-substrate/src/methods/balances/transferKeepAlive.ts#L10)
+[txwrapper-substrate/src/methods/balances/transferKeepAlive.ts:10](https://github.com/paritytech/txwrapper-core/blob/9387f90/packages/txwrapper-substrate/src/methods/balances/transferKeepAlive.ts#L10)
 
 ## Functions
 
@@ -53,7 +53,7 @@ Construct a balance transfer transaction offline.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/balances/transfer.ts:27](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-substrate/src/methods/balances/transfer.ts#L27)
+[txwrapper-substrate/src/methods/balances/transfer.ts:27](https://github.com/paritytech/txwrapper-core/blob/9387f90/packages/txwrapper-substrate/src/methods/balances/transfer.ts#L27)
 
 ___
 
@@ -83,7 +83,7 @@ deposits, etc...
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/balances/transferAll.ts:37](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-substrate/src/methods/balances/transferAll.ts#L37)
+[txwrapper-substrate/src/methods/balances/transferAll.ts:37](https://github.com/paritytech/txwrapper-core/blob/9387f90/packages/txwrapper-substrate/src/methods/balances/transferAll.ts#L37)
 
 ___
 
@@ -107,4 +107,4 @@ Construct a balance transfer transaction offline.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/balances/transferKeepAlive.ts:19](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-substrate/src/methods/balances/transferKeepAlive.ts#L19)
+[txwrapper-substrate/src/methods/balances/transferKeepAlive.ts:19](https://github.com/paritytech/txwrapper-core/blob/9387f90/packages/txwrapper-substrate/src/methods/balances/transferKeepAlive.ts#L19)

--- a/docs/modules/txwrapper_substrate_src.methods.balances.md
+++ b/docs/modules/txwrapper_substrate_src.methods.balances.md
@@ -27,7 +27,7 @@
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/balances/transferKeepAlive.ts:10](https://github.com/paritytech/txwrapper-core/blob/a0283d9/packages/txwrapper-substrate/src/methods/balances/transferKeepAlive.ts#L10)
+[txwrapper-substrate/src/methods/balances/transferKeepAlive.ts:10](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-substrate/src/methods/balances/transferKeepAlive.ts#L10)
 
 ## Functions
 
@@ -51,7 +51,7 @@ Construct a balance transfer transaction offline.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/balances/transfer.ts:27](https://github.com/paritytech/txwrapper-core/blob/a0283d9/packages/txwrapper-substrate/src/methods/balances/transfer.ts#L27)
+[txwrapper-substrate/src/methods/balances/transfer.ts:27](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-substrate/src/methods/balances/transfer.ts#L27)
 
 ___
 
@@ -75,4 +75,4 @@ Construct a balance transfer transaction offline.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/balances/transferKeepAlive.ts:19](https://github.com/paritytech/txwrapper-core/blob/a0283d9/packages/txwrapper-substrate/src/methods/balances/transferKeepAlive.ts#L19)
+[txwrapper-substrate/src/methods/balances/transferKeepAlive.ts:19](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-substrate/src/methods/balances/transferKeepAlive.ts#L19)

--- a/docs/modules/txwrapper_substrate_src.methods.democracy.md
+++ b/docs/modules/txwrapper_substrate_src.methods.democracy.md
@@ -36,4 +36,4 @@ Vote in a referendum.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/democracy/vote.ts:29](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-substrate/src/methods/democracy/vote.ts#L29)
+[txwrapper-substrate/src/methods/democracy/vote.ts:29](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-substrate/src/methods/democracy/vote.ts#L29)

--- a/docs/modules/txwrapper_substrate_src.methods.democracy.md
+++ b/docs/modules/txwrapper_substrate_src.methods.democracy.md
@@ -36,4 +36,4 @@ Vote in a referendum.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/democracy/vote.ts:29](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-substrate/src/methods/democracy/vote.ts#L29)
+[txwrapper-substrate/src/methods/democracy/vote.ts:29](https://github.com/paritytech/txwrapper-core/blob/9387f90/packages/txwrapper-substrate/src/methods/democracy/vote.ts#L29)

--- a/docs/modules/txwrapper_substrate_src.methods.democracy.md
+++ b/docs/modules/txwrapper_substrate_src.methods.democracy.md
@@ -36,4 +36,4 @@ Vote in a referendum.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/democracy/vote.ts:29](https://github.com/paritytech/txwrapper-core/blob/a0283d9/packages/txwrapper-substrate/src/methods/democracy/vote.ts#L29)
+[txwrapper-substrate/src/methods/democracy/vote.ts:29](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-substrate/src/methods/democracy/vote.ts#L29)

--- a/docs/modules/txwrapper_substrate_src.methods.multisig.md
+++ b/docs/modules/txwrapper_substrate_src.methods.multisig.md
@@ -47,7 +47,7 @@ NOTE: If this is the final approval, you must use `as_multi` instead.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/multisig/approveAsMulti.ts:51](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-substrate/src/methods/multisig/approveAsMulti.ts#L51)
+[txwrapper-substrate/src/methods/multisig/approveAsMulti.ts:51](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-substrate/src/methods/multisig/approveAsMulti.ts#L51)
 
 ___
 
@@ -85,7 +85,7 @@ may be found in the deposited `MultisigExecuted` event.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/multisig/asMulti.ts:46](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-substrate/src/methods/multisig/asMulti.ts#L46)
+[txwrapper-substrate/src/methods/multisig/asMulti.ts:46](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-substrate/src/methods/multisig/asMulti.ts#L46)
 
 ___
 
@@ -110,4 +110,4 @@ for this operation will be unreserved on success.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/multisig/cancelAsMulti.ts:32](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-substrate/src/methods/multisig/cancelAsMulti.ts#L32)
+[txwrapper-substrate/src/methods/multisig/cancelAsMulti.ts:32](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-substrate/src/methods/multisig/cancelAsMulti.ts#L32)

--- a/docs/modules/txwrapper_substrate_src.methods.multisig.md
+++ b/docs/modules/txwrapper_substrate_src.methods.multisig.md
@@ -47,7 +47,7 @@ NOTE: If this is the final approval, you must use `as_multi` instead.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/multisig/approveAsMulti.ts:51](https://github.com/paritytech/txwrapper-core/blob/a0283d9/packages/txwrapper-substrate/src/methods/multisig/approveAsMulti.ts#L51)
+[txwrapper-substrate/src/methods/multisig/approveAsMulti.ts:51](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-substrate/src/methods/multisig/approveAsMulti.ts#L51)
 
 ___
 
@@ -85,7 +85,7 @@ may be found in the deposited `MultisigExecuted` event.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/multisig/asMulti.ts:46](https://github.com/paritytech/txwrapper-core/blob/a0283d9/packages/txwrapper-substrate/src/methods/multisig/asMulti.ts#L46)
+[txwrapper-substrate/src/methods/multisig/asMulti.ts:46](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-substrate/src/methods/multisig/asMulti.ts#L46)
 
 ___
 
@@ -110,4 +110,4 @@ for this operation will be unreserved on success.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/multisig/cancelAsMulti.ts:32](https://github.com/paritytech/txwrapper-core/blob/a0283d9/packages/txwrapper-substrate/src/methods/multisig/cancelAsMulti.ts#L32)
+[txwrapper-substrate/src/methods/multisig/cancelAsMulti.ts:32](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-substrate/src/methods/multisig/cancelAsMulti.ts#L32)

--- a/docs/modules/txwrapper_substrate_src.methods.multisig.md
+++ b/docs/modules/txwrapper_substrate_src.methods.multisig.md
@@ -47,7 +47,7 @@ NOTE: If this is the final approval, you must use `as_multi` instead.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/multisig/approveAsMulti.ts:51](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-substrate/src/methods/multisig/approveAsMulti.ts#L51)
+[txwrapper-substrate/src/methods/multisig/approveAsMulti.ts:51](https://github.com/paritytech/txwrapper-core/blob/9387f90/packages/txwrapper-substrate/src/methods/multisig/approveAsMulti.ts#L51)
 
 ___
 
@@ -85,7 +85,7 @@ may be found in the deposited `MultisigExecuted` event.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/multisig/asMulti.ts:46](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-substrate/src/methods/multisig/asMulti.ts#L46)
+[txwrapper-substrate/src/methods/multisig/asMulti.ts:46](https://github.com/paritytech/txwrapper-core/blob/9387f90/packages/txwrapper-substrate/src/methods/multisig/asMulti.ts#L46)
 
 ___
 
@@ -110,4 +110,4 @@ for this operation will be unreserved on success.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/multisig/cancelAsMulti.ts:32](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-substrate/src/methods/multisig/cancelAsMulti.ts#L32)
+[txwrapper-substrate/src/methods/multisig/cancelAsMulti.ts:32](https://github.com/paritytech/txwrapper-core/blob/9387f90/packages/txwrapper-substrate/src/methods/multisig/cancelAsMulti.ts#L32)

--- a/docs/modules/txwrapper_substrate_src.methods.proxy.md
+++ b/docs/modules/txwrapper_substrate_src.methods.proxy.md
@@ -18,6 +18,7 @@
 - [addProxy](txwrapper_substrate_src.methods.proxy.md#addproxy)
 - [announce](txwrapper_substrate_src.methods.proxy.md#announce)
 - [anonymous](txwrapper_substrate_src.methods.proxy.md#anonymous)
+- [killAnonymous](txwrapper_substrate_src.methods.proxy.md#killanonymous)
 - [proxy](txwrapper_substrate_src.methods.proxy.md#proxy)
 - [proxyAnnounced](txwrapper_substrate_src.methods.proxy.md#proxyannounced)
 - [rejectAnnouncement](txwrapper_substrate_src.methods.proxy.md#rejectannouncement)
@@ -46,7 +47,7 @@ Register a proxy account for the sender that is able to make calls on its behalf
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/proxy/addProxy.ts:32](https://github.com/paritytech/txwrapper-core/blob/a0283d9/packages/txwrapper-substrate/src/methods/proxy/addProxy.ts#L32)
+[txwrapper-substrate/src/methods/proxy/addProxy.ts:32](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-substrate/src/methods/proxy/addProxy.ts#L32)
 
 ___
 
@@ -83,7 +84,7 @@ The dispatch origin for this call must be _Signed_ and a proxy of `real`.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/proxy/announce.ts:40](https://github.com/paritytech/txwrapper-core/blob/a0283d9/packages/txwrapper-substrate/src/methods/proxy/announce.ts#L40)
+[txwrapper-substrate/src/methods/proxy/announce.ts:40](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-substrate/src/methods/proxy/announce.ts#L40)
 
 ___
 
@@ -115,7 +116,40 @@ Fails if there are insufficient funds to pay for deposit.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/proxy/anonymous.ts:44](https://github.com/paritytech/txwrapper-core/blob/a0283d9/packages/txwrapper-substrate/src/methods/proxy/anonymous.ts#L44)
+[txwrapper-substrate/src/methods/proxy/anonymous.ts:44](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-substrate/src/methods/proxy/anonymous.ts#L44)
+
+___
+
+### killAnonymous
+
+▸ **killAnonymous**(`args`, `info`, `options`): [`UnsignedTransaction`](../interfaces/txwrapper_core_src.UnsignedTransaction.md)
+
+Removes a previously spawned anonymous proxy.
+
+WARNING: **All access to this account will be lost.** Any funds held in it will be
+inaccessible.
+
+Requires a `Signed` origin, and the sender account must have been created by a call to
+`anonymous` with corresponding parameters.
+
+Fails with `NoPermission` in case the caller is not a previously created anonymous
+account whose `anonymous` call has corresponding parameters.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `args` | `ProxyKillAnonymousArgs` | Arguments specific to this method. |
+| `info` | [`BaseTxInfo`](../interfaces/txwrapper_core_src.BaseTxInfo.md) | Information required to construct the transaction. |
+| `options` | [`OptionsWithMeta`](../interfaces/txwrapper_core_src.OptionsWithMeta.md) | Registry and metadata used for constructing the method. |
+
+#### Returns
+
+[`UnsignedTransaction`](../interfaces/txwrapper_core_src.UnsignedTransaction.md)
+
+#### Defined in
+
+[txwrapper-substrate/src/methods/proxy/killAnonymous.ts:49](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-substrate/src/methods/proxy/killAnonymous.ts#L49)
 
 ___
 
@@ -139,7 +173,7 @@ Dispatch the given `call` from an account for which the sender is authorized.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/proxy/proxy.ts:33](https://github.com/paritytech/txwrapper-core/blob/a0283d9/packages/txwrapper-substrate/src/methods/proxy/proxy.ts#L33)
+[txwrapper-substrate/src/methods/proxy/proxy.ts:33](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-substrate/src/methods/proxy/proxy.ts#L33)
 
 ___
 
@@ -168,7 +202,7 @@ The dispatch origin for this call must be _Signed_.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/proxy/proxyAnnounced.ts:41](https://github.com/paritytech/txwrapper-core/blob/a0283d9/packages/txwrapper-substrate/src/methods/proxy/proxyAnnounced.ts#L41)
+[txwrapper-substrate/src/methods/proxy/proxyAnnounced.ts:41](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-substrate/src/methods/proxy/proxyAnnounced.ts#L41)
 
 ___
 
@@ -192,7 +226,7 @@ Remove the given announcement of a delegate and return the deposit. Made by the 
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/proxy/rejectAnnouncement.ts:27](https://github.com/paritytech/txwrapper-core/blob/a0283d9/packages/txwrapper-substrate/src/methods/proxy/rejectAnnouncement.ts#L27)
+[txwrapper-substrate/src/methods/proxy/rejectAnnouncement.ts:27](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-substrate/src/methods/proxy/rejectAnnouncement.ts#L27)
 
 ___
 
@@ -216,7 +250,7 @@ Unregister all proxy accounts for the sender.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/proxy/removeProxies.ts:15](https://github.com/paritytech/txwrapper-core/blob/a0283d9/packages/txwrapper-substrate/src/methods/proxy/removeProxies.ts#L15)
+[txwrapper-substrate/src/methods/proxy/removeProxies.ts:15](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-substrate/src/methods/proxy/removeProxies.ts#L15)
 
 ___
 
@@ -240,4 +274,4 @@ Unregister a proxy account for the sender.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/proxy/removeProxy.ts:17](https://github.com/paritytech/txwrapper-core/blob/a0283d9/packages/txwrapper-substrate/src/methods/proxy/removeProxy.ts#L17)
+[txwrapper-substrate/src/methods/proxy/removeProxy.ts:17](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-substrate/src/methods/proxy/removeProxy.ts#L17)

--- a/docs/modules/txwrapper_substrate_src.methods.proxy.md
+++ b/docs/modules/txwrapper_substrate_src.methods.proxy.md
@@ -47,7 +47,7 @@ Register a proxy account for the sender that is able to make calls on its behalf
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/proxy/addProxy.ts:32](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-substrate/src/methods/proxy/addProxy.ts#L32)
+[txwrapper-substrate/src/methods/proxy/addProxy.ts:32](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-substrate/src/methods/proxy/addProxy.ts#L32)
 
 ___
 
@@ -84,7 +84,7 @@ The dispatch origin for this call must be _Signed_ and a proxy of `real`.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/proxy/announce.ts:40](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-substrate/src/methods/proxy/announce.ts#L40)
+[txwrapper-substrate/src/methods/proxy/announce.ts:40](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-substrate/src/methods/proxy/announce.ts#L40)
 
 ___
 
@@ -116,7 +116,7 @@ Fails if there are insufficient funds to pay for deposit.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/proxy/anonymous.ts:44](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-substrate/src/methods/proxy/anonymous.ts#L44)
+[txwrapper-substrate/src/methods/proxy/anonymous.ts:44](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-substrate/src/methods/proxy/anonymous.ts#L44)
 
 ___
 
@@ -149,7 +149,7 @@ account whose `anonymous` call has corresponding parameters.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/proxy/killAnonymous.ts:49](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-substrate/src/methods/proxy/killAnonymous.ts#L49)
+[txwrapper-substrate/src/methods/proxy/killAnonymous.ts:49](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-substrate/src/methods/proxy/killAnonymous.ts#L49)
 
 ___
 
@@ -173,7 +173,7 @@ Dispatch the given `call` from an account for which the sender is authorized.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/proxy/proxy.ts:33](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-substrate/src/methods/proxy/proxy.ts#L33)
+[txwrapper-substrate/src/methods/proxy/proxy.ts:33](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-substrate/src/methods/proxy/proxy.ts#L33)
 
 ___
 
@@ -202,7 +202,7 @@ The dispatch origin for this call must be _Signed_.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/proxy/proxyAnnounced.ts:41](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-substrate/src/methods/proxy/proxyAnnounced.ts#L41)
+[txwrapper-substrate/src/methods/proxy/proxyAnnounced.ts:41](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-substrate/src/methods/proxy/proxyAnnounced.ts#L41)
 
 ___
 
@@ -226,7 +226,7 @@ Remove the given announcement of a delegate and return the deposit. Made by the 
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/proxy/rejectAnnouncement.ts:27](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-substrate/src/methods/proxy/rejectAnnouncement.ts#L27)
+[txwrapper-substrate/src/methods/proxy/rejectAnnouncement.ts:27](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-substrate/src/methods/proxy/rejectAnnouncement.ts#L27)
 
 ___
 
@@ -250,7 +250,7 @@ Unregister all proxy accounts for the sender.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/proxy/removeProxies.ts:15](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-substrate/src/methods/proxy/removeProxies.ts#L15)
+[txwrapper-substrate/src/methods/proxy/removeProxies.ts:15](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-substrate/src/methods/proxy/removeProxies.ts#L15)
 
 ___
 
@@ -274,4 +274,4 @@ Unregister a proxy account for the sender.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/proxy/removeProxy.ts:17](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-substrate/src/methods/proxy/removeProxy.ts#L17)
+[txwrapper-substrate/src/methods/proxy/removeProxy.ts:17](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-substrate/src/methods/proxy/removeProxy.ts#L17)

--- a/docs/modules/txwrapper_substrate_src.methods.proxy.md
+++ b/docs/modules/txwrapper_substrate_src.methods.proxy.md
@@ -47,7 +47,7 @@ Register a proxy account for the sender that is able to make calls on its behalf
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/proxy/addProxy.ts:32](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-substrate/src/methods/proxy/addProxy.ts#L32)
+[txwrapper-substrate/src/methods/proxy/addProxy.ts:32](https://github.com/paritytech/txwrapper-core/blob/9387f90/packages/txwrapper-substrate/src/methods/proxy/addProxy.ts#L32)
 
 ___
 
@@ -74,7 +74,7 @@ The dispatch origin for this call must be _Signed_ and a proxy of `real`.
 
 | Name | Type | Description |
 | :------ | :------ | :------ |
-| `args` | `ProxyAnnounceArgs` | Arguments specific to this method. |
+| `args` | [`ProxyAnnounceArgs`](../interfaces/txwrapper_substrate_src._internal_.ProxyAnnounceArgs.md) | Arguments specific to this method. |
 | `info` | [`BaseTxInfo`](../interfaces/txwrapper_core_src.BaseTxInfo.md) | Information required to construct the transaction. |
 | `options` | [`OptionsWithMeta`](../interfaces/txwrapper_core_src.OptionsWithMeta.md) | Registry and metadata used for constructing the method. |
 
@@ -84,7 +84,7 @@ The dispatch origin for this call must be _Signed_ and a proxy of `real`.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/proxy/announce.ts:40](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-substrate/src/methods/proxy/announce.ts#L40)
+[txwrapper-substrate/src/methods/proxy/announce.ts:40](https://github.com/paritytech/txwrapper-core/blob/9387f90/packages/txwrapper-substrate/src/methods/proxy/announce.ts#L40)
 
 ___
 
@@ -106,7 +106,7 @@ Fails if there are insufficient funds to pay for deposit.
 
 | Name | Type | Description |
 | :------ | :------ | :------ |
-| `args` | `ProxyAnonymousArgs` | Arguments specific to this method. |
+| `args` | [`ProxyAnonymousArgs`](../interfaces/txwrapper_substrate_src._internal_.ProxyAnonymousArgs.md) | Arguments specific to this method. |
 | `info` | [`BaseTxInfo`](../interfaces/txwrapper_core_src.BaseTxInfo.md) | Information required to construct the transaction. |
 | `options` | [`OptionsWithMeta`](../interfaces/txwrapper_core_src.OptionsWithMeta.md) | Registry and metadata used for constructing the method. |
 
@@ -116,7 +116,7 @@ Fails if there are insufficient funds to pay for deposit.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/proxy/anonymous.ts:44](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-substrate/src/methods/proxy/anonymous.ts#L44)
+[txwrapper-substrate/src/methods/proxy/anonymous.ts:44](https://github.com/paritytech/txwrapper-core/blob/9387f90/packages/txwrapper-substrate/src/methods/proxy/anonymous.ts#L44)
 
 ___
 
@@ -139,7 +139,7 @@ account whose `anonymous` call has corresponding parameters.
 
 | Name | Type | Description |
 | :------ | :------ | :------ |
-| `args` | `ProxyKillAnonymousArgs` | Arguments specific to this method. |
+| `args` | [`ProxyKillAnonymousArgs`](../interfaces/txwrapper_substrate_src._internal_.ProxyKillAnonymousArgs.md) | Arguments specific to this method. |
 | `info` | [`BaseTxInfo`](../interfaces/txwrapper_core_src.BaseTxInfo.md) | Information required to construct the transaction. |
 | `options` | [`OptionsWithMeta`](../interfaces/txwrapper_core_src.OptionsWithMeta.md) | Registry and metadata used for constructing the method. |
 
@@ -149,7 +149,7 @@ account whose `anonymous` call has corresponding parameters.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/proxy/killAnonymous.ts:49](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-substrate/src/methods/proxy/killAnonymous.ts#L49)
+[txwrapper-substrate/src/methods/proxy/killAnonymous.ts:49](https://github.com/paritytech/txwrapper-core/blob/9387f90/packages/txwrapper-substrate/src/methods/proxy/killAnonymous.ts#L49)
 
 ___
 
@@ -173,7 +173,7 @@ Dispatch the given `call` from an account for which the sender is authorized.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/proxy/proxy.ts:33](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-substrate/src/methods/proxy/proxy.ts#L33)
+[txwrapper-substrate/src/methods/proxy/proxy.ts:33](https://github.com/paritytech/txwrapper-core/blob/9387f90/packages/txwrapper-substrate/src/methods/proxy/proxy.ts#L33)
 
 ___
 
@@ -202,7 +202,7 @@ The dispatch origin for this call must be _Signed_.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/proxy/proxyAnnounced.ts:41](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-substrate/src/methods/proxy/proxyAnnounced.ts#L41)
+[txwrapper-substrate/src/methods/proxy/proxyAnnounced.ts:41](https://github.com/paritytech/txwrapper-core/blob/9387f90/packages/txwrapper-substrate/src/methods/proxy/proxyAnnounced.ts#L41)
 
 ___
 
@@ -226,7 +226,7 @@ Remove the given announcement of a delegate and return the deposit. Made by the 
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/proxy/rejectAnnouncement.ts:27](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-substrate/src/methods/proxy/rejectAnnouncement.ts#L27)
+[txwrapper-substrate/src/methods/proxy/rejectAnnouncement.ts:27](https://github.com/paritytech/txwrapper-core/blob/9387f90/packages/txwrapper-substrate/src/methods/proxy/rejectAnnouncement.ts#L27)
 
 ___
 
@@ -250,7 +250,7 @@ Unregister all proxy accounts for the sender.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/proxy/removeProxies.ts:15](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-substrate/src/methods/proxy/removeProxies.ts#L15)
+[txwrapper-substrate/src/methods/proxy/removeProxies.ts:15](https://github.com/paritytech/txwrapper-core/blob/9387f90/packages/txwrapper-substrate/src/methods/proxy/removeProxies.ts#L15)
 
 ___
 
@@ -274,4 +274,4 @@ Unregister a proxy account for the sender.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/proxy/removeProxy.ts:17](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-substrate/src/methods/proxy/removeProxy.ts#L17)
+[txwrapper-substrate/src/methods/proxy/removeProxy.ts:17](https://github.com/paritytech/txwrapper-core/blob/9387f90/packages/txwrapper-substrate/src/methods/proxy/removeProxy.ts#L17)

--- a/docs/modules/txwrapper_substrate_src.methods.session.md
+++ b/docs/modules/txwrapper_substrate_src.methods.session.md
@@ -36,4 +36,4 @@ Sets the session key(s) of the function caller to `key`.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/session/setKeys.ts:27](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-substrate/src/methods/session/setKeys.ts#L27)
+[txwrapper-substrate/src/methods/session/setKeys.ts:27](https://github.com/paritytech/txwrapper-core/blob/9387f90/packages/txwrapper-substrate/src/methods/session/setKeys.ts#L27)

--- a/docs/modules/txwrapper_substrate_src.methods.session.md
+++ b/docs/modules/txwrapper_substrate_src.methods.session.md
@@ -36,4 +36,4 @@ Sets the session key(s) of the function caller to `key`.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/session/setKeys.ts:27](https://github.com/paritytech/txwrapper-core/blob/a0283d9/packages/txwrapper-substrate/src/methods/session/setKeys.ts#L27)
+[txwrapper-substrate/src/methods/session/setKeys.ts:27](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-substrate/src/methods/session/setKeys.ts#L27)

--- a/docs/modules/txwrapper_substrate_src.methods.session.md
+++ b/docs/modules/txwrapper_substrate_src.methods.session.md
@@ -36,4 +36,4 @@ Sets the session key(s) of the function caller to `key`.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/session/setKeys.ts:27](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-substrate/src/methods/session/setKeys.ts#L27)
+[txwrapper-substrate/src/methods/session/setKeys.ts:27](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-substrate/src/methods/session/setKeys.ts#L27)

--- a/docs/modules/txwrapper_substrate_src.methods.staking.md
+++ b/docs/modules/txwrapper_substrate_src.methods.staking.md
@@ -55,7 +55,7 @@ Construct a transaction to bond funds and create a Stash account.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/staking/bond.ts:28](https://github.com/paritytech/txwrapper-core/blob/a0283d9/packages/txwrapper-substrate/src/methods/staking/bond.ts#L28)
+[txwrapper-substrate/src/methods/staking/bond.ts:28](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-substrate/src/methods/staking/bond.ts#L28)
 
 ___
 
@@ -82,7 +82,7 @@ Can only be called when `EraElectionStatus` is `Closed`.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/staking/bondExtra.ts:26](https://github.com/paritytech/txwrapper-core/blob/a0283d9/packages/txwrapper-substrate/src/methods/staking/bondExtra.ts#L26)
+[txwrapper-substrate/src/methods/staking/bondExtra.ts:26](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-substrate/src/methods/staking/bondExtra.ts#L26)
 
 ___
 
@@ -108,7 +108,7 @@ Can only be called when `EraElectionStatus` is `Closed`.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/staking/chill.ts:17](https://github.com/paritytech/txwrapper-core/blob/a0283d9/packages/txwrapper-substrate/src/methods/staking/chill.ts#L17)
+[txwrapper-substrate/src/methods/staking/chill.ts:17](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-substrate/src/methods/staking/chill.ts#L17)
 
 ___
 
@@ -134,7 +134,7 @@ Can only be called when `EraElectionStatus` is `Closed`.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/staking/nominate.ts:28](https://github.com/paritytech/txwrapper-core/blob/a0283d9/packages/txwrapper-substrate/src/methods/staking/nominate.ts#L28)
+[txwrapper-substrate/src/methods/staking/nominate.ts:28](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-substrate/src/methods/staking/nominate.ts#L28)
 
 ___
 
@@ -162,7 +162,7 @@ Can only be called when `EraElectionStatus` is `Closed`.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/staking/payoutStakers.ts:34](https://github.com/paritytech/txwrapper-core/blob/a0283d9/packages/txwrapper-substrate/src/methods/staking/payoutStakers.ts#L34)
+[txwrapper-substrate/src/methods/staking/payoutStakers.ts:34](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-substrate/src/methods/staking/payoutStakers.ts#L34)
 
 ___
 
@@ -189,7 +189,7 @@ The dispatch origin must be signed by the controller, and it can be only called 
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/staking/rebond.ts:23](https://github.com/paritytech/txwrapper-core/blob/a0283d9/packages/txwrapper-substrate/src/methods/staking/rebond.ts#L23)
+[txwrapper-substrate/src/methods/staking/rebond.ts:23](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-substrate/src/methods/staking/rebond.ts#L23)
 
 ___
 
@@ -213,7 +213,7 @@ ___
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/staking/setController.ts:23](https://github.com/paritytech/txwrapper-core/blob/a0283d9/packages/txwrapper-substrate/src/methods/staking/setController.ts#L23)
+[txwrapper-substrate/src/methods/staking/setController.ts:23](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-substrate/src/methods/staking/setController.ts#L23)
 
 ___
 
@@ -241,7 +241,7 @@ Comes into effect at the beginning of the next era.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/staking/setPayee.ts:27](https://github.com/paritytech/txwrapper-core/blob/a0283d9/packages/txwrapper-substrate/src/methods/staking/setPayee.ts#L27)
+[txwrapper-substrate/src/methods/staking/setPayee.ts:27](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-substrate/src/methods/staking/setPayee.ts#L27)
 
 ___
 
@@ -268,7 +268,7 @@ Can only be called when `EraElectionStatus` is `Closed`.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/staking/unbond.ts:26](https://github.com/paritytech/txwrapper-core/blob/a0283d9/packages/txwrapper-substrate/src/methods/staking/unbond.ts#L26)
+[txwrapper-substrate/src/methods/staking/unbond.ts:26](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-substrate/src/methods/staking/unbond.ts#L26)
 
 ___
 
@@ -294,7 +294,7 @@ Can only be called when `EraElectionStatus` is `Closed`.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/staking/validate.ts:27](https://github.com/paritytech/txwrapper-core/blob/a0283d9/packages/txwrapper-substrate/src/methods/staking/validate.ts#L27)
+[txwrapper-substrate/src/methods/staking/validate.ts:27](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-substrate/src/methods/staking/validate.ts#L27)
 
 ___
 
@@ -324,4 +324,4 @@ Can only be called when `EraElectionStatus` is `Closed`.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/staking/withdrawUnbonded.ts:26](https://github.com/paritytech/txwrapper-core/blob/a0283d9/packages/txwrapper-substrate/src/methods/staking/withdrawUnbonded.ts#L26)
+[txwrapper-substrate/src/methods/staking/withdrawUnbonded.ts:26](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-substrate/src/methods/staking/withdrawUnbonded.ts#L26)

--- a/docs/modules/txwrapper_substrate_src.methods.staking.md
+++ b/docs/modules/txwrapper_substrate_src.methods.staking.md
@@ -55,7 +55,7 @@ Construct a transaction to bond funds and create a Stash account.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/staking/bond.ts:28](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-substrate/src/methods/staking/bond.ts#L28)
+[txwrapper-substrate/src/methods/staking/bond.ts:28](https://github.com/paritytech/txwrapper-core/blob/9387f90/packages/txwrapper-substrate/src/methods/staking/bond.ts#L28)
 
 ___
 
@@ -82,7 +82,7 @@ Can only be called when `EraElectionStatus` is `Closed`.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/staking/bondExtra.ts:26](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-substrate/src/methods/staking/bondExtra.ts#L26)
+[txwrapper-substrate/src/methods/staking/bondExtra.ts:26](https://github.com/paritytech/txwrapper-core/blob/9387f90/packages/txwrapper-substrate/src/methods/staking/bondExtra.ts#L26)
 
 ___
 
@@ -108,7 +108,7 @@ Can only be called when `EraElectionStatus` is `Closed`.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/staking/chill.ts:17](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-substrate/src/methods/staking/chill.ts#L17)
+[txwrapper-substrate/src/methods/staking/chill.ts:17](https://github.com/paritytech/txwrapper-core/blob/9387f90/packages/txwrapper-substrate/src/methods/staking/chill.ts#L17)
 
 ___
 
@@ -134,7 +134,7 @@ Can only be called when `EraElectionStatus` is `Closed`.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/staking/nominate.ts:28](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-substrate/src/methods/staking/nominate.ts#L28)
+[txwrapper-substrate/src/methods/staking/nominate.ts:28](https://github.com/paritytech/txwrapper-core/blob/9387f90/packages/txwrapper-substrate/src/methods/staking/nominate.ts#L28)
 
 ___
 
@@ -162,7 +162,7 @@ Can only be called when `EraElectionStatus` is `Closed`.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/staking/payoutStakers.ts:34](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-substrate/src/methods/staking/payoutStakers.ts#L34)
+[txwrapper-substrate/src/methods/staking/payoutStakers.ts:34](https://github.com/paritytech/txwrapper-core/blob/9387f90/packages/txwrapper-substrate/src/methods/staking/payoutStakers.ts#L34)
 
 ___
 
@@ -189,7 +189,7 @@ The dispatch origin must be signed by the controller, and it can be only called 
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/staking/rebond.ts:23](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-substrate/src/methods/staking/rebond.ts#L23)
+[txwrapper-substrate/src/methods/staking/rebond.ts:23](https://github.com/paritytech/txwrapper-core/blob/9387f90/packages/txwrapper-substrate/src/methods/staking/rebond.ts#L23)
 
 ___
 
@@ -213,7 +213,7 @@ ___
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/staking/setController.ts:23](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-substrate/src/methods/staking/setController.ts#L23)
+[txwrapper-substrate/src/methods/staking/setController.ts:23](https://github.com/paritytech/txwrapper-core/blob/9387f90/packages/txwrapper-substrate/src/methods/staking/setController.ts#L23)
 
 ___
 
@@ -241,7 +241,7 @@ Comes into effect at the beginning of the next era.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/staking/setPayee.ts:27](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-substrate/src/methods/staking/setPayee.ts#L27)
+[txwrapper-substrate/src/methods/staking/setPayee.ts:27](https://github.com/paritytech/txwrapper-core/blob/9387f90/packages/txwrapper-substrate/src/methods/staking/setPayee.ts#L27)
 
 ___
 
@@ -268,7 +268,7 @@ Can only be called when `EraElectionStatus` is `Closed`.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/staking/unbond.ts:26](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-substrate/src/methods/staking/unbond.ts#L26)
+[txwrapper-substrate/src/methods/staking/unbond.ts:26](https://github.com/paritytech/txwrapper-core/blob/9387f90/packages/txwrapper-substrate/src/methods/staking/unbond.ts#L26)
 
 ___
 
@@ -294,7 +294,7 @@ Can only be called when `EraElectionStatus` is `Closed`.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/staking/validate.ts:27](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-substrate/src/methods/staking/validate.ts#L27)
+[txwrapper-substrate/src/methods/staking/validate.ts:27](https://github.com/paritytech/txwrapper-core/blob/9387f90/packages/txwrapper-substrate/src/methods/staking/validate.ts#L27)
 
 ___
 
@@ -324,4 +324,4 @@ Can only be called when `EraElectionStatus` is `Closed`.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/staking/withdrawUnbonded.ts:26](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-substrate/src/methods/staking/withdrawUnbonded.ts#L26)
+[txwrapper-substrate/src/methods/staking/withdrawUnbonded.ts:26](https://github.com/paritytech/txwrapper-core/blob/9387f90/packages/txwrapper-substrate/src/methods/staking/withdrawUnbonded.ts#L26)

--- a/docs/modules/txwrapper_substrate_src.methods.staking.md
+++ b/docs/modules/txwrapper_substrate_src.methods.staking.md
@@ -55,7 +55,7 @@ Construct a transaction to bond funds and create a Stash account.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/staking/bond.ts:28](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-substrate/src/methods/staking/bond.ts#L28)
+[txwrapper-substrate/src/methods/staking/bond.ts:28](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-substrate/src/methods/staking/bond.ts#L28)
 
 ___
 
@@ -82,7 +82,7 @@ Can only be called when `EraElectionStatus` is `Closed`.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/staking/bondExtra.ts:26](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-substrate/src/methods/staking/bondExtra.ts#L26)
+[txwrapper-substrate/src/methods/staking/bondExtra.ts:26](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-substrate/src/methods/staking/bondExtra.ts#L26)
 
 ___
 
@@ -108,7 +108,7 @@ Can only be called when `EraElectionStatus` is `Closed`.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/staking/chill.ts:17](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-substrate/src/methods/staking/chill.ts#L17)
+[txwrapper-substrate/src/methods/staking/chill.ts:17](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-substrate/src/methods/staking/chill.ts#L17)
 
 ___
 
@@ -134,7 +134,7 @@ Can only be called when `EraElectionStatus` is `Closed`.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/staking/nominate.ts:28](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-substrate/src/methods/staking/nominate.ts#L28)
+[txwrapper-substrate/src/methods/staking/nominate.ts:28](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-substrate/src/methods/staking/nominate.ts#L28)
 
 ___
 
@@ -162,7 +162,7 @@ Can only be called when `EraElectionStatus` is `Closed`.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/staking/payoutStakers.ts:34](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-substrate/src/methods/staking/payoutStakers.ts#L34)
+[txwrapper-substrate/src/methods/staking/payoutStakers.ts:34](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-substrate/src/methods/staking/payoutStakers.ts#L34)
 
 ___
 
@@ -189,7 +189,7 @@ The dispatch origin must be signed by the controller, and it can be only called 
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/staking/rebond.ts:23](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-substrate/src/methods/staking/rebond.ts#L23)
+[txwrapper-substrate/src/methods/staking/rebond.ts:23](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-substrate/src/methods/staking/rebond.ts#L23)
 
 ___
 
@@ -213,7 +213,7 @@ ___
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/staking/setController.ts:23](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-substrate/src/methods/staking/setController.ts#L23)
+[txwrapper-substrate/src/methods/staking/setController.ts:23](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-substrate/src/methods/staking/setController.ts#L23)
 
 ___
 
@@ -241,7 +241,7 @@ Comes into effect at the beginning of the next era.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/staking/setPayee.ts:27](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-substrate/src/methods/staking/setPayee.ts#L27)
+[txwrapper-substrate/src/methods/staking/setPayee.ts:27](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-substrate/src/methods/staking/setPayee.ts#L27)
 
 ___
 
@@ -268,7 +268,7 @@ Can only be called when `EraElectionStatus` is `Closed`.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/staking/unbond.ts:26](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-substrate/src/methods/staking/unbond.ts#L26)
+[txwrapper-substrate/src/methods/staking/unbond.ts:26](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-substrate/src/methods/staking/unbond.ts#L26)
 
 ___
 
@@ -294,7 +294,7 @@ Can only be called when `EraElectionStatus` is `Closed`.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/staking/validate.ts:27](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-substrate/src/methods/staking/validate.ts#L27)
+[txwrapper-substrate/src/methods/staking/validate.ts:27](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-substrate/src/methods/staking/validate.ts#L27)
 
 ___
 
@@ -324,4 +324,4 @@ Can only be called when `EraElectionStatus` is `Closed`.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/staking/withdrawUnbonded.ts:26](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-substrate/src/methods/staking/withdrawUnbonded.ts#L26)
+[txwrapper-substrate/src/methods/staking/withdrawUnbonded.ts:26](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-substrate/src/methods/staking/withdrawUnbonded.ts#L26)

--- a/docs/modules/txwrapper_substrate_src.methods.system.md
+++ b/docs/modules/txwrapper_substrate_src.methods.system.md
@@ -36,4 +36,4 @@ Make some on-chain remark.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/system/remark.ts:23](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-substrate/src/methods/system/remark.ts#L23)
+[txwrapper-substrate/src/methods/system/remark.ts:23](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-substrate/src/methods/system/remark.ts#L23)

--- a/docs/modules/txwrapper_substrate_src.methods.system.md
+++ b/docs/modules/txwrapper_substrate_src.methods.system.md
@@ -36,4 +36,4 @@ Make some on-chain remark.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/system/remark.ts:23](https://github.com/paritytech/txwrapper-core/blob/a0283d9/packages/txwrapper-substrate/src/methods/system/remark.ts#L23)
+[txwrapper-substrate/src/methods/system/remark.ts:23](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-substrate/src/methods/system/remark.ts#L23)

--- a/docs/modules/txwrapper_substrate_src.methods.system.md
+++ b/docs/modules/txwrapper_substrate_src.methods.system.md
@@ -36,4 +36,4 @@ Make some on-chain remark.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/system/remark.ts:23](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-substrate/src/methods/system/remark.ts#L23)
+[txwrapper-substrate/src/methods/system/remark.ts:23](https://github.com/paritytech/txwrapper-core/blob/9387f90/packages/txwrapper-substrate/src/methods/system/remark.ts#L23)

--- a/docs/modules/txwrapper_substrate_src.methods.utility.md
+++ b/docs/modules/txwrapper_substrate_src.methods.utility.md
@@ -58,7 +58,7 @@ The dispatch origin for this call must be _Signed_.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/utility/asDerivative.ts:48](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-substrate/src/methods/utility/asDerivative.ts#L48)
+[txwrapper-substrate/src/methods/utility/asDerivative.ts:48](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-substrate/src/methods/utility/asDerivative.ts#L48)
 
 ___
 
@@ -80,7 +80,7 @@ ___
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/utility/batch.ts:18](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-substrate/src/methods/utility/batch.ts#L18)
+[txwrapper-substrate/src/methods/utility/batch.ts:18](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-substrate/src/methods/utility/batch.ts#L18)
 
 ___
 
@@ -110,4 +110,4 @@ If origin is root then calls are dispatch without checking origin filter.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/utility/batchAll.ts:23](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-substrate/src/methods/utility/batchAll.ts#L23)
+[txwrapper-substrate/src/methods/utility/batchAll.ts:23](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-substrate/src/methods/utility/batchAll.ts#L23)

--- a/docs/modules/txwrapper_substrate_src.methods.utility.md
+++ b/docs/modules/txwrapper_substrate_src.methods.utility.md
@@ -58,7 +58,7 @@ The dispatch origin for this call must be _Signed_.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/utility/asDerivative.ts:48](https://github.com/paritytech/txwrapper-core/blob/a0283d9/packages/txwrapper-substrate/src/methods/utility/asDerivative.ts#L48)
+[txwrapper-substrate/src/methods/utility/asDerivative.ts:48](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-substrate/src/methods/utility/asDerivative.ts#L48)
 
 ___
 
@@ -80,7 +80,7 @@ ___
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/utility/batch.ts:18](https://github.com/paritytech/txwrapper-core/blob/a0283d9/packages/txwrapper-substrate/src/methods/utility/batch.ts#L18)
+[txwrapper-substrate/src/methods/utility/batch.ts:18](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-substrate/src/methods/utility/batch.ts#L18)
 
 ___
 
@@ -110,4 +110,4 @@ If origin is root then calls are dispatch without checking origin filter.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/utility/batchAll.ts:23](https://github.com/paritytech/txwrapper-core/blob/a0283d9/packages/txwrapper-substrate/src/methods/utility/batchAll.ts#L23)
+[txwrapper-substrate/src/methods/utility/batchAll.ts:23](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-substrate/src/methods/utility/batchAll.ts#L23)

--- a/docs/modules/txwrapper_substrate_src.methods.utility.md
+++ b/docs/modules/txwrapper_substrate_src.methods.utility.md
@@ -58,7 +58,7 @@ The dispatch origin for this call must be _Signed_.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/utility/asDerivative.ts:48](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-substrate/src/methods/utility/asDerivative.ts#L48)
+[txwrapper-substrate/src/methods/utility/asDerivative.ts:48](https://github.com/paritytech/txwrapper-core/blob/9387f90/packages/txwrapper-substrate/src/methods/utility/asDerivative.ts#L48)
 
 ___
 
@@ -80,7 +80,7 @@ ___
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/utility/batch.ts:18](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-substrate/src/methods/utility/batch.ts#L18)
+[txwrapper-substrate/src/methods/utility/batch.ts:18](https://github.com/paritytech/txwrapper-core/blob/9387f90/packages/txwrapper-substrate/src/methods/utility/batch.ts#L18)
 
 ___
 
@@ -110,4 +110,4 @@ If origin is root then calls are dispatch without checking origin filter.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/utility/batchAll.ts:23](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-substrate/src/methods/utility/batchAll.ts#L23)
+[txwrapper-substrate/src/methods/utility/batchAll.ts:23](https://github.com/paritytech/txwrapper-core/blob/9387f90/packages/txwrapper-substrate/src/methods/utility/batchAll.ts#L23)

--- a/docs/modules/txwrapper_substrate_src.methods.vesting.md
+++ b/docs/modules/txwrapper_substrate_src.methods.vesting.md
@@ -37,7 +37,7 @@ Unlock any vested funds of the sender account.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/vesting/vest.ts:15](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-substrate/src/methods/vesting/vest.ts#L15)
+[txwrapper-substrate/src/methods/vesting/vest.ts:15](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-substrate/src/methods/vesting/vest.ts#L15)
 
 ___
 
@@ -61,4 +61,4 @@ Unlock any vested funds of a `target` account.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/vesting/vestOther.ts:24](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-substrate/src/methods/vesting/vestOther.ts#L24)
+[txwrapper-substrate/src/methods/vesting/vestOther.ts:24](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-substrate/src/methods/vesting/vestOther.ts#L24)

--- a/docs/modules/txwrapper_substrate_src.methods.vesting.md
+++ b/docs/modules/txwrapper_substrate_src.methods.vesting.md
@@ -37,7 +37,7 @@ Unlock any vested funds of the sender account.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/vesting/vest.ts:15](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-substrate/src/methods/vesting/vest.ts#L15)
+[txwrapper-substrate/src/methods/vesting/vest.ts:15](https://github.com/paritytech/txwrapper-core/blob/9387f90/packages/txwrapper-substrate/src/methods/vesting/vest.ts#L15)
 
 ___
 
@@ -61,4 +61,4 @@ Unlock any vested funds of a `target` account.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/vesting/vestOther.ts:24](https://github.com/paritytech/txwrapper-core/blob/d3e4018/packages/txwrapper-substrate/src/methods/vesting/vestOther.ts#L24)
+[txwrapper-substrate/src/methods/vesting/vestOther.ts:24](https://github.com/paritytech/txwrapper-core/blob/9387f90/packages/txwrapper-substrate/src/methods/vesting/vestOther.ts#L24)

--- a/docs/modules/txwrapper_substrate_src.methods.vesting.md
+++ b/docs/modules/txwrapper_substrate_src.methods.vesting.md
@@ -37,7 +37,7 @@ Unlock any vested funds of the sender account.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/vesting/vest.ts:15](https://github.com/paritytech/txwrapper-core/blob/a0283d9/packages/txwrapper-substrate/src/methods/vesting/vest.ts#L15)
+[txwrapper-substrate/src/methods/vesting/vest.ts:15](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-substrate/src/methods/vesting/vest.ts#L15)
 
 ___
 
@@ -61,4 +61,4 @@ Unlock any vested funds of a `target` account.
 
 #### Defined in
 
-[txwrapper-substrate/src/methods/vesting/vestOther.ts:24](https://github.com/paritytech/txwrapper-core/blob/a0283d9/packages/txwrapper-substrate/src/methods/vesting/vestOther.ts#L24)
+[txwrapper-substrate/src/methods/vesting/vestOther.ts:24](https://github.com/paritytech/txwrapper-core/blob/f50cd9c/packages/txwrapper-substrate/src/methods/vesting/vestOther.ts#L24)

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "test": "substrate-exec-jest",
     "test:watch": "substrate-exec-jest --watch",
     "test:cov": "substrate-exec-jest --coverage",
-    "docs": "typedoc"
+    "docs": "typedoc --gitRemote origin"
   },
   "resolutions": {
     "@polkadot/api": "7.15.1",

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "tsconfig-paths": "^3.9.0",
     "typedoc": "^0.22.10",
     "typedoc-plugin-markdown": "^3.11.8",
+    "typedoc-plugin-missing-exports": "^0.22.6",
     "typescript": "^4.4.3"
   },
   "packageManager": "yarn@3.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -10252,6 +10252,7 @@ fsevents@^2.3.2:
     tsconfig-paths: ^3.9.0
     typedoc: ^0.22.10
     typedoc-plugin-markdown: ^3.11.8
+    typedoc-plugin-missing-exports: ^0.22.6
     typescript: ^4.4.3
   languageName: unknown
   linkType: soft
@@ -10361,6 +10362,15 @@ fsevents@^2.3.2:
   peerDependencies:
     typedoc: ">=0.22.0"
   checksum: 8cd28b8d4e27890df5696c51ad9ca7f2987938aecbaf6f5f580784cf2bfdbbf44c1ff6509f6adc8f0854f325a5ff63289e7c6af988216ca1529cd8f0004d4d02
+  languageName: node
+  linkType: hard
+
+"typedoc-plugin-missing-exports@npm:^0.22.6":
+  version: 0.22.6
+  resolution: "typedoc-plugin-missing-exports@npm:0.22.6"
+  peerDependencies:
+    typedoc: 0.22.x
+  checksum: 012f44beaac05731b4d37c26bfba2d972ac48344eab6be793a95982712a207416e7dc3451279be4e4cebc8b6b99a16764d2d4aaa06e041fac60ce21cc22cf796
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This updates the docs:

Warnings:

```
Warning: GetRegistryBaseArgs, defined at packages/txwrapper-core/src/core/metadata/getRegistryBase.ts:7, is referenced by txwrapper-core/src.getRegistryBase.getRegistryBase.__namedParameters but not included in the documentation.
Warning: __module, defined at packages/txwrapper-polkadot/src/methods/crowdloan/index.ts:0, is referenced by txwrapper-polkadot/src.methods.__type.crowdloan but not included in the documentation.
Warning: AccountVote, defined at packages/txwrapper-substrate/src/methods/democracy/types.ts:29, is referenced by txwrapper-substrate/src.methods.democracy.DemocracyVoteArgs.vote but not included in the documentation.
Warning: Timepoint, defined at packages/txwrapper-substrate/src/methods/multisig/types.ts:5, is referenced by txwrapper-substrate/src.methods.multisig.MultiSigApproveAsMulti.maybeTimepoint but not included in the documentation.
Warning: ProxyAnnounceArgs, defined at packages/txwrapper-substrate/src/methods/proxy/announce.ts:8, is referenced by txwrapper-substrate/src.methods.proxy.announce.announce.args but not included in the documentation.
Warning: ProxyAnonymousArgs, defined at packages/txwrapper-substrate/src/methods/proxy/anonymous.ts:8, is referenced by txwrapper-substrate/src.methods.proxy.anonymous.anonymous.args but not included in the documentation.
Warning: ProxyKillAnonymousArgs, defined at packages/txwrapper-substrate/src/methods/proxy/killAnonymous.ts:8, is referenced by txwrapper-substrate/src.methods.proxy.killAnonymous.killAnonymous.args but not included in the documentation.

```