### PR TITLE
fix(readme-changelog): update correct 2.0.0 release notes, and instructions in the readme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,28 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 # [2.0.0](https://github.com/paritytech/txwrapper-core/compare/v1.7.0...v2.0.0) (2022-04-06)
 
 
+### BREAKING CHANGES
+
+* feat!: add isImmortalEra option for decoding and encoding era periods ([#201](https://github.com/paritytech/txwrapper-core/pull/201)) ([ab5873f](https://github.com/paritytech/txwrapper-core/commit/ab5873f54ca93f847f1ead95939b018376e4c904))
+    - When creating unsigned transactions, execution will fail when the `eraPeriod` passed in is less than 4 or greater than 65536. If you dont pass anything in it will default to 64. For those who would like to create immortal transactions, use the option in `OptionsWithMeta` called `isImmortalTx`.
+
 ### Bug Fixes
 
 * **changelog:** deprecate 1.7.0, and remove 1.6.0 ([#205](https://github.com/paritytech/txwrapper-core/issues/205)) ([cec26b1](https://github.com/paritytech/txwrapper-core/commit/cec26b12e56a07d37c0e7213d07c4a411264c269))
+* **deps:** update polkadot-js api, apps-config, networks ([#203](https://github.com/paritytech/txwrapper-core/issues/203)) ([088c6ca](https://github.com/paritytech/txwrapper-core/commit/088c6caaf31aee7261c0cc71f5afb639d2b80286))
+    "@polkadot/api": "7.15.1",
+    "@polkadot/keyring": "8.7.1",
+    "@polkadot/networks": "8.7.1",
+    "@polkadot/types": "7.15.1",
+    "@polkadot/types-known": "7.15.1",
+    "@polkadot/util": "8.7.1",
+    "@polkadot/util-crypto": "8.7.1",
+    "@polkadot/wasm-crypto": "5.1.1",
+    "@polkadot/apps-config": "0.111.1"
+
+### Features
+
+* add balances::transferAll ([#200](https://github.com/paritytech/txwrapper-core/issues/200)) ([f50cd9c](https://github.com/paritytech/txwrapper-core/commit/f50cd9cacd1598b26d7aa9c404babf97cfe81ff7))
 
 
 

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ This libraries release process uses Lerna, and the following below is required t
     yarn run test
     ```
 
-4. Deploy the new release.
+4. Deploy the new release. It is important to note there will be a step that asks you to confirm whether or not the version bump is correct. Please confirm with the maintainers the suggested versions are correct.
 
     ```bash
     yarn run deploy


### PR DESCRIPTION
This updates the readme with a note about verifying versions, and the changelog to reflect version 2.0.0 correctly. 