### PR TITLE
add dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,9 @@ updates:
       interval: daily
       time: '03:00'
       timezone: Europe/Berlin
-  - package-ecosystem: npm
-    directory: '/'
-    schedule:
-      interval: 'daily'
+  # DO NOT ENABLE UNTIL RESOLVED
+  # https://github.com/dependabot/dependabot-core/issues/1297
+  # - package-ecosystem: npm
+  #   directory: '/'
+  #   schedule:
+  #     interval: 'daily'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+
+updates:
+  - package-ecosystem: github-actions
+    directory: '/'
+    schedule:
+      interval: daily
+      time: '03:00'
+      timezone: Europe/Berlin
+  - package-ecosystem: npm
+    directory: '/'
+    schedule:
+      interval: 'daily'


### PR DESCRIPTION
This PR adds `dependabot` to repository. To automate dependency updates and security vulnerabilities fixes.  
Related issue https://github.com/paritytech/ci_cd/issues/114