### PR TITLE
fix(example): `polkadotbatchAll` example & corrections in the README files of the examples

### DIFF
--- a/packages/txwrapper-examples/multisig/README.md
+++ b/packages/txwrapper-examples/multisig/README.md
@@ -18,7 +18,7 @@ More specifically the code implements the following steps :
 
 ## Setup environment
 
-1) Fetch the latest Substrate or Polkadot/Kusama node from the above link. Follow instructions to build it, and start a dev chain :
+1) Fetch the latest Substrate or Polkadot/Kusama node from the following link https://github.com/paritytech/polkadot/. Follow the instructions to build it, and start a dev chain :
 
     ```bash
     target/release/polkadot --dev

--- a/packages/txwrapper-examples/multisig/src/multisig.ts
+++ b/packages/txwrapper-examples/multisig/src/multisig.ts
@@ -464,19 +464,13 @@ async function main(): Promise<void> {
 		multisigCallHash.substring(2) +
 		callTxHashMulti.substring(2);
 
-	console.log('multi key1', multisigAddressHash.substring(2));
-	console.log('key 1.1', multisigAddressInHex);
-	console.log('key 2', multisigCallHash.substring(2));
-	console.log('key 2.2', callTxHashMulti.substring(2));
-	console.log('storage item ?', multisigStorageKey);
-
 	// Adding a delay before making the RPC request
 	console.log(
 		`${PURPLE}Waiting 10 seconds ${RESET}before making the RPC request` +
 			` so that we are sure that the Multisig storage has been updated` +
 			` with the info from the \`approveAsMulti\` transaction.`
 	);
-	await delay(50000);
+	await delay(10000);
 
 	// 2. Making an RPC request with the `state_getStorage` endpoint to retrieve the SCALE-encoded Multisig storage data from the chain under the key `multisigStorageKey`.
 	const multisigStorage = await rpcToLocalNode('state_getStorage', [

--- a/packages/txwrapper-examples/polkadot/README.md
+++ b/packages/txwrapper-examples/polkadot/README.md
@@ -2,11 +2,11 @@
 
 ## How to use `txwrapper-polkadot`
 
-Here's a mini-tutorial on how `txwrapper-polkadot` can interact with a Polkadot chain. We're using a Polkadot/Kusama dev chain (https://github.com/paritytech/polkadot/)
+Here's a mini-tutorial on how `txwrapper-polkadot` can interact with a Polkadot chain. We are using a Polkadot/Kusama dev chain (https://github.com/paritytech/polkadot/).
 
 ## Get Started
 
-1) Fetch the latest Substrate or Polkadot/Kusama node from the above link. Follow instructions to build it, and start a dev chain.
+1) Fetch the latest Substrate or Polkadot/Kusama node from the above link. Follow the instructions to build it, and start a dev chain.
 
     ```bash
     target/release/polkadot --dev

--- a/packages/txwrapper-examples/polkadotBatchAll/README.md
+++ b/packages/txwrapper-examples/polkadotBatchAll/README.md
@@ -1,11 +1,11 @@
 # Polkadot Batch All example
 
 ## Description
-Example that shows how to use the `batchAll` method to send a number of transactions at once.
+Example that shows how to use the `batchAll` method to send a number of transactions at once. We are using a Polkadot/Kusama dev chain (https://github.com/paritytech/polkadot/).
 
 ## Get Started
 
-1) Fetch the latest Substrate or Polkadot/Kusama node from the above link. Follow instructions to build it, and start a dev chain.
+1) Fetch the latest Substrate or Polkadot/Kusama node from the above link. Follow the instructions to build it, and start a dev chain.
 
     ```bash
     target/release/polkadot --dev

--- a/packages/txwrapper-examples/polkadotBatchAll/src/polkadotBatchAll.ts
+++ b/packages/txwrapper-examples/polkadotBatchAll/src/polkadotBatchAll.ts
@@ -76,7 +76,7 @@ async function main(): Promise<void> {
 	// Metadata and type defintion registry used to create the calls
 	const optionsWithMeta = {
 		registry: registry,
-		metadataRpc: registry.metadata.toHex(),
+		metadataRpc,
 	};
 
 	// Arguments for 12 balances transferKeepAlive


### PR DESCRIPTION
## Description
While trying to run the `polkadotBatchAll` example found [here](https://github.com/paritytech/txwrapper-core/blob/main/packages/txwrapper-examples/polkadotBatchAll/src/polkadotBatchAll.ts), we (@IkerAlus tried it also with the same result) were getting the following error message : 
```
Error: decodeU8a: failed at 0xf50a000c1c73705f636f726518637279… on magicNumber: u32:: MagicNumber mismatch: expected 0x6174656d, found 0x0c000af5
```

## Solution
As @TarikGul explained, the example code is using the `registry.metadata.toHex()` (L79) which will strip a lot of things, and will not apply the magic number. So after his recommendation we changed it to `metadataRpc`and that fixes the problem.

## Additional Changes
- Added some minor corrections in the README files of the examples.
- Minor changes to the `multisig` example : 
  - Removed some unnecessary outputs and 
  - Restored the `delay` in the code to 10 seconds.
