### PR TITLE
fix: decodeSigningPayload for immortal era

### DIFF
--- a/packages/txwrapper-core/src/core/decode/decodeSigningPayload.spec.ts
+++ b/packages/txwrapper-core/src/core/decode/decodeSigningPayload.spec.ts
@@ -45,4 +45,22 @@ describe('decodeSigningPayload', () => {
 
 		itDecodesBalancesTransferCommon(decoded);
 	});
+
+	it('Should decode balances::transfer with a immortal era', () => {
+		const signingPayload = construct.signingPayload(
+			balancesTransfer(
+				TEST_METHOD_ARGS.balances.transfer,
+				TEST_BASE_TX_INFO,
+				Object.assign({}, POLKADOT_25_TEST_OPTIONS, { isImmortalEra: true })
+			),
+			POLKADOT_25_TEST_OPTIONS
+		);
+
+		const decoded = decodeSigningPayload(
+			signingPayload,
+			POLKADOT_25_TEST_OPTIONS
+		);
+
+		expect(decoded.eraPeriod).toBe(0);
+	});
 });

--- a/packages/txwrapper-core/src/core/decode/decodeSigningPayload.spec.ts
+++ b/packages/txwrapper-core/src/core/decode/decodeSigningPayload.spec.ts
@@ -46,7 +46,7 @@ describe('decodeSigningPayload', () => {
 		itDecodesBalancesTransferCommon(decoded);
 	});
 
-	it('Should decode balances::transfer with a immortal era', () => {
+	it('should decode balances::transfer with an immortal era', () => {
 		const signingPayload = construct.signingPayload(
 			balancesTransfer(
 				TEST_METHOD_ARGS.balances.transfer,

--- a/packages/txwrapper-core/src/core/decode/decodeSigningPayload.ts
+++ b/packages/txwrapper-core/src/core/decode/decodeSigningPayload.ts
@@ -50,9 +50,14 @@ export function decodeSigningPayload(
 	const methodCall: Call = createTypeUnsafe(registry, 'Call', [payload.method]);
 	const method = toTxMethod(registry, methodCall);
 
+	// Immortal eras should return a period of 0
+	const eraPeriod = payload.era.isMortalEra
+		? payload.era.asMortalEra.period.toNumber()
+		: 0;
+
 	return {
 		blockHash: payload.blockHash.toHex(),
-		eraPeriod: payload.era.asMortalEra.period.toNumber(),
+		eraPeriod,
 		genesisHash: payload.genesisHash.toHex(),
 		metadataRpc,
 		method,


### PR DESCRIPTION
closes: https://github.com/paritytech/txwrapper-core/issues/244

Todo:

- [x] Test for immortal era in a signing payload