### PR TITLE
fix: remove asSpecifiedCallsOnlyV14 from getRegistryBase

### DIFF
--- a/packages/txwrapper-core/src/core/metadata/getRegistryBase.ts
+++ b/packages/txwrapper-core/src/core/metadata/getRegistryBase.ts
@@ -23,13 +23,6 @@ export interface GetRegistryBaseArgs {
 	 */
 	asCallsOnlyArg?: boolean;
 	/**
-	 * Used to reduce the metadata size by only having specific inputted calls,
-	 * and reducing the types to only whats needed to construct the transaction.
-	 *
-	 * An Array which contains all the pallets that should be included in the metadata
-	 */
-	asSpecifiedCallsOnlyV14?: string[];
-	/**
 	 * Array of signedExtensions
 	 */
 	signedExtensions?: string[];
@@ -47,7 +40,6 @@ export function getRegistryBase({
 	specTypes,
 	metadataRpc,
 	asCallsOnlyArg,
-	asSpecifiedCallsOnlyV14,
 	signedExtensions,
 	userExtensions,
 }: GetRegistryBaseArgs): TypeRegistry {
@@ -56,8 +48,7 @@ export function getRegistryBase({
 	const generatedMetadata = createMetadata(
 		registry,
 		metadataRpc,
-		asCallsOnlyArg,
-		asSpecifiedCallsOnlyV14
+		asCallsOnlyArg
 	);
 
 	registry.register(specTypes);

--- a/packages/txwrapper-core/src/types/registry.ts
+++ b/packages/txwrapper-core/src/types/registry.ts
@@ -31,13 +31,6 @@ export interface GetRegistryOptsCore {
 	 */
 	asCallsOnlyArg?: boolean;
 	/**
-	 * Used to reduce the metadata size by only having specific inputted calls,
-	 * and reducing the types to only whats needed to construct the transaction
-	 *
-	 * An Array which contains all the pallets that should be included in the metadata
-	 */
-	asSpecifiedCallsOnlyV14?: string[];
-	/**
 	 * Array of signedExtensions
 	 */
 	signedExtensions?: string[];

--- a/packages/txwrapper-examples/options/src/asSpecifiedCallsOnlyV14.ts
+++ b/packages/txwrapper-examples/options/src/asSpecifiedCallsOnlyV14.ts
@@ -24,7 +24,6 @@ async function main(): Promise<void> {
 		specName,
 		specVersion,
 		metadataRpc,
-		asSpecifiedCallsOnlyV14,
 	});
 
 	/**

--- a/packages/txwrapper-examples/options/src/asSpecifiedCallsOnlyV14.ts
+++ b/packages/txwrapper-examples/options/src/asSpecifiedCallsOnlyV14.ts
@@ -13,11 +13,6 @@ async function main(): Promise<void> {
 
 	/**
 	 * Create the type registry.
-	 *
-	 * In order to minimize the metadata, add the asSpecifiedCallsOnlyV14 option
-	 * which will point to an array that will contain pallets names as strings. Each pallet
-	 * specified will include the types needed for constructing transactions for those pallets only
-	 * within the metadata.
 	 */
 	const registry = getRegistry({
 		chainName: 'Polkadot',

--- a/packages/txwrapper-polkadot/src/index.ts
+++ b/packages/txwrapper-polkadot/src/index.ts
@@ -85,7 +85,6 @@ export function getRegistry({
 	metadataRpc,
 	properties,
 	asCallsOnlyArg,
-	asSpecifiedCallsOnlyV14,
 	signedExtensions,
 	userExtensions,
 }: GetRegistryOpts): TypeRegistry {
@@ -106,7 +105,6 @@ export function getRegistry({
 		),
 		metadataRpc,
 		asCallsOnlyArg,
-		asSpecifiedCallsOnlyV14,
 		signedExtensions,
 		userExtensions,
 	});

--- a/packages/txwrapper-registry/src/index.ts
+++ b/packages/txwrapper-registry/src/index.ts
@@ -72,7 +72,6 @@ export function getRegistry({
 	metadataRpc,
 	properties,
 	asCallsOnlyArg,
-	asSpecifiedCallsOnlyV14,
 }: GetRegistryOpts): TypeRegistry {
 	// Polkadot, kusama, and westend have known types in the default polkadot-js registry. If we are
 	// dealing with another network, use the apps-config types to fill the registry.
@@ -86,6 +85,5 @@ export function getRegistry({
 		specTypes: getSpecTypes(registry, chainName, specName, specVersion),
 		metadataRpc,
 		asCallsOnlyArg,
-		asSpecifiedCallsOnlyV14,
 	});
 }


### PR DESCRIPTION
closes: https://github.com/paritytech/txwrapper-core/issues/247

Remove `asSpecifiedCallsOnlyV14` from `getRegistryBase`. It does some heavy minifying on the metadata which can cause issues when using that instantiated registry to create a metadata type. `asSpecifiedCallsOnlyV14` should only be used when creating metadata that needs to be minified. 