### PR TITLE
fix(types): Update polkadot-js deps to get the latest types

### DIFF
--- a/packages/txwrapper-core/package.json
+++ b/packages/txwrapper-core/package.json
@@ -18,8 +18,8 @@
     "build": "yarn build:workspace"
   },
   "dependencies": {
-    "@polkadot/api": "9.3.3",
-    "@polkadot/keyring": "10.1.7",
+    "@polkadot/api": "9.4.1",
+    "@polkadot/keyring": "10.1.8",
     "memoizee": "0.4.15"
   },
   "devDependencies": {

--- a/packages/txwrapper-examples/package.json
+++ b/packages/txwrapper-examples/package.json
@@ -21,7 +21,7 @@
     "asSpecifiedCallsOnlyV14": "node lib/options/src/asSpecifiedCallsOnlyV14"
   },
   "dependencies": {
-    "@polkadot/api": "9.3.3",
+    "@polkadot/api": "9.4.1",
     "@substrate/txwrapper-polkadot": "^3.2.2",
     "@substrate/txwrapper-registry": "^3.2.2"
   }

--- a/packages/txwrapper-registry/package.json
+++ b/packages/txwrapper-registry/package.json
@@ -18,7 +18,7 @@
     "build": "yarn build:workspace"
   },
   "dependencies": {
-    "@polkadot/networks": "10.1.7",
+    "@polkadot/networks": "10.1.8",
     "@substrate/txwrapper-core": "^3.2.2"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -365,12 +365,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/runtime@npm:^7.18.9":
-  version: 7.18.9
-  resolution: "@babel/runtime@npm:7.18.9"
+"@babel/runtime@npm:^7.18.9, @babel/runtime@npm:^7.19.0":
+  version: 7.19.0
+  resolution: "@babel/runtime@npm:7.19.0"
   dependencies:
     regenerator-runtime: ^0.13.4
-  checksum: 36dd736baba7164e82b3cc9d43e081f0cb2d05ff867ad39cac515d99546cee75b7f782018b02a3dcf5f2ef3d27f319faa68965fdfec49d4912c60c6002353a2e
+  checksum: fa69c351bb05e1db3ceb9a02fdcf620c234180af68cdda02152d3561015f6d55277265d3109815992f96d910f3db709458cae4f8df1c3def66f32e0867d82294
   languageName: node
   linkType: hard
 
@@ -1535,10 +1535,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@noble/secp256k1@npm:1.6.3":
-  version: 1.6.3
-  resolution: "@noble/secp256k1@npm:1.6.3"
-  checksum: 16eb3242533e645deb64444c771515f66bdc2ee0759894efd42fdeed4ab226ed29827aaaf6caa27d3d95b831452fd4246aa1007cd688aa462ad48fc084ab76e6
+"@noble/secp256k1@npm:1.7.0":
+  version: 1.7.0
+  resolution: "@noble/secp256k1@npm:1.7.0"
+  checksum: 540a2b8e527ee1e5522af1c430e54945ad373883cac983b115136cd0950efa1f2c473ee6a36d8e69b6809b3ee586276de62f5fa705c77a9425721e81bada8116
   languageName: node
   linkType: hard
 
@@ -1799,257 +1799,257 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@polkadot/api-augment@npm:9.3.3":
-  version: 9.3.3
-  resolution: "@polkadot/api-augment@npm:9.3.3"
+"@polkadot/api-augment@npm:9.4.1":
+  version: 9.4.1
+  resolution: "@polkadot/api-augment@npm:9.4.1"
   dependencies:
-    "@babel/runtime": ^7.18.9
-    "@polkadot/api-base": 9.3.3
-    "@polkadot/rpc-augment": 9.3.3
-    "@polkadot/types": 9.3.3
-    "@polkadot/types-augment": 9.3.3
-    "@polkadot/types-codec": 9.3.3
-    "@polkadot/util": ^10.1.7
-  checksum: 83404e9036365a67e46a5c04673df8ca74e03a9e7b220f62053451aea440c979dd4d74173f3b87baebd18603a8e7fce3f727b2fcbca0b0414a43211274787379
+    "@babel/runtime": ^7.19.0
+    "@polkadot/api-base": 9.4.1
+    "@polkadot/rpc-augment": 9.4.1
+    "@polkadot/types": 9.4.1
+    "@polkadot/types-augment": 9.4.1
+    "@polkadot/types-codec": 9.4.1
+    "@polkadot/util": ^10.1.8
+  checksum: b9fea9020250f2370f340896ee8cfbee6564115a39a80ddacbe82fa31045686798d04f8157e9280cfd7a371137c18d86101553224657fadcb0ba69d84652a613
   languageName: node
   linkType: hard
 
-"@polkadot/api-base@npm:9.3.3":
-  version: 9.3.3
-  resolution: "@polkadot/api-base@npm:9.3.3"
+"@polkadot/api-base@npm:9.4.1":
+  version: 9.4.1
+  resolution: "@polkadot/api-base@npm:9.4.1"
   dependencies:
-    "@babel/runtime": ^7.18.9
-    "@polkadot/rpc-core": 9.3.3
-    "@polkadot/types": 9.3.3
-    "@polkadot/util": ^10.1.7
+    "@babel/runtime": ^7.19.0
+    "@polkadot/rpc-core": 9.4.1
+    "@polkadot/types": 9.4.1
+    "@polkadot/util": ^10.1.8
     rxjs: ^7.5.6
-  checksum: f7b09084df481c15ef0e4b210c5ac61388bb6286330c1516b12a9003bfb4a8d7364f07503726232d15c42ada3174d35613bfb473bbd9552f1beb387d404f5baa
+  checksum: 292399aaebc77eb2ef0e8692c3c91748859df0e58fffa7665e95986ce0eee023207e76435f58aa4b703390fdb14f7fa2d76c36b8bdf46fc9ed6484f867f9b9ec
   languageName: node
   linkType: hard
 
-"@polkadot/api-derive@npm:9.3.3":
-  version: 9.3.3
-  resolution: "@polkadot/api-derive@npm:9.3.3"
+"@polkadot/api-derive@npm:9.4.1":
+  version: 9.4.1
+  resolution: "@polkadot/api-derive@npm:9.4.1"
   dependencies:
-    "@babel/runtime": ^7.18.9
-    "@polkadot/api": 9.3.3
-    "@polkadot/api-augment": 9.3.3
-    "@polkadot/api-base": 9.3.3
-    "@polkadot/rpc-core": 9.3.3
-    "@polkadot/types": 9.3.3
-    "@polkadot/types-codec": 9.3.3
-    "@polkadot/util": ^10.1.7
-    "@polkadot/util-crypto": ^10.1.7
+    "@babel/runtime": ^7.19.0
+    "@polkadot/api": 9.4.1
+    "@polkadot/api-augment": 9.4.1
+    "@polkadot/api-base": 9.4.1
+    "@polkadot/rpc-core": 9.4.1
+    "@polkadot/types": 9.4.1
+    "@polkadot/types-codec": 9.4.1
+    "@polkadot/util": ^10.1.8
+    "@polkadot/util-crypto": ^10.1.8
     rxjs: ^7.5.6
-  checksum: b06edd5e26b649c227fc196c6249b120e2a7f28fa5a03fa8a1d47eb8f7de3efacc9f5ed71ebc76d86397fa75434cf056f43cff18d5f41deee4d7a4caba1023f1
+  checksum: a06f449653c16b5c7570c5c231991c45fc497705e41e8bfa4af256f15df50917e3e558bed7aaa499a683863686afc09512dc9a100fc4d39a8ebc8bb02ea115d0
   languageName: node
   linkType: hard
 
-"@polkadot/api@npm:9.3.3":
-  version: 9.3.3
-  resolution: "@polkadot/api@npm:9.3.3"
+"@polkadot/api@npm:9.4.1":
+  version: 9.4.1
+  resolution: "@polkadot/api@npm:9.4.1"
   dependencies:
-    "@babel/runtime": ^7.18.9
-    "@polkadot/api-augment": 9.3.3
-    "@polkadot/api-base": 9.3.3
-    "@polkadot/api-derive": 9.3.3
-    "@polkadot/keyring": ^10.1.7
-    "@polkadot/rpc-augment": 9.3.3
-    "@polkadot/rpc-core": 9.3.3
-    "@polkadot/rpc-provider": 9.3.3
-    "@polkadot/types": 9.3.3
-    "@polkadot/types-augment": 9.3.3
-    "@polkadot/types-codec": 9.3.3
-    "@polkadot/types-create": 9.3.3
-    "@polkadot/types-known": 9.3.3
-    "@polkadot/util": ^10.1.7
-    "@polkadot/util-crypto": ^10.1.7
+    "@babel/runtime": ^7.19.0
+    "@polkadot/api-augment": 9.4.1
+    "@polkadot/api-base": 9.4.1
+    "@polkadot/api-derive": 9.4.1
+    "@polkadot/keyring": ^10.1.8
+    "@polkadot/rpc-augment": 9.4.1
+    "@polkadot/rpc-core": 9.4.1
+    "@polkadot/rpc-provider": 9.4.1
+    "@polkadot/types": 9.4.1
+    "@polkadot/types-augment": 9.4.1
+    "@polkadot/types-codec": 9.4.1
+    "@polkadot/types-create": 9.4.1
+    "@polkadot/types-known": 9.4.1
+    "@polkadot/util": ^10.1.8
+    "@polkadot/util-crypto": ^10.1.8
     eventemitter3: ^4.0.7
     rxjs: ^7.5.6
-  checksum: 4723087c480cdd5582e58a9b4b2d92e7fd002a38d99e42e2c3b5a86a945a59e049466c7211330b379780694547f07a194b4e7392b74cbe5d651f6817e9df8f61
+  checksum: efaf5bf6fc6b4c983c829368f1a86b2190c1ff619b73e019bfd979e2bb129cef644cbd4d9ebf82a6a95650a626049a869d9b8d2a9c032f0a162e6d9b2b9f1328
   languageName: node
   linkType: hard
 
-"@polkadot/keyring@npm:10.1.7, @polkadot/keyring@npm:^10.1.7":
-  version: 10.1.7
-  resolution: "@polkadot/keyring@npm:10.1.7"
+"@polkadot/keyring@npm:10.1.8, @polkadot/keyring@npm:^10.1.8":
+  version: 10.1.8
+  resolution: "@polkadot/keyring@npm:10.1.8"
   dependencies:
-    "@babel/runtime": ^7.18.9
-    "@polkadot/util": 10.1.7
-    "@polkadot/util-crypto": 10.1.7
+    "@babel/runtime": ^7.19.0
+    "@polkadot/util": 10.1.8
+    "@polkadot/util-crypto": 10.1.8
   peerDependencies:
-    "@polkadot/util": 10.1.7
-    "@polkadot/util-crypto": 10.1.7
-  checksum: d6efe684e16f535f5583c48fdfd1c0d48c9d87941a585881328507ef5dc5cda31fb800a7095e176ae614c79b7574e4aaa2e4b5fb14f2903b137cc34b7619da3e
+    "@polkadot/util": 10.1.8
+    "@polkadot/util-crypto": 10.1.8
+  checksum: b52f0b6b5550ede6ad8b99334bbeab31c2c0cf62cabefeae33ca7349b5d43dc9ba10c799ed1a027b69cc7e0be8b862ee7d99e4fa66c7b2fa6e5b872eb3bef9be
   languageName: node
   linkType: hard
 
-"@polkadot/networks@npm:10.1.7, @polkadot/networks@npm:^10.1.7":
-  version: 10.1.7
-  resolution: "@polkadot/networks@npm:10.1.7"
+"@polkadot/networks@npm:10.1.8, @polkadot/networks@npm:^10.1.8":
+  version: 10.1.8
+  resolution: "@polkadot/networks@npm:10.1.8"
   dependencies:
-    "@babel/runtime": ^7.18.9
-    "@polkadot/util": 10.1.7
-    "@substrate/ss58-registry": ^1.28.0
-  checksum: 135190d1a3e3b91ad6eb7375ca1d4ab6c05e5cce975b566a2735a2b94ffae45ad1a6ee049bc5d53ebb735310781e6338a2eb710edb6718136eb06c000ec5ee46
+    "@babel/runtime": ^7.19.0
+    "@polkadot/util": 10.1.8
+    "@substrate/ss58-registry": ^1.29.0
+  checksum: 185e3d87d98616cddaebfe1787b10e1344dcf62804e3e74e1d86abc737289e62c3155f618b15384fe00cdd006aa09d14fdcd54e4c836ba0787ae3ad003d50f36
   languageName: node
   linkType: hard
 
-"@polkadot/rpc-augment@npm:9.3.3":
-  version: 9.3.3
-  resolution: "@polkadot/rpc-augment@npm:9.3.3"
+"@polkadot/rpc-augment@npm:9.4.1":
+  version: 9.4.1
+  resolution: "@polkadot/rpc-augment@npm:9.4.1"
   dependencies:
-    "@babel/runtime": ^7.18.9
-    "@polkadot/rpc-core": 9.3.3
-    "@polkadot/types": 9.3.3
-    "@polkadot/types-codec": 9.3.3
-    "@polkadot/util": ^10.1.7
-  checksum: a94ecd3dae3760b07c7399680368b2c227bcdb3dab91bc45cae15f450e41cb59fe59d8f81a6f9ae1248363f91c22fc279c69cb99cc4e5965016cdae73bc95084
+    "@babel/runtime": ^7.19.0
+    "@polkadot/rpc-core": 9.4.1
+    "@polkadot/types": 9.4.1
+    "@polkadot/types-codec": 9.4.1
+    "@polkadot/util": ^10.1.8
+  checksum: 9a99adb17884cba7bb1d478fb59a7eb7bbbacfcf5680ccfefe349b173f212f6e8ec66934f149d9eb03ea6bafb7c581cbee7642d8974e5aeab93eaeed090d16af
   languageName: node
   linkType: hard
 
-"@polkadot/rpc-core@npm:9.3.3":
-  version: 9.3.3
-  resolution: "@polkadot/rpc-core@npm:9.3.3"
+"@polkadot/rpc-core@npm:9.4.1":
+  version: 9.4.1
+  resolution: "@polkadot/rpc-core@npm:9.4.1"
   dependencies:
-    "@babel/runtime": ^7.18.9
-    "@polkadot/rpc-augment": 9.3.3
-    "@polkadot/rpc-provider": 9.3.3
-    "@polkadot/types": 9.3.3
-    "@polkadot/util": ^10.1.7
+    "@babel/runtime": ^7.19.0
+    "@polkadot/rpc-augment": 9.4.1
+    "@polkadot/rpc-provider": 9.4.1
+    "@polkadot/types": 9.4.1
+    "@polkadot/util": ^10.1.8
     rxjs: ^7.5.6
-  checksum: a5affeabe4e2a208efa056325175ffe8967b6cc6b35efc80b57e6892b7a2decc4c4589634c9bfc934135b524e14949742160dc2acb2a15f2fe8e23eef06be6f6
+  checksum: 44c1c2462e92f673601152e4090187c3f42d3ff43a5cff58a327f9e318b128868500e85ba4c2aca5cdf9c0bde1e213a458aef8368a106232624eece17880bf97
   languageName: node
   linkType: hard
 
-"@polkadot/rpc-provider@npm:9.3.3":
-  version: 9.3.3
-  resolution: "@polkadot/rpc-provider@npm:9.3.3"
+"@polkadot/rpc-provider@npm:9.4.1":
+  version: 9.4.1
+  resolution: "@polkadot/rpc-provider@npm:9.4.1"
   dependencies:
-    "@babel/runtime": ^7.18.9
-    "@polkadot/keyring": ^10.1.7
-    "@polkadot/types": 9.3.3
-    "@polkadot/types-support": 9.3.3
-    "@polkadot/util": ^10.1.7
-    "@polkadot/util-crypto": ^10.1.7
-    "@polkadot/x-fetch": ^10.1.7
-    "@polkadot/x-global": ^10.1.7
-    "@polkadot/x-ws": ^10.1.7
-    "@substrate/connect": 0.7.11
+    "@babel/runtime": ^7.19.0
+    "@polkadot/keyring": ^10.1.8
+    "@polkadot/types": 9.4.1
+    "@polkadot/types-support": 9.4.1
+    "@polkadot/util": ^10.1.8
+    "@polkadot/util-crypto": ^10.1.8
+    "@polkadot/x-fetch": ^10.1.8
+    "@polkadot/x-global": ^10.1.8
+    "@polkadot/x-ws": ^10.1.8
+    "@substrate/connect": 0.7.13
     eventemitter3: ^4.0.7
     mock-socket: ^9.1.5
     nock: ^13.2.9
-  checksum: c262f26b0fd472395fd2d21f6714c4ad0cfa4cfb5477471aaec72e3d25f80fa9679b840923630e0d855c7b7218fec92f47b91baa0fffccf2afc491ecab9b3245
+  checksum: 7109fb1602652daf3d18fecee208be4a9510ad92a17726fe5f481c967b9e330b0c56333d5f1008c7066a2494736f464c7fb46fc00df53e685ee3113fbbf2a73a
   languageName: node
   linkType: hard
 
-"@polkadot/types-augment@npm:9.3.3":
-  version: 9.3.3
-  resolution: "@polkadot/types-augment@npm:9.3.3"
+"@polkadot/types-augment@npm:9.4.1":
+  version: 9.4.1
+  resolution: "@polkadot/types-augment@npm:9.4.1"
   dependencies:
-    "@babel/runtime": ^7.18.9
-    "@polkadot/types": 9.3.3
-    "@polkadot/types-codec": 9.3.3
-    "@polkadot/util": ^10.1.7
-  checksum: c749c10dd1cd22436b70707039404f94e7e1fbad867ebbd76891dd1ea38ead658035ca0b26bfb8dd6fc48182c610dfd2ffdcd36f486c10325d16c26c05045a86
+    "@babel/runtime": ^7.19.0
+    "@polkadot/types": 9.4.1
+    "@polkadot/types-codec": 9.4.1
+    "@polkadot/util": ^10.1.8
+  checksum: fe4e9ca7f8720e6bcce18430e412f4130d8d2a2710f20e5b999665dfd2f1342e630e73819e1ece2a43fcb20f0d1e91f04a29b21f01d82e722b8f28a4f82d9193
   languageName: node
   linkType: hard
 
-"@polkadot/types-codec@npm:9.3.3":
-  version: 9.3.3
-  resolution: "@polkadot/types-codec@npm:9.3.3"
+"@polkadot/types-codec@npm:9.4.1":
+  version: 9.4.1
+  resolution: "@polkadot/types-codec@npm:9.4.1"
   dependencies:
-    "@babel/runtime": ^7.18.9
-    "@polkadot/util": ^10.1.7
-    "@polkadot/x-bigint": ^10.1.7
-  checksum: ae0c3690a2d6807a76eccff0283e086f272f5ee6c96ffbc6fd127e1c99973092c4d4200c0ef80c8df64044b93500b89228aab91553c1ac527f7df3ea24f2887d
+    "@babel/runtime": ^7.19.0
+    "@polkadot/util": ^10.1.8
+    "@polkadot/x-bigint": ^10.1.8
+  checksum: 350cb0bbd46acab5b76d9a4c87ecfc7bf5da5e1dfea810c919e0990b6df59ac05021f09d4c6eb7ec875977823217eb7d18e0fdbbd591cb972bba12d579180982
   languageName: node
   linkType: hard
 
-"@polkadot/types-create@npm:9.3.3":
-  version: 9.3.3
-  resolution: "@polkadot/types-create@npm:9.3.3"
+"@polkadot/types-create@npm:9.4.1":
+  version: 9.4.1
+  resolution: "@polkadot/types-create@npm:9.4.1"
   dependencies:
-    "@babel/runtime": ^7.18.9
-    "@polkadot/types-codec": 9.3.3
-    "@polkadot/util": ^10.1.7
-  checksum: ca38ac899dacaa10fd782c7c627405bf7c8f479b6532e90bca598f5e0dbf6052b0dfce8124d31646cb63ab8be4fd8daa04046700addbc3c43a1eb9b7bb58b15d
+    "@babel/runtime": ^7.19.0
+    "@polkadot/types-codec": 9.4.1
+    "@polkadot/util": ^10.1.8
+  checksum: bed46245b762e46b1002332e0bcf0fe6e7404475e8a9915a9dd68103b56bcfa0f6b63fcfac287af7d526d9933f8a843c5c821eb88504644d700f90b44c354972
   languageName: node
   linkType: hard
 
-"@polkadot/types-known@npm:9.3.3":
-  version: 9.3.3
-  resolution: "@polkadot/types-known@npm:9.3.3"
+"@polkadot/types-known@npm:9.4.1":
+  version: 9.4.1
+  resolution: "@polkadot/types-known@npm:9.4.1"
   dependencies:
-    "@babel/runtime": ^7.18.9
-    "@polkadot/networks": ^10.1.7
-    "@polkadot/types": 9.3.3
-    "@polkadot/types-codec": 9.3.3
-    "@polkadot/types-create": 9.3.3
-    "@polkadot/util": ^10.1.7
-  checksum: 30e9f6d95634c705a22b3ffac7de2f74d75554b15c955316684cbd76b194e90797858965369e7c66eef1933f346b569d13d4e488c684df2245c7496886d6a38c
+    "@babel/runtime": ^7.19.0
+    "@polkadot/networks": ^10.1.8
+    "@polkadot/types": 9.4.1
+    "@polkadot/types-codec": 9.4.1
+    "@polkadot/types-create": 9.4.1
+    "@polkadot/util": ^10.1.8
+  checksum: 3306b7c73b506763ffa9a0c4b5d1fc9e44fa3e5ecdc9aecf6f0e6cf6d9b11ac890bb7b219890e0190f5028abae6c9c0298648840d3bcaf1fe35e9959670dba20
   languageName: node
   linkType: hard
 
-"@polkadot/types-support@npm:9.3.3":
-  version: 9.3.3
-  resolution: "@polkadot/types-support@npm:9.3.3"
+"@polkadot/types-support@npm:9.4.1":
+  version: 9.4.1
+  resolution: "@polkadot/types-support@npm:9.4.1"
   dependencies:
-    "@babel/runtime": ^7.18.9
-    "@polkadot/util": ^10.1.7
-  checksum: 27d39459efbcce92880821cc95d22a687b17840264323b5a798f927b4780ad386c13851d411536060c7f2ec0ff3dc3f344c65f32ffc5985d40c0d67ff34c5c28
+    "@babel/runtime": ^7.19.0
+    "@polkadot/util": ^10.1.8
+  checksum: 999791ec10c5dc80023bc869ef6af5b9b44be56cf63d7531e08fb26affe152caeb56759e83d30731e81c3301d0e8fb25beea04ce00fdacd61c60e7d1295785b2
   languageName: node
   linkType: hard
 
-"@polkadot/types@npm:9.3.3":
-  version: 9.3.3
-  resolution: "@polkadot/types@npm:9.3.3"
+"@polkadot/types@npm:9.4.1":
+  version: 9.4.1
+  resolution: "@polkadot/types@npm:9.4.1"
   dependencies:
-    "@babel/runtime": ^7.18.9
-    "@polkadot/keyring": ^10.1.7
-    "@polkadot/types-augment": 9.3.3
-    "@polkadot/types-codec": 9.3.3
-    "@polkadot/types-create": 9.3.3
-    "@polkadot/util": ^10.1.7
-    "@polkadot/util-crypto": ^10.1.7
+    "@babel/runtime": ^7.19.0
+    "@polkadot/keyring": ^10.1.8
+    "@polkadot/types-augment": 9.4.1
+    "@polkadot/types-codec": 9.4.1
+    "@polkadot/types-create": 9.4.1
+    "@polkadot/util": ^10.1.8
+    "@polkadot/util-crypto": ^10.1.8
     rxjs: ^7.5.6
-  checksum: 3df6cbcb282016acdcc942807c0d18dd0964eecaeb9c6ab667c89f34dc725b084e0bd16a8ad1cf3bc53725078a6e7b59cacdb70ceb3bc2e4e1d88ebe2bcaac21
+  checksum: 7064b593cf8cc03fd2c53c61d2ec569fb26957e89d40e747200a5a8155c564578b0231687d6247468d1c0637593f9c4f4396f277294a2f98746ad17f889b820e
   languageName: node
   linkType: hard
 
-"@polkadot/util-crypto@npm:10.1.7, @polkadot/util-crypto@npm:^10.1.6, @polkadot/util-crypto@npm:^10.1.7":
-  version: 10.1.7
-  resolution: "@polkadot/util-crypto@npm:10.1.7"
+"@polkadot/util-crypto@npm:10.1.8, @polkadot/util-crypto@npm:^10.1.6, @polkadot/util-crypto@npm:^10.1.8":
+  version: 10.1.8
+  resolution: "@polkadot/util-crypto@npm:10.1.8"
   dependencies:
-    "@babel/runtime": ^7.18.9
+    "@babel/runtime": ^7.19.0
     "@noble/hashes": 1.1.2
-    "@noble/secp256k1": 1.6.3
-    "@polkadot/networks": 10.1.7
-    "@polkadot/util": 10.1.7
+    "@noble/secp256k1": 1.7.0
+    "@polkadot/networks": 10.1.8
+    "@polkadot/util": 10.1.8
     "@polkadot/wasm-crypto": ^6.3.1
-    "@polkadot/x-bigint": 10.1.7
-    "@polkadot/x-randomvalues": 10.1.7
+    "@polkadot/x-bigint": 10.1.8
+    "@polkadot/x-randomvalues": 10.1.8
     "@scure/base": 1.1.1
     ed2curve: ^0.3.0
     tweetnacl: ^1.0.3
   peerDependencies:
-    "@polkadot/util": 10.1.7
-  checksum: aa23a21edeaa6d9869ce308822b90fd31254f642daa6001216a2af7817929faaea313f13f734309c4e51315051057a26513f7b21a7e2226e788cb34887e46c50
+    "@polkadot/util": 10.1.8
+  checksum: 0887e7231eeb9c41677b164469491d50c5936badfa8512d4c6ec8f07bf8491feea4ce6a91d133eb3646a8538862009b3c4e807aee7b9ee940ccd82e4cdfd9bb7
   languageName: node
   linkType: hard
 
-"@polkadot/util@npm:10.1.7, @polkadot/util@npm:^10.1.7":
-  version: 10.1.7
-  resolution: "@polkadot/util@npm:10.1.7"
+"@polkadot/util@npm:10.1.8, @polkadot/util@npm:^10.1.8":
+  version: 10.1.8
+  resolution: "@polkadot/util@npm:10.1.8"
   dependencies:
-    "@babel/runtime": ^7.18.9
-    "@polkadot/x-bigint": 10.1.7
-    "@polkadot/x-global": 10.1.7
-    "@polkadot/x-textdecoder": 10.1.7
-    "@polkadot/x-textencoder": 10.1.7
+    "@babel/runtime": ^7.19.0
+    "@polkadot/x-bigint": 10.1.8
+    "@polkadot/x-global": 10.1.8
+    "@polkadot/x-textdecoder": 10.1.8
+    "@polkadot/x-textencoder": 10.1.8
     "@types/bn.js": ^5.1.1
     bn.js: ^5.2.1
-  checksum: 7366bf739324f1e1130f6cb802b05b15c43201c50548dac58931323ca1c67450fe0d438e1e0318b898843a8939dccf43241cbc741b098f0de292909068bc15a1
+  checksum: ab908bb7cf0e7dd77b2f246234174640415f11f3ebef322097c5fca7c5ae87409b7b77e3b4200311509c77b883ee69bfb622a24540a5116c6443e51ee9382945
   languageName: node
   linkType: hard
 
@@ -2131,76 +2131,76 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@polkadot/x-bigint@npm:10.1.7, @polkadot/x-bigint@npm:^10.1.7":
-  version: 10.1.7
-  resolution: "@polkadot/x-bigint@npm:10.1.7"
+"@polkadot/x-bigint@npm:10.1.8, @polkadot/x-bigint@npm:^10.1.8":
+  version: 10.1.8
+  resolution: "@polkadot/x-bigint@npm:10.1.8"
   dependencies:
-    "@babel/runtime": ^7.18.9
-    "@polkadot/x-global": 10.1.7
-  checksum: b0594d97143c5b7226e14ab34a9be1f1531d5510d811b9ff282d0ad3d249cdef47ccc0de0db10362fcb146ce159ed0349fa4faa266d8e0ee79bee0917c78fedc
+    "@babel/runtime": ^7.19.0
+    "@polkadot/x-global": 10.1.8
+  checksum: c2ca2c90c668e2920899596bbd077d55a1417a54fa5e1fa42697373e3f18ff4e84bb7a39114b5bf5237ce0df94b6d85e9419d6409e6bd2afd36b475e62d65141
   languageName: node
   linkType: hard
 
-"@polkadot/x-fetch@npm:^10.1.7":
-  version: 10.1.7
-  resolution: "@polkadot/x-fetch@npm:10.1.7"
+"@polkadot/x-fetch@npm:^10.1.8":
+  version: 10.1.8
+  resolution: "@polkadot/x-fetch@npm:10.1.8"
   dependencies:
-    "@babel/runtime": ^7.18.9
-    "@polkadot/x-global": 10.1.7
+    "@babel/runtime": ^7.19.0
+    "@polkadot/x-global": 10.1.8
     "@types/node-fetch": ^2.6.2
     node-fetch: ^3.2.10
-  checksum: cdcfdc4ddfa705a04a17f5eb4cc800a77b2ddba100adcf0a1e0464469dee4b23f2f174d206c4404d4bed0be0714be0ebcef4a517d0e8cced8ac96f0e663b0446
+  checksum: 6fe40ecbc2b6dfe9add302a4ce5c43f290d23943d14ed7b2ea911620eb3998ae97f893ddfb59797ec911c1a4407a50c673f8aa4bec433bfb7961a1ff5cf739e2
   languageName: node
   linkType: hard
 
-"@polkadot/x-global@npm:10.1.7, @polkadot/x-global@npm:^10.1.7":
-  version: 10.1.7
-  resolution: "@polkadot/x-global@npm:10.1.7"
+"@polkadot/x-global@npm:10.1.8, @polkadot/x-global@npm:^10.1.8":
+  version: 10.1.8
+  resolution: "@polkadot/x-global@npm:10.1.8"
   dependencies:
-    "@babel/runtime": ^7.18.9
-  checksum: 834a54a58a07c58ea322433e974548415032ef1ea8a73ad48812d0d97acaf16c231cbb99d336eb020fd3e44cb5b63b98b6e9c7d51206bc8432d856d465955ffe
+    "@babel/runtime": ^7.19.0
+  checksum: e6b925cec66a0b4715c784ddd122285a8034e6a7e8d7178a0433b87abe3273950efa157dbfca860a0c0f5eac9b2b10aa916ecacbb91467dd47870c917fdac815
   languageName: node
   linkType: hard
 
-"@polkadot/x-randomvalues@npm:10.1.7":
-  version: 10.1.7
-  resolution: "@polkadot/x-randomvalues@npm:10.1.7"
+"@polkadot/x-randomvalues@npm:10.1.8":
+  version: 10.1.8
+  resolution: "@polkadot/x-randomvalues@npm:10.1.8"
   dependencies:
-    "@babel/runtime": ^7.18.9
-    "@polkadot/x-global": 10.1.7
-  checksum: adf7b0aa0f31e09ff50c3435b9cce25c616d299dc915ad0a80768500b34e853e23552dfffe3de1d0f3c4de5067cdc646ec2bd9ec169449a460849c6a45d3f034
+    "@babel/runtime": ^7.19.0
+    "@polkadot/x-global": 10.1.8
+  checksum: ae9b3a5dfb1af56c2f9855c090a3edb949cf6be35e52b160ee051283f587ef8a67f5a5918476fe7d82bc91d5a02710f8dc0ad3236d46aa70f1c8b1aa7e6b976c
   languageName: node
   linkType: hard
 
-"@polkadot/x-textdecoder@npm:10.1.7":
-  version: 10.1.7
-  resolution: "@polkadot/x-textdecoder@npm:10.1.7"
+"@polkadot/x-textdecoder@npm:10.1.8":
+  version: 10.1.8
+  resolution: "@polkadot/x-textdecoder@npm:10.1.8"
   dependencies:
-    "@babel/runtime": ^7.18.9
-    "@polkadot/x-global": 10.1.7
-  checksum: 0bfb41b21b2a6bdb4bbb4735b28d26c192d9d627895c716b08b547bd381a81f10e686760fdba15a5fbf5a81468de44bd8f4265c7abf4b38cea0f3db6234193f8
+    "@babel/runtime": ^7.19.0
+    "@polkadot/x-global": 10.1.8
+  checksum: c47ad72d50324840bd48e365b2983e374ae84372511c3dd2680781571d04375eefc96a96446438103837ab85cffa735f1fa8ea55e0aa7748cfd7c266a9789ce1
   languageName: node
   linkType: hard
 
-"@polkadot/x-textencoder@npm:10.1.7":
-  version: 10.1.7
-  resolution: "@polkadot/x-textencoder@npm:10.1.7"
+"@polkadot/x-textencoder@npm:10.1.8":
+  version: 10.1.8
+  resolution: "@polkadot/x-textencoder@npm:10.1.8"
   dependencies:
-    "@babel/runtime": ^7.18.9
-    "@polkadot/x-global": 10.1.7
-  checksum: d3cf39eac294c86ebf960ac740bac01ff79f998b92195e3ffa4d7d46d81790cd0e3cab88b255d4533d5631f8e28caa7faa075bc4ff2f151b2ebf6395daf59100
+    "@babel/runtime": ^7.19.0
+    "@polkadot/x-global": 10.1.8
+  checksum: 5c82e3e1445a4afb2a4c40560f191be245efe10c7fd90930eee20cb9be59bf11f0abe178eeeb455e9d11292a546414688f3f1cc3dcfe5539d8fc8ffc8d4df14c
   languageName: node
   linkType: hard
 
-"@polkadot/x-ws@npm:^10.1.7":
-  version: 10.1.7
-  resolution: "@polkadot/x-ws@npm:10.1.7"
+"@polkadot/x-ws@npm:^10.1.8":
+  version: 10.1.8
+  resolution: "@polkadot/x-ws@npm:10.1.8"
   dependencies:
-    "@babel/runtime": ^7.18.9
-    "@polkadot/x-global": 10.1.7
+    "@babel/runtime": ^7.19.0
+    "@polkadot/x-global": 10.1.8
     "@types/websocket": ^1.0.5
     websocket: ^1.0.34
-  checksum: 49134fc2eafb3002d44743a3513c0f91b4023edb4cd95ddda23038bc43903abd3f3f6ead17cadb7a79269645369de9acd62fdbddb1a64adbcfab141b456cdead
+  checksum: 522d045c9ddb2399484421bd1af97a3ccb866a7fc34717dc509d061ca24bfcc27d1bc69fa4ef1df1bf70d5cbaf6de55f18ee570a9e13077c0730a935ba31def0
   languageName: node
   linkType: hard
 
@@ -2236,14 +2236,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@substrate/connect@npm:0.7.11":
-  version: 0.7.11
-  resolution: "@substrate/connect@npm:0.7.11"
+"@substrate/connect@npm:0.7.13":
+  version: 0.7.13
+  resolution: "@substrate/connect@npm:0.7.13"
   dependencies:
     "@substrate/connect-extension-protocol": ^1.0.1
-    "@substrate/smoldot-light": 0.6.30
+    "@substrate/smoldot-light": 0.6.33
     eventemitter3: ^4.0.7
-  checksum: 5964228c9aab54ffd8d2c7ea746e3ef87c8901589c35dd7ceda2099f7d865f8fb545a53d7cad980af94c7b5e30b718a9d1e14087396e0a35542c1fbaa145ef41
+  checksum: b0589f8bf39d64881da5d0b9150dc0956c59f5f8c2f39cf7a9dd022f903611de2e196971c2a2dde9ee804ce29ef7fe693368f3d5ef5df1b69c6f97115a942117
   languageName: node
   linkType: hard
 
@@ -2276,20 +2276,20 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@substrate/smoldot-light@npm:0.6.30":
-  version: 0.6.30
-  resolution: "@substrate/smoldot-light@npm:0.6.30"
+"@substrate/smoldot-light@npm:0.6.33":
+  version: 0.6.33
+  resolution: "@substrate/smoldot-light@npm:0.6.33"
   dependencies:
     pako: ^2.0.4
     ws: ^8.8.1
-  checksum: 2942e4cacc685522f58f0747007271872debc8249090e037f63c162aa0d26fa65a2bcb763b786c33f299e11270d27c809afd4a87773ec78417b0ddc388791a99
+  checksum: 9e1f011bdd97c6547fa93227de5701b4eeea738963574b959ee035f5f98f29270b48fb29ca2ab985daaac49a6d6dbdcdfe13606006a5d655dea7b34502a2123f
   languageName: node
   linkType: hard
 
-"@substrate/ss58-registry@npm:^1.28.0":
-  version: 1.28.0
-  resolution: "@substrate/ss58-registry@npm:1.28.0"
-  checksum: 7fe9a4cb4d56ed65b8fea8ff63b0e82683c980523c8f8f4cc543a3fc19a9a04a70cd26097ac243f344b8c4fd710dc1e1b47c234046b79faf10d33ba81e8d0639
+"@substrate/ss58-registry@npm:^1.29.0":
+  version: 1.29.0
+  resolution: "@substrate/ss58-registry@npm:1.29.0"
+  checksum: 75993e5d3cace064adfb7b7e35ed567be674e786c0b111ef199ebfa9eec84c8457e3b3d20046fc8af3b4cc2267ae1bddfc6f6e854ddc5de66f7008332a8b4071
   languageName: node
   linkType: hard
 
@@ -2297,8 +2297,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@substrate/txwrapper-core@workspace:packages/txwrapper-core"
   dependencies:
-    "@polkadot/api": 9.3.3
-    "@polkadot/keyring": 10.1.7
+    "@polkadot/api": 9.4.1
+    "@polkadot/keyring": 10.1.8
     "@substrate/txwrapper-dev": ^3.2.2
     "@types/memoizee": ^0.4.3
     memoizee: 0.4.15
@@ -2317,7 +2317,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@substrate/txwrapper-examples@workspace:packages/txwrapper-examples"
   dependencies:
-    "@polkadot/api": 9.3.3
+    "@polkadot/api": 9.4.1
     "@substrate/txwrapper-polkadot": ^3.2.2
     "@substrate/txwrapper-registry": ^3.2.2
   languageName: unknown
@@ -2347,7 +2347,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@substrate/txwrapper-registry@workspace:packages/txwrapper-registry"
   dependencies:
-    "@polkadot/networks": 10.1.7
+    "@polkadot/networks": 10.1.8
     "@substrate/txwrapper-core": ^3.2.2
   languageName: unknown
   linkType: soft
@@ -9461,11 +9461,11 @@ fsevents@^2.3.2:
 
 "typescript@patch:typescript@^4.8.2#~builtin<compat/typescript>":
   version: 4.8.3
-  resolution: "typescript@patch:typescript@npm%3A4.8.3#~builtin<compat/typescript>::version=4.8.3&hash=f456af"
+  resolution: "typescript@patch:typescript@npm%3A4.8.3#~builtin<compat/typescript>::version=4.8.3&hash=a1c5e5"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 0404a09c625df01934ef774b45ce1ca57ccae41cd625fcdbb82056715320d9329e70d9d75c2c732ec6ef947444ca978c189a332b71fa21f5c1437d5a83e24906
+  checksum: 2222d2382fb3146089b1d27ce2b55e9d1f99cc64118f1aba75809b693b856c5d3c324f052f60c75b577947fc538bc1c27bad0eb76cbdba9a63a253489504ba7e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
The following dependencies were updated :
```
"@polkadot/api": "9.4.1",
"@polkadot/keyring": "10.1.8",
"@polkadot/networks": "10.1.8",
```
