### PR TITLE
ci: reorganize the ci tests

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: '16.13'
-      
+
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
         run: echo "::set-output name=dir::$(yarn config get cacheFolder)"
@@ -35,7 +35,7 @@ jobs:
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
             ${{ runner.os }}-yarn-
-      
+
       - name: Install JS dependencies
         run: yarn install
 
@@ -100,7 +100,6 @@ jobs:
 
       - name: Install JS dependencies
         run: yarn install
-        
+
       - name: Build
         run: yarn build
-        

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -103,3 +103,4 @@ jobs:
         
       - name: Build
         run: yarn build
+        

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -11,12 +11,41 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
-jobs:
-  check:
-    # The type of runner that the job will run on
+jobs:  
+  lint:
     runs-on: ubuntu-latest
 
-    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      - name: Checkout files
+        uses: actions/checkout@v3
+
+      - name: Install Node v16
+        uses: actions/setup-node@v3
+        with:
+          node-version: '16.13'
+      
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn config get cacheFolder)"
+
+      - uses: actions/cache@v3
+        id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+      
+      - name: Install JS dependencies
+        run: yarn install
+
+      - name: Linter.
+        run: yarn lint:ci
+
+  tests:
+      # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
     steps:
       - name: Checkout files
         uses: actions/checkout@v3
@@ -37,15 +66,40 @@ jobs:
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
             ${{ runner.os }}-yarn-
-      
+
       - name: Install JS dependencies
-        run: yarn dedupe
-        
-      - name: Build.
-        run: yarn build
-        
-      - name: Linter.
-        run: yarn lint:ci
-        
+        run: yarn install
+
       - name: Unit tests.
-        run: yarn test
+        run: yarn test:ci
+
+  build:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout files
+        uses: actions/checkout@v3
+
+      - name: Install Node v16
+        uses: actions/setup-node@v3
+        with:
+          node-version: '16.13'
+
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn config get cacheFolder)"
+
+      - uses: actions/cache@v3
+        id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+
+      - name: Install JS dependencies
+        run: yarn install
+        
+      - name: Build
+        run: yarn build

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -17,7 +17,7 @@
 # - The latest matching rule, if multiple, takes precedence.
 
 # main codeowner @paritytech/tools-team
-* @paritytech/tools-team
+* @paritytech/integrations-tools-js-ts
 
 # CI
-/.github/ @paritytech/ci @paritytech/tools-team
+/.github/ @paritytech/ci @paritytech/integrations-tools-js-ts

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "test": "substrate-exec-jest",
     "test:watch": "substrate-exec-jest --watch",
     "test:cov": "substrate-exec-jest --coverage",
+    "test:ci": "NODE_ENV=test substrate-exec-jest --runInBand",
     "docs": "typedoc --gitRemote origin",
     "update-pjs-deps": "substrate-update-pjs-deps"
   },


### PR DESCRIPTION
This PR changes the CI tests to be more organized, and split up. Therefore if one test fails we dont need to run all the tests. 

Also changes the team associated with the repo