### PR TITLE
fix: add detectOpenHandles flag in tests (jest)

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
-        run: echo "dir::$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
+        run: echo "dir=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
 
       - uses: actions/cache@v3
         id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
@@ -57,7 +57,7 @@ jobs:
 
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
-        run: echo "dir::$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
+        run: echo "dir=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
 
       - uses: actions/cache@v3
         id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
@@ -88,7 +88,7 @@ jobs:
 
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
-        run: echo "dir::$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
+        run: echo "dir=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
 
       - uses: actions/cache@v3
         id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn config get cacheFolder)"
+        run: echo "dir::$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
 
       - uses: actions/cache@v3
         id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
@@ -57,7 +57,7 @@ jobs:
 
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn config get cacheFolder)"
+        run: echo "dir::$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
 
       - uses: actions/cache@v3
         id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
@@ -88,7 +88,7 @@ jobs:
 
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn config get cacheFolder)"
+        run: echo "dir::$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
 
       - uses: actions/cache@v3
         id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)

--- a/package.json
+++ b/package.json
@@ -15,10 +15,10 @@
     "build:workspace": "substrate-exec-rimraf $INIT_CWD/lib/ && cd $INIT_CWD && tsc -p tsconfig.build.json",
     "lint": "substrate-dev-run-lint --fix",
     "lint:ci": "substrate-dev-run-lint",
-    "test": "substrate-exec-jest",
+    "test": "substrate-exec-jest --detectOpenHandles",
     "test:watch": "substrate-exec-jest --watch",
-    "test:cov": "substrate-exec-jest --coverage",
-    "test:ci": "NODE_ENV=test substrate-exec-jest --runInBand",
+    "test:cov": "substrate-exec-jest --detectOpenHandles --coverage",
+    "test:ci": "NODE_ENV=test substrate-exec-jest --detectOpenHandles --runInBand",
     "docs": "typedoc --gitRemote origin"
   },
   "devDependencies": {


### PR DESCRIPTION
### Issue
While running the tests with the command `yarn run test` I got this message at the end : 
```
A worker process has failed to exit gracefully and has been force exited. This is likely caused by tests leaking due to improper teardown. Try running with --detectOpenHandles to find leaks. Active timers can also cause this, ensure that .unref() was called on them.
```

### Solution
So I added the suggested `--detectOpenHandles` option to the jest's related scripts in `package.json` file. I then run the tests again and the message is no longer appearing. 