### PR TITLE
fix: adjust memoization and cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ For example, those looking to construct a transaction offline on Polkadot would 
 
 #### Non-published
 
+- [@substrate/txwrapper-dev](/packages/txwrapper-dev/README.md) Exported development helpers such as registries and metadata.
 - [@substrate/txwrapper-example](/packages/txwrapper-examples/README.md) Usage examples including how to construct, sign, and decode an extrinsic with @substrate/txwrapper-polkadot.
 - [@substrate/txwrapper-template](/packages/txwrapper-template/README.md) Template package for chain builders.
 

--- a/packages/txwrapper-core/README.md
+++ b/packages/txwrapper-core/README.md
@@ -21,15 +21,39 @@
 yarn add @substrate/txwrapper-core
 ```
 
-In a JS/TS index file of package:
-
-```typescript
-import { methods as ORMLMethods } from '@substrate/txwrapper-orml';
-
-// Export methods of pallets included in the chain's runtime.
-export const methods = {
-	currencies: ORMLMethods.currencies,
-};
-```
-
 Have a look at the [txwrapper creation guide for chain builders](../../CHAIN_BUILDER.md) to see more guidance on how to use this package to build a chain specific txwrapper.
+
+## Env Variables
+
+This is a list of env variables that are used inside of txwrapper-core.
+
+
+### `createMetadata` specific env vars.
+
+**Summary**: 
+`createMetadata` memoizes the call to ensure metadata is not reallocated in memory if it is the same call.
+
+Methods that actively use `createMetadata` and are affected are:
+- `defineMethod`
+- `createDecoratedTx`
+- `createDecoratedConstants`
+- `createSignedTx`
+- `decodeSignedTx`
+- `decodeSigningPayload`
+- `decodeUnsignedTx`
+
+NOTE: `getRegistryBase` uses `createMetadataUnmemoized`
+
+#### `TXWRAPPER_METADATA_CACHE_MAX`
+
+**Summary**: 
+Set the max amount of memoized calls we want in the cache. It uses an LRU cache to handle the input and output of values. This takes in an integer. Ex: `export TXWRAPPER_METADATA_CACHE_MAX=10`. This will default to unlimited size if the value is not inputted.
+
+NOTES: 
+
+- It is recommended to use a value greater 2 for the cache size as regressions have been seen in some cases for 2 or lower.
+
+#### `TXWRAPPER_METADATA_CACHE_MAX`
+
+**Summary**:
+Set the TTL (Time To Live) for items in the memoized cache. This takes in an integer in the measurement of milliseconds. Ex: `export TXWRAPPER_METADATA_CACHE_MAX=1000` for 1 second.

--- a/packages/txwrapper-core/src/core/metadata/createMetadata.ts
+++ b/packages/txwrapper-core/src/core/metadata/createMetadata.ts
@@ -51,11 +51,11 @@ export function createMetadataUnmemoized(
  * @param asCallsOnlyArg - Option to decreases the metadata to calls only
  */
 export const createMetadata = memoizee(createMetadataUnmemoized, {
-	length: 3,
-	max: process.env.METADATA_CACHE_MAX
-		? parseInt(process.env.METADATA_CACHE_MAX)
+	length: 4,
+	max: process.env.TXWRAPPER_METADATA_CACHE_MAX
+		? parseInt(process.env.TXWRAPPER_METADATA_CACHE_MAX)
 		: undefined,
-	maxAge: process.env.METADATA_CACHE_MAX_AGE
-		? parseInt(process.env.METADATA_CACHE_MAX_AGE)
+	maxAge: process.env.TXWRAPPER_METADATA_CACHE_MAX_AGE
+		? parseInt(process.env.TXWRAPPER_METADATA_CACHE_MAX_AGE)
 		: undefined,
 });

--- a/packages/txwrapper-core/src/core/metadata/createMetadata.ts
+++ b/packages/txwrapper-core/src/core/metadata/createMetadata.ts
@@ -52,4 +52,10 @@ export function createMetadataUnmemoized(
  */
 export const createMetadata = memoizee(createMetadataUnmemoized, {
 	length: 3,
+	max: process.env.METADATA_CACHE_MAX
+		? parseInt(process.env.METADATA_CACHE_MAX)
+		: undefined,
+	maxAge: process.env.METADATA_CACHE_MAX_AGE
+		? parseInt(process.env.METADATA_CACHE_MAX_AGE)
+		: undefined,
 });

--- a/packages/txwrapper-core/src/core/metadata/getRegistryBase.ts
+++ b/packages/txwrapper-core/src/core/metadata/getRegistryBase.ts
@@ -7,7 +7,7 @@ import {
 } from '@polkadot/types/types';
 
 import { ChainProperties } from '../../types';
-import { createMetadata } from './createMetadata';
+import { createMetadataUnmemoized } from './createMetadata';
 
 export interface GetRegistryBaseArgs {
 	/**
@@ -58,8 +58,7 @@ export function getRegistryBase({
 	additionalTypes,
 }: GetRegistryBaseArgs): TypeRegistry {
 	const registry = new TypeRegistry();
-
-	const generatedMetadata = createMetadata(
+	const generatedMetadata = createMetadataUnmemoized(
 		registry,
 		metadataRpc,
 		asCallsOnlyArg


### PR DESCRIPTION
### `createMetadata` specific env vars.

**Summary**: 
`createMetadata` memoizes the call to ensure metadata is not reallocated in memory if it is the same call.

Methods that actively use `createMetadata` and are affected are:
- `defineMethod`
- `createDecoratedTx`
- `createDecoratedConstants`
- `createSignedTx`
- `decodeSignedTx`
- `decodeSigningPayload`
- `decodeUnsignedTx`

NOTE: `getRegistryBase` uses `createMetadataUnmemoized`

#### `TXWRAPPER_METADATA_CACHE_MAX`

**Summary**: 
Set the max amount of memoized calls we want in the cache. It uses an LRU cache to handle the input and output of values. This takes in an integer. Ex: `export TXWRAPPER_METADATA_CACHE_MAX=10`. This will default to unlimited size if the value is not inputted.

NOTES: 

- It is recommended to use a value greater 2 for the cache size as regressions have been seen in some cases for 2 or lower.

#### `TXWRAPPER_METADATA_CACHE_MAX`

**Summary**:
Set the TTL (Time To Live) for items in the memoized cache. This takes in an integer in the measurement of milliseconds. Ex: `export TXWRAPPER_METADATA_CACHE_MAX=1000` for 1 second.

## Other Changes

- `getRegistryBase` uses `createMetadataUnmemoized` instead of `createMetadata`