### PR TITLE
fix: safer process.env access

### DIFF
--- a/packages/txwrapper-core/src/core/metadata/createMetadata.ts
+++ b/packages/txwrapper-core/src/core/metadata/createMetadata.ts
@@ -1,6 +1,7 @@
 import { Metadata } from '@polkadot/types';
 import { TypeRegistry } from '@polkadot/types';
 import { MetadataVersioned } from '@polkadot/types/metadata/MetadataVersioned';
+import { isBrowser } from '../util';
 import memoizee from 'memoizee';
 
 import { toSpecifiedCallsOnlyV14 } from './toSpecifiedCallsOnlyV14';
@@ -52,10 +53,14 @@ export function createMetadataUnmemoized(
  */
 export const createMetadata = memoizee(createMetadataUnmemoized, {
 	length: 4,
-	max: process.env.TXWRAPPER_METADATA_CACHE_MAX
-		? parseInt(process.env.TXWRAPPER_METADATA_CACHE_MAX)
-		: undefined,
-	maxAge: process.env.TXWRAPPER_METADATA_CACHE_MAX_AGE
-		? parseInt(process.env.TXWRAPPER_METADATA_CACHE_MAX_AGE)
-		: undefined,
+	max:
+		!isBrowser &&
+		typeof process?.env?.TXWRAPPER_METADATA_CACHE_MAX !== 'undefined'
+			? parseInt(process.env.TXWRAPPER_METADATA_CACHE_MAX)
+			: undefined,
+	maxAge:
+		!isBrowser &&
+		typeof process?.env?.TXWRAPPER_METADATA_CACHE_MAX_AGE !== 'undefined'
+			? parseInt(process.env.TXWRAPPER_METADATA_CACHE_MAX_AGE)
+			: undefined,
 });

--- a/packages/txwrapper-core/src/core/metadata/createMetadata.ts
+++ b/packages/txwrapper-core/src/core/metadata/createMetadata.ts
@@ -1,9 +1,9 @@
 import { Metadata } from '@polkadot/types';
 import { TypeRegistry } from '@polkadot/types';
 import { MetadataVersioned } from '@polkadot/types/metadata/MetadataVersioned';
-import { isBrowser } from '../util';
 import memoizee from 'memoizee';
 
+import { isBrowser } from '../util';
 import { toSpecifiedCallsOnlyV14 } from './toSpecifiedCallsOnlyV14';
 
 /**

--- a/packages/txwrapper-core/src/core/util/index.ts
+++ b/packages/txwrapper-core/src/core/util/index.ts
@@ -1,3 +1,4 @@
 export * from './deriveAddress';
 export * from './importPrivateKey';
+export * from './isBrowser';
 export * from './polkadotss58Format';

--- a/packages/txwrapper-core/src/core/util/isBrowser.ts
+++ b/packages/txwrapper-core/src/core/util/isBrowser.ts
@@ -1,0 +1,1 @@
+export const isBrowser = typeof window !== 'undefined';

--- a/packages/txwrapper-registry/src/index.ts
+++ b/packages/txwrapper-registry/src/index.ts
@@ -8,6 +8,7 @@ import {
 	ChainProperties,
 	getRegistryBase,
 	GetRegistryOptsCore,
+	isBrowser,
 } from '@substrate/txwrapper-core';
 import fs from 'fs';
 
@@ -68,7 +69,9 @@ function parseTypesBundle(
 }
 
 const envTypesBundle: OverrideBundleType | undefined = parseTypesBundle(
-	process.env.TX_TYPES_BUNDLE
+	!isBrowser && typeof process?.env?.TX_TYPES_BUNDLE !== 'undefined'
+		? process.env.TX_TYPES_BUNDLE
+		: undefined
 );
 
 /**


### PR DESCRIPTION
We use `@substrate/txwrapper-core` for some tx operations in the Talisman wallet.

As of https://github.com/paritytech/txwrapper-core/pull/298, this package now throws `Uncaught ReferenceError: process is not defined` because `process.env` is injected by node, but not by browsers.
Since the environment variables used by this package are all optional, I figured a neat solution might be to just safeguard the process.env access.