### PR TITLE
fix(txwrapper-dev): fix `tokenDecimals` & `ss58Format` values of westend registry

### DIFF
--- a/packages/txwrapper-dev/src/registries/westendRegistry.ts
+++ b/packages/txwrapper-dev/src/registries/westendRegistry.ts
@@ -16,8 +16,8 @@ export function getRegistryWestend(
 ): TypeRegistry {
 	return mockGetRegistryBase({
 		chainProperties: {
-			ss58Format: 0,
-			tokenDecimals: 10,
+			ss58Format: 42,
+			tokenDecimals: 12,
 			tokenSymbol: 'WND',
 		},
 		specTypes: getSpecTypes(


### PR DESCRIPTION
This change is based on my understanding on the information outlined in the following resource: https://wiki.polkadot.network/docs/learn-DOT#getting-tokens-on-the-westend-testnet.