### PR TITLE
fix(txwrapper-substrate): export balances.transferAllowDeath

### DIFF
--- a/packages/txwrapper-substrate/src/methods/balances/index.ts
+++ b/packages/txwrapper-substrate/src/methods/balances/index.ts
@@ -1,3 +1,4 @@
 export * from './transfer';
 export * from './transferAll';
+export * from './transferAllowDeath';
 export * from './transferKeepAlive';

--- a/packages/txwrapper-substrate/src/methods/balances/transferAllowDeath.ts
+++ b/packages/txwrapper-substrate/src/methods/balances/transferAllowDeath.ts
@@ -6,7 +6,7 @@ import {
 	UnsignedTransaction,
 } from '@substrate/txwrapper-core';
 
-export interface BalancesTransferArgs extends Args {
+export interface BalancesTransferAllowDeathArgs extends Args {
 	/**
 	 * The recipient address, SS-58 encoded.
 	 */
@@ -25,7 +25,7 @@ export interface BalancesTransferArgs extends Args {
  * @param options - Registry and metadata used for constructing the method.
  */
 export function transferAllowDeath(
-	args: BalancesTransferArgs,
+	args: BalancesTransferAllowDeathArgs,
 	info: BaseTxInfo,
 	options: OptionsWithMeta
 ): UnsignedTransaction {


### PR DESCRIPTION
Export function transferAllowDeath, to be able to use it as `methods.balances.transferAllowDeath`.