### PR TITLE
feat(txwrapper-dev): export `WESTEND_SPEC_VERSION` constant

### DIFF
--- a/packages/txwrapper-dev/src/constants/constants.ts
+++ b/packages/txwrapper-dev/src/constants/constants.ts
@@ -12,7 +12,7 @@ import {
 export const KUSAMA_SPEC_VERSION = 9430;
 export const POLKADOT_SPEC_VERSION = 9430;
 const ASSET_HUB_POLKADOT_SPEC_VERSION = 9360;
-const WESTEND_SPEC_VERSION = 9430;
+export const WESTEND_SPEC_VERSION = 9430;
 
 /**
  * Base tx information common to all tested transactions


### PR DESCRIPTION
I propose this change because I intend to utilize the `getRegistryWestend` function outside this repository. I prefer to rely solely on data from the package, rather than creating a separate constant in my project.
