### PR TITLE
feat(txwrapper-polkadot): Add limited xcm calls for reserve and teleport

### DIFF
--- a/packages/txwrapper-polkadot/src/methods/xcmPallet/index.ts
+++ b/packages/txwrapper-polkadot/src/methods/xcmPallet/index.ts
@@ -1,2 +1,3 @@
+export * from './limitedReserveTransferAssets';
 export * from './reserveTransferAssets';
 export * from './teleportAssets';

--- a/packages/txwrapper-polkadot/src/methods/xcmPallet/index.ts
+++ b/packages/txwrapper-polkadot/src/methods/xcmPallet/index.ts
@@ -1,3 +1,4 @@
 export * from './limitedReserveTransferAssets';
+export * from './limitedTeleportAssets';
 export * from './reserveTransferAssets';
 export * from './teleportAssets';

--- a/packages/txwrapper-polkadot/src/methods/xcmPallet/limitedReserveTransferAssets.spec.ts
+++ b/packages/txwrapper-polkadot/src/methods/xcmPallet/limitedReserveTransferAssets.spec.ts
@@ -1,0 +1,75 @@
+import {
+	itHasCorrectBaseTxInfo,
+	KUSAMA_TEST_OPTIONS,
+	TEST_BASE_TX_INFO,
+} from '@substrate/txwrapper-dev';
+
+import { TEST_METHOD_ARGS } from '../../test-helpers';
+import { limitedReserveTransferAssets } from './limitedReserveTransferAssets';
+
+describe('xcmPallet::reserveTransferAssets', () => {
+	it('Should work for xcm V2', () => {
+		const unsigned = limitedReserveTransferAssets(
+			Object.assign(TEST_METHOD_ARGS.xcmPallet.V2, {
+				weightLimit: { Unlimited: null },
+			}),
+			TEST_BASE_TX_INFO,
+			KUSAMA_TEST_OPTIONS
+		);
+
+		itHasCorrectBaseTxInfo(unsigned);
+
+		expect(unsigned.method).toBe(
+			'0x63080101000100010100f5d5714c084c112843aca74f8c498da06cc5a2d63153b825189baa51043b1f0b01040001000091010000000000'
+		);
+	});
+	it('Should work with a real weightLimit for xcm V2', () => {
+		const unsigned = limitedReserveTransferAssets(
+			Object.assign(TEST_METHOD_ARGS.xcmPallet.V2, {
+				weightLimit: {
+					Limited: { refTime: '10000000', proofSize: '100000000' },
+				},
+			}),
+			TEST_BASE_TX_INFO,
+			KUSAMA_TEST_OPTIONS
+		);
+
+		itHasCorrectBaseTxInfo(unsigned);
+
+		expect(unsigned.method).toBe(
+			'0x63080101000100010100f5d5714c084c112843aca74f8c498da06cc5a2d63153b825189baa51043b1f0b01040001000091010000000001025a62020284d717'
+		);
+	});
+	it('Should work for xcm V3', () => {
+		const unsigned = limitedReserveTransferAssets(
+			Object.assign(TEST_METHOD_ARGS.xcmPallet.V3, {
+				weightLimit: { Unlimited: null },
+			}),
+			TEST_BASE_TX_INFO,
+			KUSAMA_TEST_OPTIONS
+		);
+
+		itHasCorrectBaseTxInfo(unsigned);
+
+		expect(unsigned.method).toBe(
+			'0x63080301000300010100f5d5714c084c112843aca74f8c498da06cc5a2d63153b825189baa51043b1f0b03040001000091010000000000'
+		);
+	});
+	it('Should work with a real weightLimit for xcm V3', () => {
+		const unsigned = limitedReserveTransferAssets(
+			Object.assign(TEST_METHOD_ARGS.xcmPallet.V3, {
+				weightLimit: {
+					Limited: { refTime: '10000000', proofSize: '100000000' },
+				},
+			}),
+			TEST_BASE_TX_INFO,
+			KUSAMA_TEST_OPTIONS
+		);
+
+		itHasCorrectBaseTxInfo(unsigned);
+
+		expect(unsigned.method).toBe(
+			'0x63080301000300010100f5d5714c084c112843aca74f8c498da06cc5a2d63153b825189baa51043b1f0b03040001000091010000000001025a62020284d717'
+		);
+	});
+});

--- a/packages/txwrapper-polkadot/src/methods/xcmPallet/limitedReserveTransferAssets.ts
+++ b/packages/txwrapper-polkadot/src/methods/xcmPallet/limitedReserveTransferAssets.ts
@@ -1,0 +1,40 @@
+import {
+	BaseTxInfo,
+	defineMethod,
+	OptionsWithMeta,
+	UnsignedTransaction,
+} from '@substrate/txwrapper-core';
+
+import { LimitedXcmAssetArgs } from './types';
+
+export type XcmLimitedReserveTransferAssets = LimitedXcmAssetArgs;
+
+/**
+ * Transfer some assets from the local chain to the sovereign account of a destination
+ * chain and forward a notification XCM.
+ *
+ * Fee payment on the destination side is made from the asset in the `assets` vector of
+ * index `fee_asset_item`. The weight limit for fees is not provided and thus is unlimited,
+ * with all fees taken as needed from the asset.
+ *
+ * @param args - Arguments specific to this method.
+ * @param info - Information required to construct the transaction.
+ * @param options - Registry and metadata used for constructing the method.
+ */
+export function limitedReserveTransferAssets(
+	args: XcmLimitedReserveTransferAssets,
+	info: BaseTxInfo,
+	options: OptionsWithMeta
+): UnsignedTransaction {
+	return defineMethod(
+		{
+			method: {
+				args,
+				name: 'limitedReserveTransferAssets',
+				pallet: 'xcmPallet',
+			},
+			...info,
+		},
+		options
+	);
+}

--- a/packages/txwrapper-polkadot/src/methods/xcmPallet/limitedTeleportAssets.spec.ts
+++ b/packages/txwrapper-polkadot/src/methods/xcmPallet/limitedTeleportAssets.spec.ts
@@ -5,11 +5,11 @@ import {
 } from '@substrate/txwrapper-dev';
 
 import { TEST_METHOD_ARGS } from '../../test-helpers';
-import { limitedReserveTransferAssets } from './limitedReserveTransferAssets';
+import { limitedTeleportAssets } from './limitedTeleportAssets';
 
-describe('xcmPallet::limitedReserveTransferAssets', () => {
+describe('xcmPallet::limitedTeleportAssets', () => {
 	it('Should work for xcm V2', () => {
-		const unsigned = limitedReserveTransferAssets(
+		const unsigned = limitedTeleportAssets(
 			Object.assign(TEST_METHOD_ARGS.xcmPallet.V2, {
 				weightLimit: { Unlimited: null },
 			}),
@@ -20,11 +20,11 @@ describe('xcmPallet::limitedReserveTransferAssets', () => {
 		itHasCorrectBaseTxInfo(unsigned);
 
 		expect(unsigned.method).toBe(
-			'0x63080101000100010100f5d5714c084c112843aca74f8c498da06cc5a2d63153b825189baa51043b1f0b01040001000091010000000000'
+			'0x63090101000100010100f5d5714c084c112843aca74f8c498da06cc5a2d63153b825189baa51043b1f0b01040001000091010000000000'
 		);
 	});
 	it('Should work with a real weightLimit for xcm V2', () => {
-		const unsigned = limitedReserveTransferAssets(
+		const unsigned = limitedTeleportAssets(
 			Object.assign(TEST_METHOD_ARGS.xcmPallet.V2, {
 				weightLimit: {
 					Limited: { refTime: '10000000', proofSize: '100000000' },
@@ -37,11 +37,11 @@ describe('xcmPallet::limitedReserveTransferAssets', () => {
 		itHasCorrectBaseTxInfo(unsigned);
 
 		expect(unsigned.method).toBe(
-			'0x63080101000100010100f5d5714c084c112843aca74f8c498da06cc5a2d63153b825189baa51043b1f0b01040001000091010000000001025a62020284d717'
+			'0x63090101000100010100f5d5714c084c112843aca74f8c498da06cc5a2d63153b825189baa51043b1f0b01040001000091010000000001025a62020284d717'
 		);
 	});
 	it('Should work for xcm V3', () => {
-		const unsigned = limitedReserveTransferAssets(
+		const unsigned = limitedTeleportAssets(
 			Object.assign(TEST_METHOD_ARGS.xcmPallet.V3, {
 				weightLimit: { Unlimited: null },
 			}),
@@ -52,11 +52,11 @@ describe('xcmPallet::limitedReserveTransferAssets', () => {
 		itHasCorrectBaseTxInfo(unsigned);
 
 		expect(unsigned.method).toBe(
-			'0x63080301000300010100f5d5714c084c112843aca74f8c498da06cc5a2d63153b825189baa51043b1f0b03040001000091010000000000'
+			'0x63090301000300010100f5d5714c084c112843aca74f8c498da06cc5a2d63153b825189baa51043b1f0b03040001000091010000000000'
 		);
 	});
 	it('Should work with a real weightLimit for xcm V3', () => {
-		const unsigned = limitedReserveTransferAssets(
+		const unsigned = limitedTeleportAssets(
 			Object.assign(TEST_METHOD_ARGS.xcmPallet.V3, {
 				weightLimit: {
 					Limited: { refTime: '10000000', proofSize: '100000000' },
@@ -69,7 +69,7 @@ describe('xcmPallet::limitedReserveTransferAssets', () => {
 		itHasCorrectBaseTxInfo(unsigned);
 
 		expect(unsigned.method).toBe(
-			'0x63080301000300010100f5d5714c084c112843aca74f8c498da06cc5a2d63153b825189baa51043b1f0b03040001000091010000000001025a62020284d717'
+			'0x63090301000300010100f5d5714c084c112843aca74f8c498da06cc5a2d63153b825189baa51043b1f0b03040001000091010000000001025a62020284d717'
 		);
 	});
 });

--- a/packages/txwrapper-polkadot/src/methods/xcmPallet/limitedTeleportAssets.ts
+++ b/packages/txwrapper-polkadot/src/methods/xcmPallet/limitedTeleportAssets.ts
@@ -7,11 +7,10 @@ import {
 
 import { LimitedXcmAssetArgs } from './types';
 
-export type XcmLimitedReserveTransferAssets = LimitedXcmAssetArgs;
+export type XcmLimitedTeleportAssets = LimitedXcmAssetArgs;
 
 /**
- * Transfer some assets from the local chain to the sovereign account of a destination
- * chain and forward a notification XCM.
+ * Teleport some assets from the local chain to some destination chain.
  *
  * Fee payment on the destination side is made from the asset in the `assets` vector of
  * index `fee_asset_item`, up to enough to pay for `weight_limit` of weight. If more weight
@@ -22,8 +21,8 @@ export type XcmLimitedReserveTransferAssets = LimitedXcmAssetArgs;
  * @param info - Information required to construct the transaction.
  * @param options - Registry and metadata used for constructing the method.
  */
-export function limitedReserveTransferAssets(
-	args: XcmLimitedReserveTransferAssets,
+export function limitedTeleportAssets(
+	args: XcmLimitedTeleportAssets,
 	info: BaseTxInfo,
 	options: OptionsWithMeta
 ): UnsignedTransaction {
@@ -31,7 +30,7 @@ export function limitedReserveTransferAssets(
 		{
 			method: {
 				args,
-				name: 'limitedReserveTransferAssets',
+				name: 'limitedTeleportAssets',
 				pallet: 'xcmPallet',
 			},
 			...info,

--- a/packages/txwrapper-polkadot/src/methods/xcmPallet/types.ts
+++ b/packages/txwrapper-polkadot/src/methods/xcmPallet/types.ts
@@ -23,3 +23,12 @@ export interface XcmBaseAssetArgs extends Args {
 	 */
 	feeAssetItem: number;
 }
+
+export interface LimitedXcmAssetArgs extends XcmBaseAssetArgs {
+	/**
+	 * The remote-side weight limit, if any, for the XCM fee purchase.
+	 */
+	weightLimit:
+		| { Limited: { refTime: string; proofSize: string } }
+		| { Unlimited: null };
+}


### PR DESCRIPTION
This adds the two following calls: 

```
limitedTeleportAssets
limitedReserveTransferAssets
```