### PR TITLE
fix(deps): bumped `typedoc` to `v0.25.9` 

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "test:watch": "substrate-exec-jest --watch",
     "test:cov": "substrate-exec-jest --detectOpenHandles --coverage",
     "test:ci": "NODE_ENV=test substrate-exec-jest --detectOpenHandles --runInBand",
-    "docs": "typedoc --gitRemote origin"
+    "docs": "typedoc --plugin typedoc-plugin-markdown --plugin typedoc-plugin-missing-exports --theme markdown --gitRemote origin"
   },
   "devDependencies": {
     "@polkadot/util-crypto": "^12.6.2",
@@ -34,9 +34,9 @@
     "ts-jest": "^29.1.1",
     "ts-node": "^9.1.1",
     "tsconfig-paths": "^3.9.0",
-    "typedoc": "^0.22.10",
-    "typedoc-plugin-markdown": "^3.11.8",
-    "typedoc-plugin-missing-exports": "^0.22.6",
+    "typedoc": "^0.25.9",
+    "typedoc-plugin-markdown": "^3.17.1",
+    "typedoc-plugin-missing-exports": "^2.2.0",
     "typescript": "4.9.4"
   },
   "packageManager": "yarn@4.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2616,6 +2616,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ansi-sequence-parser@npm:^1.1.0":
+  version: 1.1.1
+  resolution: "ansi-sequence-parser@npm:1.1.1"
+  checksum: 10/9ce30f257badc2ef62cac8028a7e26c368d22bf26650427192e8ffd102da42e377e3affe90fae58062eecc963b0b055f510dde3b677c7e0c433c67069b5a8ee5
+  languageName: node
+  linkType: hard
+
 "ansi-styles@npm:^3.2.1":
   version: 3.2.1
   resolution: "ansi-styles@npm:3.2.1"
@@ -4636,7 +4643,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"glob@npm:^7.1.3, glob@npm:^7.1.4, glob@npm:^7.2.0":
+"glob@npm:^7.1.3, glob@npm:^7.1.4":
   version: 7.2.3
   resolution: "glob@npm:7.2.3"
   dependencies:
@@ -5912,10 +5919,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jsonc-parser@npm:3.2.0, jsonc-parser@npm:^3.0.0":
+"jsonc-parser@npm:3.2.0":
   version: 3.2.0
   resolution: "jsonc-parser@npm:3.2.0"
   checksum: 10/bd68b902e5f9394f01da97921f49c5084b2dc03a0c5b4fdb2a429f8d6f292686c1bf87badaeb0a8148d024192a88f5ad2e57b2918ba43fe25cf15f3371db64d4
+  languageName: node
+  linkType: hard
+
+"jsonc-parser@npm:^3.2.0":
+  version: 3.2.1
+  resolution: "jsonc-parser@npm:3.2.1"
+  checksum: 10/fe2df6f39e21653781d52cae20c5b9e0ab62461918d97f9430b216cea9b6500efc1d8b42c6584cc0a7548b4c996055e9cdc39f09b9782fa6957af2f45306c530
   languageName: node
   linkType: hard
 
@@ -6355,12 +6369,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"marked@npm:^3.0.8":
-  version: 3.0.8
-  resolution: "marked@npm:3.0.8"
+"marked@npm:^4.3.0":
+  version: 4.3.0
+  resolution: "marked@npm:4.3.0"
   bin:
-    marked: bin/marked
-  checksum: 10/6aaf12e3a2288809f825125c60b5091f3cdaf1ac4585ee48efe6a7874aefa2e892b2b8aa427c348b68c323c53d4f1d4780cef6f8716e003501b9d2cdbfa3e5e4
+    marked: bin/marked.js
+  checksum: 10/c830bb4cb3705b754ca342b656e8a582d7428706b2678c898b856f6030c134ce2d1e19136efa3e6a1841f7330efbd24963d6bdeddc57d2938e906250f99895d0
   languageName: node
   linkType: hard
 
@@ -8104,14 +8118,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"shiki@npm:^0.9.12":
-  version: 0.9.15
-  resolution: "shiki@npm:0.9.15"
+"shiki@npm:^0.14.7":
+  version: 0.14.7
+  resolution: "shiki@npm:0.14.7"
   dependencies:
-    jsonc-parser: "npm:^3.0.0"
-    vscode-oniguruma: "npm:^1.6.1"
-    vscode-textmate: "npm:5.2.0"
-  checksum: 10/a087224620222247aa9be92f1768eb1de15bdd227ea8137e007c3143d4f6ee40e967c34e814e85e4267c21785295ec3d3db203908e5a0327e068c33400c9a21b
+    ansi-sequence-parser: "npm:^1.1.0"
+    jsonc-parser: "npm:^3.2.0"
+    vscode-oniguruma: "npm:^1.7.0"
+    vscode-textmate: "npm:^8.0.0"
+  checksum: 10/be3f2444c65bd0c57802026f171cb42ad571d361ee885be0c292b60785f68c70f19b69310f5ffe7f7a93db4c5ef50211e0a0248794bc6bb48d242bc43fe72a62
   languageName: node
   linkType: hard
 
@@ -8835,9 +8850,9 @@ __metadata:
     ts-jest: "npm:^29.1.1"
     ts-node: "npm:^9.1.1"
     tsconfig-paths: "npm:^3.9.0"
-    typedoc: "npm:^0.22.10"
-    typedoc-plugin-markdown: "npm:^3.11.8"
-    typedoc-plugin-missing-exports: "npm:^0.22.6"
+    typedoc: "npm:^0.25.9"
+    typedoc-plugin-markdown: "npm:^3.17.1"
+    typedoc-plugin-missing-exports: "npm:^2.2.0"
     typescript: "npm:4.9.4"
   languageName: unknown
   linkType: soft
@@ -8921,40 +8936,39 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typedoc-plugin-markdown@npm:^3.11.8":
-  version: 3.11.8
-  resolution: "typedoc-plugin-markdown@npm:3.11.8"
+"typedoc-plugin-markdown@npm:^3.17.1":
+  version: 3.17.1
+  resolution: "typedoc-plugin-markdown@npm:3.17.1"
   dependencies:
     handlebars: "npm:^4.7.7"
   peerDependencies:
-    typedoc: ">=0.22.0"
-  checksum: 10/fab5ac9e64dcb56ae5a8e24ac6830c1be888728f19d75a6d8eb5abdea9077e3009f5774a524a0005428cca4343db275e144f3fc248c2607c82242d0527c1bcfa
+    typedoc: ">=0.24.0"
+  checksum: 10/21bfe7fba60e3c27e15700196b1b4abdf5b63bfdc9a4af57cf6f0891f9d359ac561435773709c6ea3555bae402b7a81b637d055e767afd33e2c0dc717d0449d2
   languageName: node
   linkType: hard
 
-"typedoc-plugin-missing-exports@npm:^0.22.6":
-  version: 0.22.6
-  resolution: "typedoc-plugin-missing-exports@npm:0.22.6"
+"typedoc-plugin-missing-exports@npm:^2.2.0":
+  version: 2.2.0
+  resolution: "typedoc-plugin-missing-exports@npm:2.2.0"
   peerDependencies:
-    typedoc: 0.22.x
-  checksum: 10/28db717a56bac2e64016255e9f66fcccab21890776d3ec82b2486557f6902e95c6166b3f392143247c2d38f33d242e09c6ed07ce7c0ab5040498e842e5d774f0
+    typedoc: 0.24.x || 0.25.x
+  checksum: 10/db691b3494c8e112d7ea8621fcf79f1988ef8f0c9fc43eb5fc308fda0caa1b1e007c3d51db83236247cf9b52cdfec1186a7eb25ec3416fa03ef65f68b4e88e4e
   languageName: node
   linkType: hard
 
-"typedoc@npm:^0.22.10":
-  version: 0.22.10
-  resolution: "typedoc@npm:0.22.10"
+"typedoc@npm:^0.25.9":
+  version: 0.25.9
+  resolution: "typedoc@npm:0.25.9"
   dependencies:
-    glob: "npm:^7.2.0"
     lunr: "npm:^2.3.9"
-    marked: "npm:^3.0.8"
-    minimatch: "npm:^3.0.4"
-    shiki: "npm:^0.9.12"
+    marked: "npm:^4.3.0"
+    minimatch: "npm:^9.0.3"
+    shiki: "npm:^0.14.7"
   peerDependencies:
-    typescript: 4.0.x || 4.1.x || 4.2.x || 4.3.x || 4.4.x || 4.5.x
+    typescript: 4.6.x || 4.7.x || 4.8.x || 4.9.x || 5.0.x || 5.1.x || 5.2.x || 5.3.x
   bin:
     typedoc: bin/typedoc
-  checksum: 10/50bd22e83785e795437746ba3416f3a42bc7a92ff1ebecf834d47b929055b41d1407eebcddfda3b3345dfe6e02db32f9f3def583067bc5d91cf9bb18266dcca1
+  checksum: 10/537b29c919241620887833f8db3febf6f2b4abc432a11e368527bb82f0ca49a2ba65acef88a8982e01ae3382a65a07395b03164349dcb6020c3157fdbb171b70
   languageName: node
   linkType: hard
 
@@ -9162,17 +9176,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"vscode-oniguruma@npm:^1.6.1":
-  version: 1.6.1
-  resolution: "vscode-oniguruma@npm:1.6.1"
-  checksum: 10/675893a3d6f4f72229e65b38db97a0528e90a03a118c810b745fccd0eaabdd57d25632cc04181bfa615c6a7621ca886e450357ac8e332c59fcfe1fe487bb1895
+"vscode-oniguruma@npm:^1.7.0":
+  version: 1.7.0
+  resolution: "vscode-oniguruma@npm:1.7.0"
+  checksum: 10/7da9d21459f9788544b258a5fd1b9752df6edd8b406a19eea0209c6bf76507d5717277016799301c4da0d536095f9ca8c06afd1ab8f4001189090c804ca4814e
   languageName: node
   linkType: hard
 
-"vscode-textmate@npm:5.2.0":
-  version: 5.2.0
-  resolution: "vscode-textmate@npm:5.2.0"
-  checksum: 10/bb7e377ebee67ae1c62a6f5be3923d80e192572003f51c4243193bb057c727588d2300ad6aeb824da46c94d531d37310802bfbedc75f2758503ff795ad14b333
+"vscode-textmate@npm:^8.0.0":
+  version: 8.0.0
+  resolution: "vscode-textmate@npm:8.0.0"
+  checksum: 10/9fa7d66d6042cb090d116c2d8820d34c8870cfcbaed6e404da89f66b899970ed0ac47b59a2e30fc40a25af5414822bb3ea27974f714e9b91910d69c894be95f7
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This included, besides the `typedoc` upgrade, the upgrades of `typedoc-plugin-markdown` to `v3.17.1` and `typedoc-plugin-missing-exports` to `v2.2.0`.