### PR TITLE
feat: add support for `assetConversion` pallet

### DIFF
--- a/packages/txwrapper-substrate/src/methods/assetConversion/addLiquidity.spec.ts
+++ b/packages/txwrapper-substrate/src/methods/assetConversion/addLiquidity.spec.ts
@@ -1,0 +1,23 @@
+import {
+	ASSET_HUB_KUSAMA_TEST_BASE_TX_INFO,
+	ASSET_HUB_KUSAMA_TEST_OPTIONS,
+	itHasCorrectBaseTxInfo,
+} from '@substrate/txwrapper-dev';
+
+import { TEST_METHOD_ARGS } from '../../test-helpers';
+import { addLiquidity } from './addLiquidity';
+
+describe('assetsConversion:addLiqudity', () => {
+	it('should work', () => {
+		const unsigned = addLiquidity(
+			TEST_METHOD_ARGS.assetConversion.addLiquidity,
+			ASSET_HUB_KUSAMA_TEST_BASE_TX_INFO,
+			ASSET_HUB_KUSAMA_TEST_OPTIONS,
+		);
+
+		itHasCorrectBaseTxInfo(unsigned);
+		expect(unsigned.method).toBe(
+			'0x38010002043205011f000040420f0000000000000000000000000080969800000000000000000000000000e8030000000000000000000000000000e803000000000000000000000000000096074594cccf1cd185fa8a72ceaeefd86648f8d45514f3ce33c31bdd07e4655d',
+		);
+	});
+});

--- a/packages/txwrapper-substrate/src/methods/assetConversion/addLiquidity.ts
+++ b/packages/txwrapper-substrate/src/methods/assetConversion/addLiquidity.ts
@@ -1,0 +1,68 @@
+import { AnyJson } from '@polkadot/types/types';
+import {
+	Args,
+	BaseTxInfo,
+	defineMethod,
+	OptionsWithMeta,
+	UnsignedTransaction,
+} from '@substrate/txwrapper-core';
+
+export interface AddLiquidityArgs extends Args {
+	/**
+	 * The identifier of the first asset of the pool.
+	 */
+	asset1: AnyJson;
+	/**
+	 * The identifier of the second asset of the pool.
+	 */
+	asset2: AnyJson;
+	/**
+	 * Amount of the first asset willing to provide the liquidity pool with.
+	 */
+	amount1Desired: number | string;
+	/**
+	 * Amount of the second asset willing to provide the liquidity pool with.
+	 */
+	amount2Desired: number | string;
+	/**
+	 * Minimum amount of the first asset willing to provide the liquidity pool with.
+	 */
+	amount1Min: number | string;
+	/**
+	 * Minimum amount of the second asset willing to provide the liquidity pool with.
+	 */
+	amount2Min: number | string;
+	/**
+	 * Recipient of the liquidity tokens that represent this share of the pool.
+	 */
+	mintTo: string;
+}
+
+/**
+ * Provide liquidity into the pool of `asset1` and `asset2`.
+ *
+ * NOTE: an optimal amount of asset1 and asset2 will be calculated and
+ * might be different than the provided `amount1Desired`/`amount2Desired`,
+ * limited by `amount1Min`/`amount2Min`.
+ *
+ * @param args - Arguments specific to this method.
+ * @param info - Information required to construct the transaction.
+ * @param options - Registry and metadata used for constructing the method.
+ */
+export function addLiquidity(
+	args: AddLiquidityArgs,
+	info: BaseTxInfo,
+	options: OptionsWithMeta,
+): UnsignedTransaction {
+	return defineMethod(
+		{
+			method: {
+				args,
+				name: 'addLiquidity',
+				pallet: 'assetConversion',
+			},
+			...info,
+		},
+		options,
+	);
+}

--- a/packages/txwrapper-substrate/src/methods/assetConversion/createPool.spec.ts
+++ b/packages/txwrapper-substrate/src/methods/assetConversion/createPool.spec.ts
@@ -1,0 +1,21 @@
+import {
+	ASSET_HUB_KUSAMA_TEST_BASE_TX_INFO,
+	ASSET_HUB_KUSAMA_TEST_OPTIONS,
+	itHasCorrectBaseTxInfo,
+} from '@substrate/txwrapper-dev';
+
+import { TEST_METHOD_ARGS } from '../../test-helpers';
+import { createPool } from './createPool';
+
+describe('assetsConversion:createPool', () => {
+	it('should work', () => {
+		const unsigned = createPool(
+			TEST_METHOD_ARGS.assetConversion.createPool,
+			ASSET_HUB_KUSAMA_TEST_BASE_TX_INFO,
+			ASSET_HUB_KUSAMA_TEST_OPTIONS,
+		);
+
+		itHasCorrectBaseTxInfo(unsigned);
+		expect(unsigned.method).toBe('0x38000002043205011f0000');
+	});
+});

--- a/packages/txwrapper-substrate/src/methods/assetConversion/createPool.ts
+++ b/packages/txwrapper-substrate/src/methods/assetConversion/createPool.ts
@@ -1,0 +1,46 @@
+import { AnyJson } from '@polkadot/types/types';
+import {
+	Args,
+	BaseTxInfo,
+	defineMethod,
+	OptionsWithMeta,
+	UnsignedTransaction,
+} from '@substrate/txwrapper-core';
+
+export interface CreatePoolArgs extends Args {
+	/**
+	 * The identifier of the first asset of the pool.
+	 */
+	asset1: AnyJson;
+	/**
+	 * The identifier of the second asset of the pool.
+	 */
+	asset2: AnyJson;
+}
+
+/**
+ * Creates an empty liquidity pool and an associated new `lpToken` asset.
+ *
+ * Once a pool is created, someone may add liquidity to it.
+ *
+ * @param args - Arguments specific to this method.
+ * @param info - Information required to construct the transaction.
+ * @param options - Registry and metadata used for constructing the method.
+ */
+export function createPool(
+	args: CreatePoolArgs,
+	info: BaseTxInfo,
+	options: OptionsWithMeta,
+): UnsignedTransaction {
+	return defineMethod(
+		{
+			method: {
+				args,
+				name: 'createPool',
+				pallet: 'assetConversion',
+			},
+			...info,
+		},
+		options,
+	);
+}

--- a/packages/txwrapper-substrate/src/methods/assetConversion/removeLiquidity.spec.ts
+++ b/packages/txwrapper-substrate/src/methods/assetConversion/removeLiquidity.spec.ts
@@ -1,0 +1,23 @@
+import {
+	ASSET_HUB_KUSAMA_TEST_BASE_TX_INFO,
+	ASSET_HUB_KUSAMA_TEST_OPTIONS,
+	itHasCorrectBaseTxInfo,
+} from '@substrate/txwrapper-dev';
+
+import { TEST_METHOD_ARGS } from '../../test-helpers';
+import { removeLiquidity } from './removeLiquidity';
+
+describe('assetsConversion:removeLiqudity', () => {
+	it('should work', () => {
+		const unsigned = removeLiquidity(
+			TEST_METHOD_ARGS.assetConversion.removeLiquidity,
+			ASSET_HUB_KUSAMA_TEST_BASE_TX_INFO,
+			ASSET_HUB_KUSAMA_TEST_OPTIONS,
+		);
+
+		itHasCorrectBaseTxInfo(unsigned);
+		expect(unsigned.method).toBe(
+			'0x38020002043205011f00000a000000000000000000000000000000e8030000000000000000000000000000e803000000000000000000000000000096074594cccf1cd185fa8a72ceaeefd86648f8d45514f3ce33c31bdd07e4655d',
+		);
+	});
+});

--- a/packages/txwrapper-substrate/src/methods/assetConversion/removeLiquidity.ts
+++ b/packages/txwrapper-substrate/src/methods/assetConversion/removeLiquidity.ts
@@ -1,0 +1,64 @@
+import { AnyJson } from '@polkadot/types/types';
+import {
+	Args,
+	BaseTxInfo,
+	defineMethod,
+	OptionsWithMeta,
+	UnsignedTransaction,
+} from '@substrate/txwrapper-core';
+
+export interface RemoveLiquidityArgs extends Args {
+	/**
+	 * The identifier of the first asset of the pool.
+	 */
+	asset1: AnyJson;
+	/**
+	 * The identifier of the second asset of the pool.
+	 */
+	asset2: AnyJson;
+	/**
+	 * Amount of tokens of this liquidity pool that will be burned in the process.
+	 */
+	lpTokenBurn: number | string;
+	/**
+	 * Minimum amount of returned asset1 tokens you're happy with.
+	 */
+	amount1MinReceive: number | string;
+	/**
+	 * Minimum amount of returned asset2 tokens you're happy with.
+	 */
+	amount2MinReceive: number | string;
+	/**
+	 * Destination of the tokens returned after burning `lpTokenBurn` amount of liquidity pool tokens.
+	 */
+	withdrawTo: string;
+}
+
+/**
+ * Allows you to remove liquidity by providing the `lpTokenBurn` tokens that will be
+ * burned in the process.
+ *
+ * With the usage of `amount1MinReceive`/`amount2MinReceive`
+ * it's possible to control the min amount of returned tokens you're happy with.
+ *
+ * @param args - Arguments specific to this method.
+ * @param info - Information required to construct the transaction.
+ * @param options - Registry and metadata used for constructing the method.
+ */
+export function removeLiquidity(
+	args: RemoveLiquidityArgs,
+	info: BaseTxInfo,
+	options: OptionsWithMeta,
+): UnsignedTransaction {
+	return defineMethod(
+		{
+			method: {
+				args,
+				name: 'removeLiquidity',
+				pallet: 'assetConversion',
+			},
+			...info,
+		},
+		options,
+	);
+}

--- a/packages/txwrapper-substrate/src/methods/assetConversion/swapExactTokensForTokens.spec.ts
+++ b/packages/txwrapper-substrate/src/methods/assetConversion/swapExactTokensForTokens.spec.ts
@@ -1,0 +1,23 @@
+import {
+	ASSET_HUB_KUSAMA_TEST_BASE_TX_INFO,
+	ASSET_HUB_KUSAMA_TEST_OPTIONS,
+	itHasCorrectBaseTxInfo,
+} from '@substrate/txwrapper-dev';
+
+import { TEST_METHOD_ARGS } from '../../test-helpers';
+import { swapExactTokensForTokens } from './swapExactTokensForTokens';
+
+describe('assetsConversion:swapExactTokensForTokens', () => {
+	it('should work', () => {
+		const unsigned = swapExactTokensForTokens(
+			TEST_METHOD_ARGS.assetConversion.swapExactTokensForTokens,
+			ASSET_HUB_KUSAMA_TEST_BASE_TX_INFO,
+			ASSET_HUB_KUSAMA_TEST_OPTIONS,
+		);
+
+		itHasCorrectBaseTxInfo(unsigned);
+		expect(unsigned.method).toBe(
+			'0x3803080002043205011f00000a000000000000000000000000000000e803000000000000000000000000000096074594cccf1cd185fa8a72ceaeefd86648f8d45514f3ce33c31bdd07e4655d01',
+		);
+	});
+});

--- a/packages/txwrapper-substrate/src/methods/assetConversion/swapExactTokensForTokens.ts
+++ b/packages/txwrapper-substrate/src/methods/assetConversion/swapExactTokensForTokens.ts
@@ -1,0 +1,62 @@
+import { AnyJson } from '@polkadot/types/types';
+import {
+	Args,
+	BaseTxInfo,
+	defineMethod,
+	OptionsWithMeta,
+	UnsignedTransaction,
+} from '@substrate/txwrapper-core';
+
+export interface SwapExactTokensArgs extends Args {
+	/**
+	 * The path of the assets in to be swappeds, as an array of XCM `Locations`.
+	 */
+	path: AnyJson[];
+	/**
+	 * The amount of path[0] to swap for path[1].
+	 */
+	amountIn: number | string;
+	/**
+	 * Minimum amount of path[1] willing to receive after the swap.
+	 */
+	amountOutMin: number | string;
+	/**
+	 * Destination addres for the amount of path[1] tokens swapped.
+	 */
+	sendTo: number | string;
+	/**
+	 * Limit the amount of path[0] taken to keep the account from being reaped.
+	 */
+	keepAlive: boolean;
+}
+
+/**
+ * Swap exactly `amountIn` of asset `path[0]` for asset `path[1]`.
+ *
+ * If an `amountOutMin` is specified, it will return an error if it is unable to acquire
+ * the amount desired.
+ *
+ * Withdraws the `path[0]` asset from `sender`, deposits the `path[1]` asset to `sendTo`,
+ * respecting `keepAlive`.
+ *
+ * @param args - Arguments specific to this method.
+ * @param info - Information required to construct the transaction.
+ * @param options - Registry and metadata used for constructing the method.
+ */
+export function swapExactTokensForTokens(
+	args: SwapExactTokensArgs,
+	info: BaseTxInfo,
+	options: OptionsWithMeta,
+): UnsignedTransaction {
+	return defineMethod(
+		{
+			method: {
+				args,
+				name: 'swapExactTokensForTokens',
+				pallet: 'assetConversion',
+			},
+			...info,
+		},
+		options,
+	);
+}

--- a/packages/txwrapper-substrate/src/methods/assetConversion/swapTokensForExactTokens.spec.ts
+++ b/packages/txwrapper-substrate/src/methods/assetConversion/swapTokensForExactTokens.spec.ts
@@ -1,0 +1,23 @@
+import {
+	ASSET_HUB_KUSAMA_TEST_BASE_TX_INFO,
+	ASSET_HUB_KUSAMA_TEST_OPTIONS,
+	itHasCorrectBaseTxInfo,
+} from '@substrate/txwrapper-dev';
+
+import { TEST_METHOD_ARGS } from '../../test-helpers';
+import { swapTokensForExactTokens } from './swapTokensForExactTokens';
+
+describe('assetsConversion:swapTokensForExactTokens', () => {
+	it('should work', () => {
+		const unsigned = swapTokensForExactTokens(
+			TEST_METHOD_ARGS.assetConversion.swapTokensForExactTokens,
+			ASSET_HUB_KUSAMA_TEST_BASE_TX_INFO,
+			ASSET_HUB_KUSAMA_TEST_OPTIONS,
+		);
+
+		itHasCorrectBaseTxInfo(unsigned);
+		expect(unsigned.method).toBe(
+			'0x3804080002043205011f00000a000000000000000000000000000000e803000000000000000000000000000096074594cccf1cd185fa8a72ceaeefd86648f8d45514f3ce33c31bdd07e4655d01',
+		);
+	});
+});

--- a/packages/txwrapper-substrate/src/methods/assetConversion/swapTokensForExactTokens.ts
+++ b/packages/txwrapper-substrate/src/methods/assetConversion/swapTokensForExactTokens.ts
@@ -1,0 +1,62 @@
+import { AnyJson } from '@polkadot/types/types';
+import {
+	Args,
+	BaseTxInfo,
+	defineMethod,
+	OptionsWithMeta,
+	UnsignedTransaction,
+} from '@substrate/txwrapper-core';
+
+export interface SwapTokensArgs extends Args {
+	/**
+	 * The path of the assets in to be swappeds, as an array of XCM `Locations`.
+	 */
+	path: AnyJson[];
+	/**
+	 * The amount of path[1] to get from the swap.
+	 */
+	amountOut: number | string;
+	/**
+	 * Minimum amount of path[0] willing to deposit for the swap.
+	 */
+	amountInMax: number | string;
+	/**
+	 * Destination addres for the amount of path[1] tokens swapped.
+	 */
+	sendTo: number | string;
+	/**
+	 * Limit the amount of path[0] taken to keep the account from being reaped.
+	 */
+	keepAlive: boolean;
+}
+
+/**
+ * Swap asset `path[0]` for asset `path[1]` to get exactly `amountOut`.
+ *
+ * If an `amountInMax` is specified, it will return an error if acquiring `amountOut`
+ * would be too costly.
+ *
+ * Withdraws the `path[0]` asset from `sender`, deposits the `path[1]` asset to `sendTo`,
+ * respecting `keepAlive`.
+ *
+ * @param args - Arguments specific to this method.
+ * @param info - Information required to construct the transaction.
+ * @param options - Registry and metadata used for constructing the method.
+ */
+export function swapTokensForExactTokens(
+	args: SwapTokensArgs,
+	info: BaseTxInfo,
+	options: OptionsWithMeta,
+): UnsignedTransaction {
+	return defineMethod(
+		{
+			method: {
+				args,
+				name: 'swapTokensForExactTokens',
+				pallet: 'assetConversion',
+			},
+			...info,
+		},
+		options,
+	);
+}

--- a/packages/txwrapper-substrate/src/test-helpers/TEST_METHOD_ARGS.ts
+++ b/packages/txwrapper-substrate/src/test-helpers/TEST_METHOD_ARGS.ts
@@ -29,6 +29,64 @@ export const TEST_METHOD_ARGS = {
 			delegate: '14E5nqKAp3oAJcmzgZhUD2RcptBeUBScxKHgJKU4HPNcKVf3', // seed "//Bob"
 		},
 	},
+	assetConversion: {
+		createPool: {
+			asset1: {
+				parents: 0,
+				interior: { X2: [{ palletInstance: 50 }, { generalIndex: 1984 }] },
+			},
+			asset2: { parenst: 1, interior: 'Here' },
+		},
+		addLiquidity: {
+			asset1: {
+				parents: 0,
+				interior: { X2: [{ palletInstance: 50 }, { generalIndex: 1984 }] },
+			},
+			asset2: { parenst: 1, interior: 'Here' },
+			amount1Desired: 1000000,
+			amount2Desired: 10000000,
+			amount1Min: 1000,
+			amount2Min: 1000,
+			mintTo: 'Fy2rsYCoowQBtuFXqLE65ehAY9T6KWcGiNCQAyPDCkfpm4s',
+		},
+		removeLiquidity: {
+			asset1: {
+				parents: 0,
+				interior: { X2: [{ palletInstance: 50 }, { generalIndex: 1984 }] },
+			},
+			asset2: { parenst: 1, interior: 'Here' },
+			lpTokenBurn: 10,
+			amount1MinReceive: 1000,
+			amount2MinReceive: 1000,
+			withdrawTo: 'Fy2rsYCoowQBtuFXqLE65ehAY9T6KWcGiNCQAyPDCkfpm4s',
+		},
+		swapExactTokensForTokens: {
+			path: [
+				{
+					parents: 0,
+					interior: { X2: [{ palletInstance: 50 }, { generalIndex: 1984 }] },
+				},
+				{ parenst: 1, interior: 'Here' },
+			],
+			amountIn: 10,
+			amountOutMin: 1000,
+			sendTo: 'Fy2rsYCoowQBtuFXqLE65ehAY9T6KWcGiNCQAyPDCkfpm4s',
+			keepAlive: true,
+		},
+		swapTokensForExactTokens: {
+			path: [
+				{
+					parents: 0,
+					interior: { X2: [{ palletInstance: 50 }, { generalIndex: 1984 }] },
+				},
+				{ parenst: 1, interior: 'Here' },
+			],
+			amountOut: 10,
+			amountInMax: 1000,
+			sendTo: 'Fy2rsYCoowQBtuFXqLE65ehAY9T6KWcGiNCQAyPDCkfpm4s',
+			keepAlive: true,
+		},
+	},
 	balances: {
 		transferKeepAlive: {
 			dest: { id: 'Fy2rsYCoowQBtuFXqLE65ehAY9T6KWcGiNCQAyPDCkfpm4s' },


### PR DESCRIPTION
Added calls for handling a liquidity pool and swapping tokens.

Closes #365 