### PR TITLE
fix: prevent error in service worker environment

### DIFF
--- a/packages/txwrapper-core/src/core/metadata/createMetadata.ts
+++ b/packages/txwrapper-core/src/core/metadata/createMetadata.ts
@@ -54,12 +54,14 @@ export function createMetadataUnmemoized(
 export const createMetadata = memoizee(createMetadataUnmemoized, {
 	length: 4,
 	max:
-		!isBrowser && typeof process !== 'undefined' && 
+		!isBrowser &&
+		typeof process !== 'undefined' &&
 		typeof process.env?.TXWRAPPER_METADATA_CACHE_MAX !== 'undefined'
 			? parseInt(process.env.TXWRAPPER_METADATA_CACHE_MAX)
 			: undefined,
 	maxAge:
-		!isBrowser && typeof process !== 'undefined' && 
+		!isBrowser &&
+		typeof process !== 'undefined' &&
 		typeof process.env?.TXWRAPPER_METADATA_CACHE_MAX_AGE !== 'undefined'
 			? parseInt(process.env.TXWRAPPER_METADATA_CACHE_MAX_AGE)
 			: undefined,

--- a/packages/txwrapper-core/src/core/metadata/createMetadata.ts
+++ b/packages/txwrapper-core/src/core/metadata/createMetadata.ts
@@ -54,13 +54,13 @@ export function createMetadataUnmemoized(
 export const createMetadata = memoizee(createMetadataUnmemoized, {
 	length: 4,
 	max:
-		!isBrowser &&
-		typeof process?.env?.TXWRAPPER_METADATA_CACHE_MAX !== 'undefined'
+		!isBrowser && typeof process !== 'undefined' && 
+		typeof process.env?.TXWRAPPER_METADATA_CACHE_MAX !== 'undefined'
 			? parseInt(process.env.TXWRAPPER_METADATA_CACHE_MAX)
 			: undefined,
 	maxAge:
-		!isBrowser &&
-		typeof process?.env?.TXWRAPPER_METADATA_CACHE_MAX_AGE !== 'undefined'
+		!isBrowser && typeof process !== 'undefined' && 
+		typeof process.env?.TXWRAPPER_METADATA_CACHE_MAX_AGE !== 'undefined'
 			? parseInt(process.env.TXWRAPPER_METADATA_CACHE_MAX_AGE)
 			: undefined,
 });


### PR DESCRIPTION
In Chromium extensions under Manifest Version 3, the project throws an error:
<img width="813" alt="Screenshot 2024-06-18 at 3 27 00 PM" src="https://github.com/paritytech/txwrapper-core/assets/3326734/5d32f12d-a44c-4416-a0da-d7206a94d63f">

This is because in service workers, `window` is not defined, so `isBrowser` is false, but `process` is also not defined by default.

This could not be fixed by webpack's `DefinePlugin` because of the optional chaining; the optionally-chained expression actually gets transpiled to something quite different in the built package - `typeof process?.env?.TXWRAPPER_METADATA_CACHE_MAX !== 'undefined'` becomes `typeof ((_a = process === null || process === void 0 ? void 0 : process.env) === null || _a === void 0 ? void 0 : _a.TXWRAPPER_METADATA_CACHE_MAX) !== 'undefined'`, which `DefinePlugin` can't parse.

Currently in Talisman as we transition to MV3 we're dealing with this by monkey patching a `process` global variable into the service worker, however we'd like to avoid this if possible.
