### PR TITLE
fix: set assetId to default to undefined instead of 0

### DIFF
--- a/packages/txwrapper-core/src/core/decode/decodeUnsignedTx.ts
+++ b/packages/txwrapper-core/src/core/decode/decodeUnsignedTx.ts
@@ -53,8 +53,7 @@ export function decodeUnsignedTx(
 	}
 	return {
 		address: unsigned.address,
-		assetId:
-			typeof assetId === 'object'
+		assetId: !assetId ? undefined : typeof assetId === 'object'
 				? registry.createType('MultiLocation', assetId)
 				: registry.createType('Compact<AssetId>', assetId).toNumber(),
 		blockHash: unsigned.blockHash,

--- a/packages/txwrapper-core/src/core/decode/decodeUnsignedTx.ts
+++ b/packages/txwrapper-core/src/core/decode/decodeUnsignedTx.ts
@@ -53,7 +53,9 @@ export function decodeUnsignedTx(
 	}
 	return {
 		address: unsigned.address,
-		assetId: !assetId ? undefined : typeof assetId === 'object'
+		assetId: !assetId
+			? undefined
+			: typeof assetId === 'object'
 				? registry.createType('MultiLocation', assetId)
 				: registry.createType('Compact<AssetId>', assetId).toNumber(),
 		blockHash: unsigned.blockHash,

--- a/packages/txwrapper-core/src/core/method/defineMethod.ts
+++ b/packages/txwrapper-core/src/core/method/defineMethod.ts
@@ -161,7 +161,9 @@ export function defineMethod(
 
 	return {
 		address: info.address,
-		assetId: !assetId ? undefined : typeof assetId === 'object'
+		assetId: !assetId
+			? undefined
+			: typeof assetId === 'object'
 				? registry.createType('MultiLocation', assetId)
 				: registry.createType('Compact<AssetId>', assetId).toNumber(),
 		blockHash,

--- a/packages/txwrapper-core/src/core/method/defineMethod.ts
+++ b/packages/txwrapper-core/src/core/method/defineMethod.ts
@@ -161,8 +161,7 @@ export function defineMethod(
 
 	return {
 		address: info.address,
-		assetId:
-			typeof assetId === 'object'
+		assetId: !assetId ? undefined : typeof assetId === 'object'
 				? registry.createType('MultiLocation', assetId)
 				: registry.createType('Compact<AssetId>', assetId).toNumber(),
 		blockHash,


### PR DESCRIPTION
### Description
As reported on #393, when not specifying the `assetId` to pay for fees, the value defaulted to something other than `undefined` as it's supposed to.

Changed the `assetId` setting in `decodeUnsignedTx.ts` and `defineMethod.ts` in order to catch when the `assetId` is undefined and set it as so.

Previous:
```
assetId: typeof assetId === 'object'
				? registry.createType('MultiLocation', assetId)
				: registry.createType('Compact<AssetId>', assetId).toNumber()
```
Current:
```
assetId: !assetId ? undefined
			: typeof assetId === 'object'
				? registry.createType('MultiLocation', assetId)
				: registry.createType('Compact<AssetId>', assetId).toNumber()
``` 

Closes #393 