### PR TITLE
fix: dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,7 +20,6 @@ updates:
     commit-message:
       # Prefix all commit messages with "chore"
       # include a list of updated dependencies
-      prefix: "chore:"
-      include: "scope"
+      prefix: "chore(deps):"
     labels:
       - "dependencies"


### PR DESCRIPTION
Updates `dependabot.yml` to prefix PR's with `chore(deps)` and remove the `scope`, in order to avoid having to update the PR title every time.

All dependabot's PRs are dependencies updates, and as it stands it prefixes the PR with `chore:(deps):` and has to be manually modified every time.

Inspired by [#1482](https://github.com/paritytech/substrate-api-sidecar/pull/1482)