### PR TITLE
chore: dependabot config update

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,10 +16,14 @@ updates:
       # EST timezone
       timezone: "America/New_York"
     rebase-strategy: "auto"
-    open-pull-requests-limit: 0
+    groups:
+    pjs:
+      patterns:
+        - "@polkadot/*"
     commit-message:
       # Prefix all commit messages with "chore"
       # include a list of updated dependencies
-      prefix: "chore(deps):"
+      prefix: "chore"
+      include: "scope"
     labels:
       - "dependencies"


### PR DESCRIPTION
### Description
- Enables the Dependabot to update the packages that match the `@polkadot/*` pattern (same as in [ata](https://github.com/paritytech/asset-transfer-api/pull/457/files))
- Update again the pattern for the Dependabot PR title (same as in [ata](https://github.com/paritytech/asset-transfer-api/pull/464/files))